### PR TITLE
Fix typos in example and model comments

### DIFF
--- a/examples/steady_horseshoe_vortex_lattice_method_solver.py
+++ b/examples/steady_horseshoe_vortex_lattice_method_solver.py
@@ -82,7 +82,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="symmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                    # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The
@@ -193,7 +193,7 @@ example_operating_point = ps.operating_point.OperatingPoint(
 example_problem = ps.problems.SteadyProblem(
     # Set this steady problem's airplane object to be the one we just created.
     airplanes=[example_airplane],
-    # Set this steady problem's operating point object ot be the one we just created.
+    # Set this steady problem's operating point object to be the one we just created.
     operating_point=example_operating_point,
 )
 

--- a/examples/steady_ring_vortex_lattice_method_solver.py
+++ b/examples/steady_ring_vortex_lattice_method_solver.py
@@ -82,7 +82,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="asymmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                    # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The
@@ -221,7 +221,7 @@ example_operating_point = ps.operating_point.OperatingPoint(
 example_problem = ps.problems.SteadyProblem(
     # Set this steady problem's list of airplane objects to be the one we just created.
     airplanes=[example_airplane],
-    # Set this steady problem's operating point object ot be the one we just created.
+    # Set this steady problem's operating point object to be the one we just created.
     operating_point=example_operating_point,
 )
 

--- a/examples/unsteady_ring_vortex_lattice_method_solver_static.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_static.py
@@ -84,7 +84,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="symmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                    # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The

--- a/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
@@ -84,7 +84,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="symmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                    # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The

--- a/pterasoftware/models/steady_ring_vortex_lattice_method_solver.py
+++ b/pterasoftware/models/steady_ring_vortex_lattice_method_solver.py
@@ -82,7 +82,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="asymmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+        # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The
@@ -221,7 +221,7 @@ example_operating_point = ps.operating_point.OperatingPoint(
 example_problem = ps.problems.SteadyProblem(
     # Set this steady problem's list of airplane objects to be the one we just created.
     airplanes=[example_airplane],
-    # Set this steady problem's operating point object ot be the one we just created.
+    # Set this steady problem's operating point object to be the one we just created.
     operating_point=example_operating_point,
 )
 

--- a/pterasoftware/models/unsteady_ring_vortex_lattice_method_solver_static.py
+++ b/pterasoftware/models/unsteady_ring_vortex_lattice_method_solver_static.py
@@ -84,7 +84,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="symmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                 # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The

--- a/pterasoftware/models/unsteady_ring_vortex_lattice_method_solver_variable.py
+++ b/pterasoftware/models/unsteady_ring_vortex_lattice_method_solver_variable.py
@@ -84,7 +84,7 @@ example_airplane = ps.geometry.Airplane(
                     # The default value is "symmetric".
                     control_surface_type="symmetric",
                     # Define the point on the airfoil where the control surface
-                    # hinges. This is expressed as a faction of the chord length,
+                   # hinges. This is expressed as a fraction of the chord length,
                     # back from the leading edge. The default value is 0.75.
                     control_surface_hinge_point=0.75,
                     # Define the deflection of the control surface in degrees. The


### PR DESCRIPTION
## Summary
- fix typo 'faction of the chord length' -> 'fraction of the chord length'
- fix typo 'operating point object ot be' -> 'operating point object to be'

## Testing
- `pytest -q` *(fails: Fatal Python error: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_686b0a9d75a48330ab929cf9b23162e5