### PR TITLE
Resolve the PyVista depreciation warning our output methods sometimes throw (re-submission)

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -29,9 +29,11 @@
       <w>coanda</w>
       <w>colormaps</w>
       <w>coolwarm</w>
+      <w>coords</w>
       <w>cosspace</w>
       <w>curtiss</w>
       <w>customspace</w>
+      <w>darkgray</w>
       <w>davissm</w>
       <w>dbln</w>
       <w>dfvlr</w>

--- a/README.md
+++ b/README.md
@@ -158,18 +158,18 @@ contribute to this, feel free to open a feature request issue and start a conver
 ### What If I'm Having Trouble Getting Set Up?
 
 Not to worry! I've made [a video](https://www.youtube.com/watch?v=oX8u2ZflJM4) that
-walks through getting Ptera Software up and
-running. It includes every step, from downloading Python for the first time to setting
-up your IDE to running the software. However, I recorded this video a while ago, so in
-it I download Python 3.8. For all versions of Ptera Software 3.1.0 and on, use Python 
-3.10 instead. If you still run into problems, feel free to open an issue for guidance.
+walks through getting Ptera Software up and running. It includes every step, from 
+downloading Python for the first time to setting up your IDE to running the software. 
+Please note that the video demonstrates installation with Python 3.8, but for Ptera 
+Software version 3.1.0 and later, you should use Python 3.10. If you still run into 
+problems, feel free to open an issue for guidance.
 
 ## Example Code
 
 The following code snippet is all that is needed (after running pip install
 pterasoftware) to run the steady horseshoe solver on an airplane with custom geometry.
 
