### PR TITLE
Fixed bugs in `Wing` properties

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,3 +14,4 @@ jobs:
         continue-on-error: true
         with:
           ignore_words_file: .codespell-ignore.txt
+          skip: "*/_build/*,*.dat"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: codespell
         args: ["--ignore-words=.codespell-ignore.txt"]
-        exclude: '.*\.dat$'
+        exclude: '(^docs/_build/.*|.*\.dat$)'
   - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.7
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Once you understand the process, here's how to implement it:
    - Run automated checks locally before pushing:  
      ```shell
      .venv\Scripts\activate # On Mac or Linux use source .venv/bin/activate
-     codespell --ignore-words=.codespell-ignore.txt --skip="*.dat"
+     codespell --ignore-words=.codespell-ignore.txt --skip="*/_build/*,*.dat"
      docformatter --black --in-place pterasoftware -r
      black .
      mypy pterasoftware

--- a/tests/unit/fixtures/geometry_fixtures.py
+++ b/tests/unit/fixtures/geometry_fixtures.py
@@ -784,3 +784,459 @@ def make_basic_panel_fixture():
     )
 
     return basic_panel_fixture
+
+
+def make_simple_rectangular_wing_fixture():
+    """This method makes a fixture that is a simple rectangular Wing with constant
+    chord and no sweep or dihedral for testing geometric property calculations.
+
+    This Wing has:
+    - Root and tip at y=0 and y=2, with chord=1.0 at both
+    - No sweep, twist, or dihedral
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 2.0 meters
+    - Expected projected area (when meshed): 2.0 square meters
+
+    :return simple_rectangular_wing_fixture: Wing
+        This is the simple rectangular Wing for geometric property testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=8,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection at y=2.0, same chord
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create simple rectangular Wing
+    simple_rectangular_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Simple Rectangular Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=4,
+        chordwise_spacing="uniform",
+    )
+
+    return simple_rectangular_wing_fixture
+
+
+def make_simple_tapered_wing_fixture():
+    """This method makes a fixture that is a simple tapered Wing with linearly
+    varying chord and no sweep or dihedral for testing geometric property
+    calculations.
+
+    This Wing has:
+    - Root at y=0 with chord=2.0
+    - Tip at y=3.0 with chord=1.0
+    - No sweep, twist, or dihedral
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 3.0 meters
+    - Expected projected area (when meshed): 4.5 square meters (trapezoid area)
+
+    :return simple_tapered_wing_fixture: Wing
+        This is the simple tapered Wing for geometric property testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin with chord=2.0
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=12,
+        chord=2.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection at y=3.0 with chord=1.0
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 3.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create simple tapered Wing
+    simple_tapered_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Simple Tapered Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=8,
+        chordwise_spacing="uniform",
+    )
+
+    return simple_tapered_wing_fixture
+
+
+def make_symmetric_continuous_rectangular_wing_fixture():
+    """This method makes a fixture that is a symmetric and continuous rectangular
+    Wing for testing geometric property calculations with type 4 symmetry.
+
+    This Wing has:
+    - Root at y=0 with chord=1.5
+    - Tip at y=2.5 with chord=1.5
+    - No sweep, twist, or dihedral
+    - Type 4 symmetry (symmetric and continuous)
+    - Expected span (after symmetry): 5.0 meters (2 * 2.5)
+    - Expected projected area (when meshed, after symmetry): 7.5 square meters (2 * 3.75)
+
+    :return symmetric_continuous_rectangular_wing_fixture: Wing
+        This is the symmetric continuous rectangular Wing for geometric property
+        testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin with chord=1.5
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=10,
+        chord=1.5,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        control_surface_symmetry_type="symmetric",
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection at y=2.5 with chord=1.5
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.5,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.5, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        control_surface_symmetry_type="symmetric",
+        spanwise_spacing=None,
+    )
+
+    # Create symmetric continuous rectangular Wing
+    symmetric_continuous_rectangular_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Symmetric Continuous Rectangular Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=True,
+        mirror_only=False,
+        symmetryNormal_G=np.array([0.0, 1.0, 0.0]),
+        symmetryPoint_G_Cg=np.array([0.0, 0.0, 0.0]),
+        num_chordwise_panels=6,
+        chordwise_spacing="uniform",
+    )
+
+    return symmetric_continuous_rectangular_wing_fixture
+
+
+def make_three_section_tapered_wing_fixture():
+    """This method makes a fixture that is a Wing with 3 WingCrossSections
+    (root, middle, tip) with varying chords for testing geometric property
+    calculations.
+
+    This Wing has:
+    - Root at y=0 with chord=3.0
+    - Middle at y=2.0 with chord=2.0
+    - Tip at y=4.0 with chord=1.0
+    - No sweep, twist, or dihedral
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 4.0 meters
+    - Expected projected area (when meshed): 8.0 square meters
+
+    :return three_section_tapered_wing_fixture: Wing
+        This is the three section tapered Wing for geometric property testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin with chord=3.0
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=8,
+        chord=3.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Middle WingCrossSection at y=2.0 with chord=2.0
+    middle_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=8,
+        chord=2.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection at y=4.0 with chord=1.0
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create three section tapered Wing
+    three_section_tapered_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, middle_wcs, tip_wcs],
+        name="Three Section Tapered Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=8,
+        chordwise_spacing="uniform",
+    )
+
+    return three_section_tapered_wing_fixture
+
+
+def make_rotated_rectangular_wing_fixture(angles_Gs_to_Wn_ixyz):
+    """This method makes a fixture that is a simple rectangular Wing rotated
+    relative to geometry axes for testing span calculation invariance under rotation.
+
+    This Wing has the same geometry as make_simple_rectangular_wing_fixture but is
+    rotated by the specified angles. The span should remain 2.0 meters regardless
+    of rotation.
+
+    :param angles_Gs_to_Wn_ixyz: (3,) array-like of floats representing the rotation
+        angles (in geometry axes, to wing axes, intrinsic xyz sequence). Units are
+        degrees.
+    :return rotated_rectangular_wing_fixture: Wing
+        This is the rotated rectangular Wing for span invariance testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=8,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection at y=2.0, same chord
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create rotated rectangular Wing
+    rotated_rectangular_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Rotated Rectangular Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array(angles_Gs_to_Wn_ixyz),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=4,
+        chordwise_spacing="uniform",
+    )
+
+    return rotated_rectangular_wing_fixture
+
+
+def make_wing_with_rotated_cross_sections_fixture():
+    """This method makes a fixture that is a Wing with rotated WingCrossSections
+    for testing that span calculation correctly handles cross section rotations.
+
+    This Wing has:
+    - Root at y=0 with chord=2.0, no rotation
+    - Middle at y=3.0 with chord=1.5, rotated 15 degrees about the Wing's axes y axis
+    - Tip at y=5.0 with chord=1.0, rotated 30 degrees about Wing's axes y axis
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 5.0 meters (rotation about the Wing's axes y axis does not affect y
+      position)
+
+    :return wing_with_rotated_cross_sections_fixture: Wing
+        This is the Wing with rotated WingCrossSections.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=10,
+        chord=2.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    middle_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=8,
+        chord=1.5,
+        Lp_Wcsp_Lpp=np.array([0.0, 3.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 15.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 2.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 15.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    wing_with_rotated_cross_sections_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, middle_wcs, tip_wcs],
+        name="Wing with Rotated Cross Sections Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=6,
+        chordwise_spacing="uniform",
+    )
+
+    return wing_with_rotated_cross_sections_fixture
+
+
+def make_swept_wing_fixture():
+    """This method makes a fixture that is a swept Wing (sweep in xz plane)
+    for testing span calculation with sweep.
+
+    This Wing has:
+    - Root at y=0 with chord=2.0
+    - Tip at x=1.5, y=3.0, z=0 (swept back 1.5 m) with chord=1.0
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 3.0 meters (sweep does not affect spanwise extent)
+
+    :return swept_wing_fixture: Wing
+        This is the swept Wing for testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin with chord=2.0
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=12,
+        chord=2.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection swept back by 1.5 m at y=3.0
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([1.5, 3.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create swept Wing
+    swept_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Swept Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=8,
+        chordwise_spacing="uniform",
+    )
+
+    return swept_wing_fixture
+
+
+def make_dihedral_wing_fixture():
+    """This method makes a fixture that is a Wing with dihedral (upward angle)
+    for testing span calculation with dihedral.
+
+    This Wing has:
+    - Root at y=0, z=0 with chord=2.0
+    - Tip at y=3.0, z=0.5 (dihedral angle ~ 9.46 deg) with chord=1.0
+    - Type 1 symmetry (no symmetry)
+    - Expected span: 3.0 meters (dihedral does not affect spanwise extent in wing axes)
+
+    :return dihedral_wing_fixture: Wing
+        This is the Wing with dihedral for testing.
+    """
+    # Create WingCrossSections for the wing.
+    test_airfoil = make_test_airfoil_fixture()
+
+    # Root WingCrossSection at origin with chord=2.0
+    root_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=10,
+        chord=2.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 0.0, 0.0]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing="uniform",
+    )
+
+    # Tip WingCrossSection with dihedral (y=3.0, z=0.5)
+    tip_wcs = ps.geometry.wing_cross_section.WingCrossSection(
+        airfoil=test_airfoil,
+        num_spanwise_panels=None,
+        chord=1.0,
+        Lp_Wcsp_Lpp=np.array([0.0, 3.0, 0.5]),
+        angles_Wcsp_to_Wcs_ixyz=np.array([0.0, 0.0, 0.0]),
+        spanwise_spacing=None,
+    )
+
+    # Create Wing with dihedral
+    dihedral_wing_fixture = ps.geometry.wing.Wing(
+        wing_cross_sections=[root_wcs, tip_wcs],
+        name="Dihedral Test Wing",
+        Ler_Gs_Cgs=np.array([0.0, 0.0, 0.0]),
+        angles_Gs_to_Wn_ixyz=np.array([0.0, 0.0, 0.0]),
+        symmetric=False,
+        mirror_only=False,
+        symmetryNormal_G=None,
+        symmetryPoint_G_Cg=None,
+        num_chordwise_panels=8,
+        chordwise_spacing="uniform",
+    )
+
+    return dihedral_wing_fixture

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -429,6 +429,413 @@ class TestWing(unittest.TestCase):
         with self.assertRaises(ValueError):
             geometry_fixtures.make_invalid_root_wing_fixture()
 
+    def test_span_simple_rectangular_wing(self):
+        """Test span calculation for simple rectangular Wing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 2.0 meters (from y=0 to y=2.0)
+        expected_span = 2.0
+        actual_span = wing.span
+
+        self.assertIsNotNone(actual_span)
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_simple_tapered_wing(self):
+        """Test span calculation for simple tapered Wing."""
+        wing = geometry_fixtures.make_simple_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 3.0 meters (from y=0 to y=3.0)
+        expected_span = 3.0
+        actual_span = wing.span
+
+        self.assertIsNotNone(actual_span)
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_symmetric_continuous_rectangular_wing(self):
+        """Test span calculation for symmetric continuous rectangular Wing."""
+        wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
+        wing.generate_mesh(4)
+
+        # Expected span: 5.0 meters (2 * 2.5, due to symmetry)
+        expected_span = 5.0
+        actual_span = wing.span
+
+        self.assertIsNotNone(actual_span)
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_three_section_tapered_wing(self):
+        """Test span calculation for three section tapered Wing."""
+        wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 4.0 meters (from y=0 to y=4.0)
+        expected_span = 4.0
+        actual_span = wing.span
+
+        self.assertIsNotNone(actual_span)
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_projected_area_simple_rectangular_wing(self):
+        """Test projected area calculation for simple rectangular Wing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected projected area: 2.0 square meters (1.0 m chord * 2.0 m span)
+        expected_area = 2.0
+        actual_area = wing.projected_area
+
+        self.assertIsNotNone(actual_area)
+        npt.assert_allclose(actual_area, expected_area, rtol=1e-10, atol=1e-14)
+
+    def test_projected_area_simple_tapered_wing(self):
+        """Test projected area calculation for simple tapered Wing."""
+        wing = geometry_fixtures.make_simple_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected projected area: 4.5 square meters
+        # Trapezoid: (chord_root + chord_tip) / 2 * span = (2.0 + 1.0) / 2 * 3.0 = 4.5
+        expected_area = 4.5
+        actual_area = wing.projected_area
+
+        self.assertIsNotNone(actual_area)
+        npt.assert_allclose(actual_area, expected_area, rtol=1e-10, atol=1e-14)
+
+    def test_projected_area_symmetric_continuous_rectangular_wing(self):
+        """Test projected area calculation for symmetric continuous rectangular
+        Wing."""
+        wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
+        wing.generate_mesh(4)
+
+        # Expected projected area: 7.5 square meters
+        # Rectangle: chord * span = 1.5 * 5.0 = 7.5
+        expected_area = 7.5
+        actual_area = wing.projected_area
+
+        self.assertIsNotNone(actual_area)
+        npt.assert_allclose(actual_area, expected_area, rtol=1e-10, atol=1e-14)
+
+    def test_projected_area_three_section_tapered_wing(self):
+        """Test projected area calculation for three section tapered Wing."""
+        wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected projected area: 8.0 square meters
+        # Section 1 (root to middle): (3.0 + 2.0) / 2 * 2.0 = 5.0
+        # Section 2 (middle to tip): (2.0 + 1.0) / 2 * 2.0 = 3.0
+        # Total: 5.0 + 3.0 = 8.0
+        expected_area = 8.0
+        actual_area = wing.projected_area
+
+        self.assertIsNotNone(actual_area)
+        npt.assert_allclose(actual_area, expected_area, rtol=1e-10, atol=1e-14)
+
+    def test_wetted_area_greater_than_projected_area(self):
+        """Test that wetted area is greater than or equal to projected area for all
+        Wings."""
+        wings = [
+            geometry_fixtures.make_simple_rectangular_wing_fixture(),
+            geometry_fixtures.make_simple_tapered_wing_fixture(),
+            geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture(),
+            geometry_fixtures.make_three_section_tapered_wing_fixture(),
+        ]
+
+        symmetry_types = [1, 1, 4, 1]
+
+        for wing, symmetry_type in zip(wings, symmetry_types):
+            with self.subTest(wing=wing.name):
+                wing.generate_mesh(symmetry_type)
+
+                projected_area = wing.projected_area
+                wetted_area = wing.wetted_area
+
+                self.assertIsNotNone(projected_area)
+                self.assertIsNotNone(wetted_area)
+                self.assertGreaterEqual(wetted_area, projected_area)
+
+    def test_standard_mean_chord_simple_rectangular_wing(self):
+        """Test standard mean chord calculation for simple rectangular Wing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Standard mean chord = projected_area / span = 2.0 / 2.0 = 1.0
+        expected_smc = 1.0
+        actual_smc = wing.standard_mean_chord
+
+        self.assertIsNotNone(actual_smc)
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
+    def test_standard_mean_chord_simple_tapered_wing(self):
+        """Test standard mean chord calculation for simple tapered Wing."""
+        wing = geometry_fixtures.make_simple_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Standard mean chord = projected_area / span = 4.5 / 3.0 = 1.5
+        expected_smc = 1.5
+        actual_smc = wing.standard_mean_chord
+
+        self.assertIsNotNone(actual_smc)
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
+    def test_standard_mean_chord_symmetric_continuous_rectangular_wing(self):
+        """Test standard mean chord calculation for symmetric continuous rectangular
+        Wing."""
+        wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
+        wing.generate_mesh(4)
+
+        # Standard mean chord = projected_area / span = 7.5 / 5.0 = 1.5
+        expected_smc = 1.5
+        actual_smc = wing.standard_mean_chord
+
+        self.assertIsNotNone(actual_smc)
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
+    def test_standard_mean_chord_three_section_tapered_wing(self):
+        """Test standard mean chord calculation for three section tapered Wing."""
+        wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Standard mean chord = projected_area / span = 8.0 / 4.0 = 2.0
+        expected_smc = 2.0
+        actual_smc = wing.standard_mean_chord
+
+        self.assertIsNotNone(actual_smc)
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
+    def test_mean_aerodynamic_chord_simple_rectangular_wing(self):
+        """Test mean aerodynamic chord calculation for simple rectangular Wing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+        wing.generate_mesh(1)
+
+        # For a rectangular wing (constant chord), MAC = chord = 1.0
+        expected_mac = 1.0
+        actual_mac = wing.mean_aerodynamic_chord
+
+        self.assertIsNotNone(actual_mac)
+        npt.assert_allclose(actual_mac, expected_mac, rtol=1e-10, atol=1e-14)
+
+    def test_mean_aerodynamic_chord_simple_tapered_wing(self):
+        """Test mean aerodynamic chord calculation for simple tapered Wing."""
+        wing = geometry_fixtures.make_simple_tapered_wing_fixture()
+        wing.generate_mesh(1)
+
+        # For a linearly tapered wing:
+        # MAC = (2/3) * (c_root + c_tip - c_root * c_tip / (c_root + c_tip))
+        # With c_root=2.0, c_tip=1.0:
+        # MAC = (2/3) * (2.0 + 1.0 - 2.0 * 1.0 / (2.0 + 1.0))
+        # MAC = (2/3) * (3.0 - 2.0/3.0) = (2/3) * (7.0/3.0) = 14.0/9.0 = 1.555...
+        c_root = 2.0
+        c_tip = 1.0
+        expected_mac = (2.0 / 3.0) * (
+            c_root + c_tip - c_root * c_tip / (c_root + c_tip)
+        )
+
+        actual_mac = wing.mean_aerodynamic_chord
+
+        self.assertIsNotNone(actual_mac)
+        npt.assert_allclose(actual_mac, expected_mac, rtol=1e-10, atol=1e-14)
+
+    def test_mean_aerodynamic_chord_symmetric_continuous_rectangular_wing(self):
+        """Test mean aerodynamic chord calculation for symmetric continuous
+        rectangular Wing."""
+        wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
+        wing.generate_mesh(4)
+
+        # For a rectangular wing (constant chord), MAC = chord = 1.5
+        expected_mac = 1.5
+        actual_mac = wing.mean_aerodynamic_chord
+
+        self.assertIsNotNone(actual_mac)
+        npt.assert_allclose(actual_mac, expected_mac, rtol=1e-10, atol=1e-14)
+
+    def test_geometric_properties_consistency(self):
+        """Test that geometric properties are internally consistent across different
+        Wings."""
+        wings_data = [
+            (geometry_fixtures.make_simple_rectangular_wing_fixture(), 1),
+            (geometry_fixtures.make_simple_tapered_wing_fixture(), 1),
+            (
+                geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture(),
+                4,
+            ),
+            (geometry_fixtures.make_three_section_tapered_wing_fixture(), 1),
+        ]
+
+        for wing, symmetry_type in wings_data:
+            with self.subTest(wing=wing.name):
+                wing.generate_mesh(symmetry_type)
+
+                # Get properties
+                span = wing.span
+                projected_area = wing.projected_area
+                standard_mean_chord = wing.standard_mean_chord
+
+                # Verify consistency: projected_area = span * standard_mean_chord
+                self.assertIsNotNone(span)
+                self.assertIsNotNone(projected_area)
+                self.assertIsNotNone(standard_mean_chord)
+
+                calculated_area = span * standard_mean_chord
+                npt.assert_allclose(
+                    projected_area, calculated_area, rtol=1e-10, atol=1e-14
+                )
+
+    def test_properties_none_before_meshing(self):
+        """Test that span, standard_mean_chord, and mean_aerodynamic_chord return
+        None before meshing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+
+        # Properties should return None before meshing
+        self.assertIsNone(wing.span)
+        self.assertIsNone(wing.projected_area)
+        self.assertIsNone(wing.wetted_area)
+        self.assertIsNone(wing.standard_mean_chord)
+        self.assertIsNone(wing.mean_aerodynamic_chord)
+
+    def test_properties_available_after_meshing(self):
+        """Test that span, standard_mean_chord, and mean_aerodynamic_chord are
+        available after meshing."""
+        wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Properties should be available and positive after meshing
+        self.assertIsNotNone(wing.span)
+        self.assertIsNotNone(wing.projected_area)
+        self.assertIsNotNone(wing.wetted_area)
+        self.assertIsNotNone(wing.standard_mean_chord)
+        self.assertIsNotNone(wing.mean_aerodynamic_chord)
+
+        self.assertGreater(wing.span, 0.0)
+        self.assertGreater(wing.projected_area, 0.0)
+        self.assertGreater(wing.wetted_area, 0.0)
+        self.assertGreater(wing.standard_mean_chord, 0.0)
+        self.assertGreater(wing.mean_aerodynamic_chord, 0.0)
+
+    def test_span_rotated_wing_x_axis(self):
+        """Test span calculation invariance for Wing rotated about x axis."""
+        # Create a Wing rotated 45 degrees about x axis
+        wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([45.0, 0.0, 0.0])
+        wing.generate_mesh(1)
+
+        # Expected span: 2.0 meters (rotation about x axis does not affect y extent)
+        expected_span = 2.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_rotated_wing_y_axis(self):
+        """Test span calculation invariance for Wing rotated about y axis."""
+        # Create a Wing rotated 30 degrees about y axis
+        wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([0.0, 30.0, 0.0])
+        wing.generate_mesh(1)
+
+        # Expected span: 2.0 meters (rotation about y axis does not affect y extent)
+        expected_span = 2.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_rotated_wing_z_axis(self):
+        """Test span calculation invariance for Wing rotated about z axis."""
+        # Create a Wing rotated 60 degrees about z axis
+        wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([0.0, 0.0, 60.0])
+        wing.generate_mesh(1)
+
+        # Expected span: 2.0 meters (rotation about z axis does not affect y extent)
+        expected_span = 2.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_rotated_wing_combined_rotations(self):
+        """Test span calculation invariance for Wing with combined rotations."""
+        # Create a Wing with combined rotations
+        wing = geometry_fixtures.make_rotated_rectangular_wing_fixture(
+            [15.0, 25.0, 35.0]
+        )
+        wing.generate_mesh(1)
+
+        # Expected span: 2.0 meters (rotations do not affect y extent in wing axes)
+        expected_span = 2.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_wing_with_rotated_cross_sections(self):
+        """Test span calculation for Wing with rotated WingCrossSections."""
+        wing = geometry_fixtures.make_wing_with_rotated_cross_sections_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 5.0 meters (rotation about y axis does not affect y position)
+        expected_span = 5.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_swept_wing(self):
+        """Test span calculation for swept Wing."""
+        wing = geometry_fixtures.make_swept_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 3.0 meters (sweep in x direction does not affect y extent)
+        expected_span = 3.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_span_dihedral_wing(self):
+        """Test span calculation for Wing with dihedral."""
+        wing = geometry_fixtures.make_dihedral_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected span: 3.0 meters (dihedral in z direction does not affect y extent in wing axes)
+        expected_span = 3.0
+
+        actual_span = wing.span
+        self.assertIsNotNone(actual_span)
+
+        npt.assert_allclose(actual_span, expected_span, rtol=1e-10, atol=1e-14)
+
+    def test_standard_mean_chord_rotated_wing(self):
+        """Test standard mean chord calculation for rotated Wing."""
+        # Create a Wing rotated 45 degrees about x axis
+        wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([45.0, 0.0, 0.0])
+        wing.generate_mesh(1)
+
+        # Expected standard mean chord: 1.0 (projected_area / span = 2.0 / 2.0)
+        expected_smc = 1.0
+
+        actual_smc = wing.standard_mean_chord
+        self.assertIsNotNone(actual_smc)
+
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
+    def test_standard_mean_chord_swept_wing(self):
+        """Test standard mean chord calculation for swept Wing."""
+        wing = geometry_fixtures.make_swept_wing_fixture()
+        wing.generate_mesh(1)
+
+        # Expected standard mean chord: projected_area / span = 4.5 / 3.0 = 1.5
+        expected_smc = 1.5
+
+        actual_smc = wing.standard_mean_chord
+        self.assertIsNotNone(actual_smc)
+
+        npt.assert_allclose(actual_smc, expected_smc, rtol=1e-10, atol=1e-14)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Description
Fixed bugs in `Wing`'s `span` and `mean_aerodynamic_chord` properties along with adding tests for them, along with `standard_mean_chord`, `wetted_area`, and `projected_area`.

## Motivation
`Wing`'s `span` and `mean_aerodynamic_chord` properties were producing strange results.

## Relevant Issues
Closes #59.

## Changes
- Simplified and corrected logic in `Wing`'s `span` property.
- Simplified and corrected logic in `Wing`'s `mean_aerodynamic_chord` property.
- Added fixtures and unit tests for `Wing`'s `span`, `mean_aerodynamic_chord`, `standard_mean_chord`, `projected_area`, and `wetted_area` properties.
- Added exclusions in codespell usage (example, pre-commit, and action usage) to exclude `docs/_build/` directory.

## New Dependencies
None

## Change Magnitude
**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I have created or claimed an issue for this work as described in [Contributing Code](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md#contributing-code).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] Code is well documented with block comments where appropriate.
- [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
- [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`).
- [x] All new classes, functions, and methods use type hints.
- [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
- [x] Code locally passes all tests in the `tests` package.
- [x] After pushing, PR passes all automated checks (`codespell`, `black`, `mypy`, and `tests`).
- [x] PR description links all relevant issues and follows this template.

---