### PR TITLE
Add /ptera and Animate.webp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,8 @@ cython_debug/
 
 # These are files and folders created by usage to ignore
 Animate.webp
-/ptera
+Draw.webp
+* Forces.png
+* ForceCoefficients.png
+* Moments.png
+* MomentCoefficients.png


### PR DESCRIPTION
# Description

Add /ptera and Animate.webp to gitignore

## Motivation
Instead of having to delete your /ptera folder and animation every time you push, you can now just `git add .` and not worry.

## Relevant Issues
Change is small enough

## Changes
Add /ptera and Animate.webp to gitignore

## New Dependencies
N/A

## Change Magnitude
**Minor**
# Checklist

- [x] (WAIVED) I have created or claimed an issue for this work as described in 
[Contributing Code](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md#contributing-code).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] All new modules, classes, functions, and methods have docstrings in 
[reStructuredText format](https://realpython.com/documenting-python-code/).
- [x] Code is well documented with block comments where appropriate.
- [x] Code passes local automated checks (`codespell`, `black`, and `tests`).
- [x] If any major functionality was added or significantly changed, I have added or 
updated tests in the `tests` package.
- [x] Any external code, algorithms, or equations used have been cited in comments or 
docstrings.
- [x] PR description links all relevant issues and follows this template.

---