-```
+```python
 import pterasoftware as ps
 
 airplane = ps.geometry.Airplane(
@@ -267,6 +267,9 @@ community's understanding and appreciation for unsteady aerodynamics in general 
 flapping-wing flight in particular. This will only happen through your participation.
 Feel free to request features, report bugs or security issues, and provide suggestions.
 No comment is too big or small!
+
+Before contributing, make sure to read through the
+[CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to best help out.
 
 Here is a list of changes I would like to make in the coming releases. If you want to
 contribute and don't know where to start, this is for you!

--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -147,15 +147,17 @@ def analyze_steady_convergence(
 
     # Begin iterating through the outer loop of panel aspect ratios.
     for ar_id, panel_aspect_ratio in enumerate(panel_aspect_ratios_list):
-        convergence_logger.info("Panel aspect ratio: " + str(panel_aspect_ratio))
+        convergence_logger.info("\tPanel aspect ratio: " + str(panel_aspect_ratio))
 
         # Begin iterating through the inner loop of number of chordwise panels.
         for chord_id, num_chordwise_panels in enumerate(num_chordwise_panels_list):
-            convergence_logger.info("\tChordwise panels: " + str(num_chordwise_panels))
+            convergence_logger.info(
+                "\t\tChordwise panels: " + str(num_chordwise_panels)
+            )
 
             iteration += 1
             convergence_logger.info(
-                "\t\tIteration Number: " + str(iteration) + "/" + str(num_iterations)
+                "\t\t\tIteration Number: " + str(iteration) + "/" + str(num_iterations)
             )
 
             # Initialize an empty list to hold this iteration's problem's airplanes.
@@ -302,13 +304,13 @@ def analyze_steady_convergence(
                 )
 
             # Populate the arrays that store information of all the iterations with
-            # the data from this iteration..
+            # the data from this iteration.
             force_coefficients[ar_id, chord_id, :] = these_force_coefficients
             moment_coefficients[ar_id, chord_id, :] = these_moment_coefficients
             iter_times[ar_id, chord_id] = this_iter_time
 
             convergence_logger.info(
-                "\t\tIteration Time: " + str(round(this_iter_time, 3)) + " s"
+                "\t\t\tIteration Time: " + str(round(this_iter_time, 3)) + " s"
             )
 
             max_ar_pc = np.inf
@@ -338,13 +340,13 @@ def analyze_steady_convergence(
                 max_ar_pc = max(max_ar_force_pc, max_ar_moment_pc)
 
                 convergence_logger.info(
-                    "\t\tMaximum coefficient change from panel aspect ratio: "
+                    "\t\t\tMaximum coefficient change from panel aspect ratio: "
                     + str(round(max_ar_pc, 2))
                     + "%"
                 )
             else:
                 convergence_logger.info(
-                    "\t\tMaximum coefficient change from panel aspect ratio: "
+                    "\t\t\tMaximum coefficient change from panel aspect ratio: "
                     + str(max_ar_pc)
                 )
 
@@ -374,13 +376,13 @@ def analyze_steady_convergence(
                 max_chord_pc = max(max_chord_force_pc, max_chord_moment_pc)
 
                 convergence_logger.info(
-                    "\t\tMaximum coefficient change from chordwise panels: "
+                    "\t\t\tMaximum coefficient change from chordwise panels: "
                     + str(round(max_chord_pc, 2))
                     + "%"
                 )
             else:
                 convergence_logger.info(
-                    "\t\tMaximum coefficient change from chordwise panels: "
+                    "\t\t\tMaximum coefficient change from chordwise panels: "
                     + str(max_chord_pc)
                 )
 
@@ -641,21 +643,21 @@ def analyze_unsteady_convergence(
     # Begin iterating through the first loop of wake states.
     for wake_id, wake in enumerate(wake_list):
         if wake:
-            convergence_logger.info("Wake type: prescribed")
+            convergence_logger.info("\tWake type: prescribed")
         else:
-            convergence_logger.info("Wake type: free")
+            convergence_logger.info("\tWake type: free")
 
         # Begin iterating through the second loop of wake lengths.
         for length_id, wake_length in enumerate(wake_lengths_list):
             if is_static:
-                convergence_logger.info("\tChord lengths: " + str(wake_length))
+                convergence_logger.info("\t\tChord lengths: " + str(wake_length))
             else:
-                convergence_logger.info("\tCycles: " + str(wake_length))
+                convergence_logger.info("\t\tCycles: " + str(wake_length))
 
             # Begin iterating through the third loop of panel aspect ratios.
             for ar_id, panel_aspect_ratio in enumerate(panel_aspect_ratios_list):
                 convergence_logger.info(
-                    "\t\tPanel aspect ratio: " + str(panel_aspect_ratio)
+                    "\t\t\tPanel aspect ratio: " + str(panel_aspect_ratio)
                 )
 
                 # Begin iterating through the fourth and innermost loop of number of
@@ -664,12 +666,12 @@ def analyze_unsteady_convergence(
                     num_chordwise_panels_list
                 ):
                     convergence_logger.info(
-                        "\t\t\tChordwise panels: " + str(num_chordwise_panels)
+                        "\t\t\t\tChordwise panels: " + str(num_chordwise_panels)
                     )
 
                     iteration += 1
                     convergence_logger.info(
-                        "\t\t\t\tIteration Number: "
+                        "\t\t\t\t\tIteration Number: "
                         + str(iteration)
                         + "/"
                         + str(num_iterations)
@@ -961,7 +963,7 @@ def analyze_unsteady_convergence(
                     )
                     iter_start = time.time()
                     this_solver.run(
-                        logging_level="Warning",
+                        logging_level="Critical",
                         prescribed_wake=wake,
                         calculate_streamlines=False,
                     )
@@ -1009,7 +1011,7 @@ def analyze_unsteady_convergence(
                     iter_times[wake_id, length_id, ar_id, chord_id] = this_iter_time
 
                     convergence_logger.info(
-                        "\t\t\t\tIteration Time: "
+                        "\t\t\t\t\tIteration Time: "
                         + str(round(this_iter_time, 3))
                         + " s"
                     )
@@ -1033,13 +1035,13 @@ def analyze_unsteady_convergence(
                         )
 
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from wake type: "
+                            "\t\t\t\t\tMaximum coefficient change from wake type: "
                             + str(round(max_wake_pc, 2))
                             + "%"
                         )
                     else:
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from wake type: "
+                            "\t\t\t\t\tMaximum coefficient change from wake type: "
                             + str(max_wake_pc)
                         )
 
@@ -1057,13 +1059,13 @@ def analyze_unsteady_convergence(
                         )
 
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from wake length: "
+                            "\t\t\t\t\tMaximum coefficient change from wake length: "
                             + str(round(max_length_pc, 2))
                             + "%"
                         )
                     else:
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from wake length: "
+                            "\t\t\t\t\tMaximum coefficient change from wake length: "
                             + str(max_length_pc)
                         )
 
@@ -1082,12 +1084,12 @@ def analyze_unsteady_convergence(
                         )
 
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from panel aspect "
+                            "\t\t\t\t\tMaximum coefficient change from panel aspect "
                             "ratio: " + str(round(max_ar_pc, 2)) + "%"
                         )
                     else:
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from panel aspect "
+                            "\t\t\t\t\tMaximum coefficient change from panel aspect "
                             "ratio: " + str(max_ar_pc)
                         )
 
@@ -1106,13 +1108,13 @@ def analyze_unsteady_convergence(
                         )
 
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from chordwise panels: "
+                            "\t\t\t\t\tMaximum coefficient change from chordwise panels: "
                             + str(round(max_chord_pc, 2))
                             + "%"
                         )
                     else:
                         convergence_logger.info(
-                            "\t\t\t\tMaximum coefficient change from chordwise panels: "
+                            "\t\t\t\t\tMaximum coefficient change from chordwise panels: "
                             + str(max_chord_pc)
                         )
 

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -32,7 +32,7 @@ This module contains the following functions:
     objects, and puts them into a 1D array to be used as scalars for display by other
     output methods.
 
-    plot_scalars: This function plots a scalar bars, the mesh panels with a
+    plot_scalars: This function plots a scalar bar, the mesh panels with a
     particular set of scalars, and labels for the minimum and maximum scalar values."""
 
 import math
@@ -1243,6 +1243,7 @@ def get_scalars(
     return scalars
 
 
+# ToDo: Update this function's docstring.
 def plot_scalars(
     plotter,
     these_scalars,
@@ -1254,7 +1255,7 @@ def plot_scalars(
     c_max,
     panel_surfaces,
 ):
-    """This function plots a scalar bars, the mesh panels with a particular set of
+    """This function plots a scalar bar, the mesh panels with a particular set of
     scalars, and labels for the minimum and maximum scalar values.
 
     :param plotter:
@@ -1302,4 +1303,3 @@ def plot_scalars(
         viewport=True,
         color=text_color,
     )
-    plotter.update_scalars(these_scalars)

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -32,8 +32,8 @@ This module contains the following functions:
     objects, and puts them into a 1D array to be used as scalars for display by other
     output methods.
 
-    plot_scalars: This function plots a scalar bar, the mesh panels with a
-    particular set of scalars, and labels for the minimum and maximum scalar values."""
+    plot_scalars: This function plots a scalar bar, the mesh panels with a particular
+    set of scalars, and labels for the minimum and maximum scalar values."""
 
 import math
 import time
@@ -371,7 +371,7 @@ def animate(
         show_scalars = True
 
     # Initialize variables to hold the problems' scalars and their attributes.
-    all_scalars = np.empty(0, dtype=int)
+    all_scalars = np.empty(0, dtype=float)
     min_scalar = None
     max_scalar = None
 
@@ -1247,12 +1247,12 @@ def get_scalars(
         This variable determines which scalar values will be returned. Acceptable
         inputs are "induced drag", "side force", and "lift", which respectively
         return each panel's induced drag, side force, or lift coefficient.
-    :return scalars: 1D array of ints
-        This is the 1D array of integers for each panel's coefficient value.
+    :return scalars: 1D array of floats
+        This is the 1D array of floats for each panel's coefficient value.
     """
 
     # Initialize an empty array to hold the scalars.
-    scalars = np.empty(0, dtype=int)
+    scalars = np.empty(0, dtype=float)
 
     # Increment through the airplanes' wings.
     for airplane in airplanes:
@@ -1274,7 +1274,6 @@ def get_scalars(
     return scalars
 
 
-# ToDo: Update this function's docstring.
 def plot_scalars(
     plotter,
     these_scalars,
@@ -1289,16 +1288,27 @@ def plot_scalars(
     """This function plots a scalar bar, the mesh panels with a particular set of
     scalars, and labels for the minimum and maximum scalar values.
 
-    :param plotter:
-    :param these_scalars:
-    :param scalar_type:
-    :param min_scalar:
-    :param max_scalar:
-    :param color_map:
-    :param c_min:
-    :param c_max:
-    :param panel_surfaces:
-    :return:
+    :param plotter: `pyvista.Plotter`
+        The plotter object used for visualization.
+    :param these_scalars: 1D array of floats
+        This is the 1D array of floats for each panel's coefficient value.
+    :param scalar_type: str
+        This variable determines which scalar values will be returned. Acceptable
+        inputs are "induced drag", "side force", and "lift", which respectively
+        return each panel's induced drag, side force, or lift coefficient.
+    :param min_scalar: float
+        Minimum scalar value, which is displayed as text on the plotter.
+    :param max_scalar: float
+        Maximum scalar value, which is displayed as text on the plotter.
+    :param color_map: str
+        Name of the colormap to use for scalar visualization.
+    :param c_min: float
+        Lower bound for the colormap scaling.
+    :param c_max: float
+        Upper bound for the colormap scaling.
+    :param panel_surfaces: `pyvista.PolyData`
+        PolyData object representing the mesh panel surfaces.
+    :return: None
     """
     scalar_bar_args = dict(
         title=scalar_type.title() + " Coefficient",

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -36,6 +36,7 @@ This module contains the following functions:
     particular set of scalars, and labels for the minimum and maximum scalar values."""
 
 import math
+import time
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -108,6 +109,7 @@ def draw(
     show_streamlines=False,
     show_wake_vortices=False,
     save=False,
+    testing=False,
 ):
     """Draw the geometry of the airplanes in a solver object.
 
@@ -134,6 +136,9 @@ def draw(
     :param save: bool, optional
         Set this variable to True to save the image as a WebP. The default value is
         False.
+    :param testing: bool, optional
+        Set this variable to True to close the image after 1 second, which is useful
+        for running test suites. The default value is False.
     :return: None
     """
 
@@ -251,16 +256,27 @@ def draw(
                         smooth_shading=False,
                     )
 
-    # Set the plotter's background color and camera position. Then show the plotter
-    # so the user can adjust the camera position and window. When the user closes the
-    # window, the plotter object won't be closed so that it can be saved as an image
-    # if the user wants.
+    # Set the plotter's background color.
     plotter.set_background(color=plotter_background_color)
-    plotter.show(
-        cpos=(-1, -1, 1),
-        full_screen=False,
-        auto_close=False,
-    )
+    if not testing:
+        # Show the plotter so the user can adjust the camera position and window.
+        # When the user closes the window, the plotter object itself won't close so
+        # that it can be saved as an image if the user wants.
+        plotter.show(
+            cpos=(-1, -1, 1),
+            full_screen=False,
+            auto_close=False,
+        )
+    else:
+        # Show the plotter for 1 second, then proceed automatically. This is useful
+        # for testing.
+        plotter.show(
+            cpos=(-1, -1, 1),
+            full_screen=False,
+            interactive=False,
+            auto_close=False,
+        )
+        time.sleep(1)
 
     # If the user wants to save the image, take a screenshot, convert it into an
     # image object, and save it as a WebP.
@@ -285,6 +301,7 @@ def animate(
     scalar_type=None,
     show_wake_vortices=False,
     save=False,
+    testing=False,
 ):
     """Create an animation of a solver's geometries.
 
@@ -302,6 +319,9 @@ def animate(
     :param save: bool, optional
         Set this variable to True in order to save the resulting WebP animation. The
         default value is False.
+    :param testing: bool, optional
+        Set this variable to True to close the image after 1 second, which is useful
+        for running test suites. The default value is False.
     :return: None
     """
 
@@ -415,19 +435,30 @@ def animate(
     # Set the plotter background color and show the plotter.
     plotter.set_background(color=plotter_background_color)
 
-    # Print a message to the console on how to set up the window.
-    print(
-        'Orient the view, then press "q" to close the window and produce the animation.'
-    )
+    if not testing:
+        # If not testing, print a message to the console on how to set up the window.
+        print(
+            'Orient the view, then press "q" to close the window and produce the animation.'
+        )
 
-    # Show the plotter so the user can set up the camera. Then, they will close the
-    # window, but the plotter object will stay open off-screen.
-    plotter.show(
-        title="Rendering speed not to scale.",
-        cpos=(-1, -1, 1),
-        full_screen=False,
-        auto_close=False,
-    )
+        # Show the plotter so the user can set up the camera. Then, they will close the
+        # window, starting the animation, but the plotter object will stay open.
+        plotter.show(
+            title="Rendering speed not to scale.",
+            cpos=(-1, -1, 1),
+            full_screen=False,
+            auto_close=False,
+        )
+    else:
+        # If we are testing, show the plotter for 1 second, then start the animation.
+        plotter.show(
+            title="Rendering speed not to scale.",
+            cpos=(-1, -1, 1),
+            full_screen=False,
+            interactive=False,
+            auto_close=False,
+        )
+        time.sleep(1)
 
     # Start a list which will hold a WebP image of each frame.
     images = [

--- a/pterasoftware/trim.py
+++ b/pterasoftware/trim.py
@@ -33,6 +33,7 @@ from . import problems
 
 trim_logger = logging.getLogger("trim")
 trim_logger.setLevel(logging.DEBUG)
+logging.basicConfig()
 
 
 # ToDo: Document this function.
@@ -135,7 +136,7 @@ def analyze_steady_trim(
         o_str = str(round(objective, 3))
 
         state_msg = (
-            "State: velocity="
+            "\tState: velocity="
             + v_str
             + ", alpha="
             + a_str
@@ -144,7 +145,7 @@ def analyze_steady_trim(
             + ", external thrust="
             + t_str
         )
-        obj_msg = "Objective: " + o_str
+        obj_msg = "\t\tObjective: " + o_str
 
         trim_logger.info(state_msg)
         trim_logger.info(obj_msg)
@@ -301,8 +302,10 @@ def analyze_unsteady_trim(
         b_str = str(round(beta, 2))
         o_str = str(round(objective, 3))
 
-        state_msg = "State: velocity=" + v_str + ", alpha=" + a_str + ", beta=" + b_str
-        obj_msg = "Objective: " + o_str
+        state_msg = (
+            "\tState: velocity=" + v_str + ", alpha=" + a_str + ", beta=" + b_str
+        )
+        obj_msg = "\t\tObjective: " + o_str
 
         trim_logger.info(state_msg)
         trim_logger.info(obj_msg)

--- a/tests/integration/test_output.py
+++ b/tests/integration/test_output.py
@@ -1,8 +1,8 @@
 """This module is a testing case for the output module.
 
 Note: Most of the tests in this case do not currently test the output against an
-expected output. Instead,
-they test that the methods to create the output don't throw any errors.
+expected output. Instead, they test that the methods to create the output don't throw
+any errors.
 
 This module contains the following classes:
     TestOutput: This is a class with functions to test the output module.
@@ -24,15 +24,20 @@ class TestOutput(unittest.TestCase):
     """This is a class with functions to test the output module.
 
     This class contains the following public methods:
-        setUp: This method is automatically called before each testing method to set up the fixtures.
+        setUp: This method is automatically called before each testing method to set
+        up the fixtures.
 
-        tearDown: This method is automatically called before each testing method to tear down the fixtures.
+        tearDown: This method is automatically called before each testing method to
+        tear down the fixtures.
 
-        test_plot_results_versus_time: This method tests the plot_results_versus_time method.
+        test_plot_results_versus_time: This method tests the plot_results_versus_time
+        method.
 
-        test_animate_does_not_throw: This method tests that the animate method does not throw any errors.
+        test_animate_does_not_throw: This method tests that the animate method does
+        not throw any errors.
 
-        test_draw_does_not_throw: This method tests that the draw method does not throw any errors.
+        test_draw_does_not_throw: This method tests that the draw method does not
+        throw any errors.
 
     This class contains the following class attributes:
         None
@@ -42,7 +47,8 @@ class TestOutput(unittest.TestCase):
     """
 
     def setUp(self):
-        """This method is automatically called before each testing method to set up the fixtures.
+        """This method is automatically called before each testing method to set up
+        the fixtures.
 
         :return: None
         """
@@ -53,7 +59,8 @@ class TestOutput(unittest.TestCase):
         )
 
     def tearDown(self):
-        """This method is automatically called before each testing method to tear down the fixtures.
+        """This method is automatically called before each testing method to tear
+        down the fixtures.
 
         :return: None
         """
@@ -62,13 +69,14 @@ class TestOutput(unittest.TestCase):
         del self.unsteady_solver
 
     def test_plot_results_versus_time_does_not_throw(self):
-        """This method tests that the plot_results_versus_time method doesn't throw any errors.
+        """This method tests that the plot_results_versus_time method doesn't throw
+        any errors.
 
         :return: None
         """
 
-        # Call the plot_results_versus_time method on the solver fixture. The show flag is set to False,
-        # so the figures will not be displayed.
+        # Call the plot_results_versus_time method on the solver fixture. The show
+        # flag is set to False, so the figures will not be displayed.
         ps.output.plot_results_versus_time(
             unsteady_solver=self.unsteady_solver, show=False
         )
@@ -79,12 +87,14 @@ class TestOutput(unittest.TestCase):
         :return: None
         """
 
-        # Call the animate function on the unsteady solver fixture.
+        # Call the animate function on the unsteady solver fixture. The testing flag
+        # is true so the animation will start automatically after 1 second.
         ps.output.animate(
             unsteady_solver=self.unsteady_solver,
             scalar_type=None,
             show_wake_vortices=False,
             save=False,
+            testing=True,
         )
 
     def test_draw_does_not_throw(self):
@@ -93,10 +103,12 @@ class TestOutput(unittest.TestCase):
         :return: None
         """
 
-        # Call the draw function on the unsteady solver fixture.
+        # Call the draw function on the unsteady solver fixture. The testing flag is
+        # set to true, so the plotter will close after 1 second.
         ps.output.draw(
             solver=self.unsteady_solver,
             scalar_type=None,
             show_wake_vortices=False,
             show_streamlines=False,
+            testing=True,
         )

--- a/tests/integration/test_steady_horseshoe_vortex_lattice_method.py
+++ b/tests/integration/test_steady_horseshoe_vortex_lattice_method.py
@@ -116,6 +116,7 @@ class TestSteadyHorseshoeVortexLatticeMethod(unittest.TestCase):
             show_wake_vortices=False,
             show_streamlines=True,
             scalar_type="lift",
+            testing=True,
         )
 
         # Assert that the percent errors are less than the allowable error.
@@ -167,6 +168,7 @@ class TestSteadyHorseshoeVortexLatticeMethod(unittest.TestCase):
             scalar_type="induced drag",
             show_streamlines=True,
             show_wake_vortices=False,
+            testing=True,
         )
 
         # Assert that the percent errors are less than the allowable error.

--- a/tests/integration/test_steady_ring_vortex_lattice_method.py
+++ b/tests/integration/test_steady_ring_vortex_lattice_method.py
@@ -103,6 +103,7 @@ class TestSteadyRingVortexLatticeMethod(unittest.TestCase):
             show_wake_vortices=False,
             show_streamlines=True,
             scalar_type="lift",
+            testing=True,
         )
 
         # Assert that the percent errors are less than the allowable error.

--- a/tests/integration/test_unsteady_ring_vortex_lattice_method_multiple_wing_static_geometry.py
+++ b/tests/integration/test_unsteady_ring_vortex_lattice_method_multiple_wing_static_geometry.py
@@ -76,4 +76,5 @@ class TestUnsteadyRingVortexLatticeMethodMultipleWingStaticGeometry(unittest.Tes
             show_wake_vortices=True,
             scalar_type="side force",
             save=False,
+            testing=True,
         )

--- a/tests/integration/test_unsteady_ring_vortex_lattice_method_multiple_wing_variable_geometry.py
+++ b/tests/integration/test_unsteady_ring_vortex_lattice_method_multiple_wing_variable_geometry.py
@@ -78,4 +78,5 @@ class TestUnsteadyRingVortexLatticeMethodMultipleWingVariableGeometry(
             scalar_type="induced drag",
             show_wake_vortices=True,
             save=False,
+            testing=True,
         )

--- a/tests/integration/test_unsteady_ring_vortex_lattice_method_static_geometry.py
+++ b/tests/integration/test_unsteady_ring_vortex_lattice_method_static_geometry.py
@@ -100,6 +100,7 @@ class TestUnsteadyRingVortexLatticeMethodStaticGeometry(unittest.TestCase):
             show_wake_vortices=True,
             scalar_type="lift",
             save=False,
+            testing=True,
         )
 
         ps.output.plot_results_versus_time(

--- a/tests/integration/test_unsteady_ring_vortex_lattice_method_variable_geometry.py
+++ b/tests/integration/test_unsteady_ring_vortex_lattice_method_variable_geometry.py
@@ -74,6 +74,7 @@ class TestUnsteadyRingVortexLatticeMethodVariableGeometry(unittest.TestCase):
             scalar_type="lift",
             show_wake_vortices=True,
             save=False,
+            testing=True,
         )
 
         ps.output.plot_results_versus_time(


### PR DESCRIPTION
# Description

This pull request eliminates the call the depreciated PyVista `update_scalars` method. It also introduces several minor improvements focused on logging clarity, usability for automated testing, and documentation.

## Motivation
Our output methods sometimes call a depreciated PyVista method which causes annoying error messages. 

## Relevant Issues
Closes #35

## Changes

### output.py
* Removed the call to PyVista's depreciated `update_scalars` method. I double checked that this has no apparent affect on the drawings and animations
* Added a `testing` parameter to the `draw` and `animate` functions in `pterasoftware/output.py`. When enabled, plots are automatically closed after 1 second, facilitating non-interactive test runs. Corresponding docstrings were updated to describe this behavior.
* Fixed a potential minor bug where the `scalars` array was assigned the wrong `dtype`.
* I added a docstring to the `plot_scalars` function.

### convergence.py
* Set the logging level for the simulation calls to "Critical" in order to not show the progress bars during convergence runs.
* Increased indentation to make logging output more readable

### trim.py
* Ensured logging configuration is set up properly
* Increased indentation to make logging output more readable

### README.md
 * Added Python syntax highlighting. A big thanks to [tkoyama010](https://github.com/tkoyama010) for originally suggesting this via  a PR a while back. Unfortunately, that PR was accidentally closed when I changed the name of the default branch
 * Improved clarity regarding Python version requirements
 * Added a reference to CONTRIBUTING.md

### Other
 * Added 'coords' and 'darkgray' to the project dictionary for spellchecking
 * Fixed typos in docstrings and comments

## New Dependencies
None

## Change Magnitude
Minor

---

# Checklist

- [x] I have created or claimed an issue for this work as described in 
[Contributing Code](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md#contributing-code).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] All new modules, classes, functions, and methods have docstrings in 
[reStructuredText format](https://realpython.com/documenting-python-code/).
- [x] Code is well documented with block comments where appropriate.
- [x] Code passes local automated checks (`codespell`, `black`, and `unittests`).
- [x] If any major functionality was added or significantly changed, I have added or 
updated tests in the `tests` package.
- [x] Any external code, algorithms, or equations used have been cited in comments or 
docstrings.
- [x] PR description links all relevant issues and follows this template.

---