### PR TITLE
Bugfix/bad first wake vortex spacing

### DIFF
--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -543,7 +543,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
                                 # be found on pages 37-39 of "Modeling of aerodynamic
                                 # forces in flapping flight with the Unsteady Vortex
                                 # Lattice Method" by Thomas Lambert.
-                                if steady_problem_id < 1:
+                                if steady_problem_id == 0:
                                     Blrvp_GP1_CgP1 = (
                                         panel.Blpp_GP1_CgP1
                                         + vInf_GP1__E * self.delta_time * 0.25


### PR DESCRIPTION
# Description

This PR fixes a bug where, in UVLM simulations, the first row of wake RingVortices is always placed too far from the trailing edge of their parent Wing.

## Motivation

The UVLM is known to be sensitive to the placement of the row of wake ring vortices closest to the wing(s). Therefore, it is important to fix this to avoid potential issues with load calculations.

## Relevant Issues

Closes #52 

## Changes

- In `UnsteadyRingVortexLatticeMethodSolver`'s `_initialize_panel_vortices` method, I replaced the logic that previously calculated the positions of the back left and right points for the ring vortices on the trailing edge of each wing. Now, the locations of these points are set using the method described on pages 37-39 of "Modeling of aerodynamic forces in flapping flight with the Unsteady Vortex Lattice Method" by Thomas Lambert.
- I removed the `FIXME` comment from line 547 in `pterasoftware\unsteady_ring_vortex_lattice_method_solver.py` that described the bug this PR fixes.

## New Dependencies
None

## Change Magnitude
**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I have created or claimed an issue for this work as described in 
[Contributing Code](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md#contributing-code).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] All new modules, classes, functions, and methods have docstrings in 
[reStructuredText format](https://realpython.com/documenting-python-code/).
- [x] Code is well documented with block comments where appropriate.
- [x] Code passes local automated checks (`codespell`, `black`, and `tests`).
- [x] If any major functionality was added or significantly changed, I have added or 
updated tests in the `tests` package.
- [x] Any external code, algorithms, or equations used have been cited in comments or 
docstrings.
- [x] PR description links all relevant issues and follows this template.

---