### PR TITLE
Fix installer paths for portability

### DIFF
--- a/make_installer.iss
+++ b/make_installer.iss
@@ -24,7 +24,8 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
 ChangesAssociations=yes
 DisableProgramGroupPage=yes
-LicenseFile=C:\Users\zacht\PycharmProjects\PteraSoftware\LICENSE.txt
+; Use a relative path to allow building the installer from any checkout
+LicenseFile=LICENSE.txt
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 OutputBaseFilename=PteraSoftware_installer
@@ -39,8 +40,9 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "C:\Users\zacht\PycharmProjects\PteraSoftware\dist\main\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\zacht\PycharmProjects\PteraSoftware\dist\main\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Use relative paths so the installer can be built from any checkout
+Source: "dist\\main\\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "dist\\main\\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Registry]


### PR DESCRIPTION
## Summary
- use relative license path
- use relative file paths so installer works from any checkout

## Testing
- `pytest -q` *(fails: segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_686b1bed66b88330bcb3e87965eab0da