### PR TITLE
Update the year in LICENSE.txt to 2026

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Cameron Urban
+Copyright (c) 2026 Cameron Urban
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software


### PR DESCRIPTION
# Description
Updates the copyright year to 2026.

## Motivation
It is now a new year.

## Relevant Issues
Closes #83.

## Changes
- Updates the copyright year to 2026 from 2025 in LICENSE.txt

## New Dependencies
None

## Change Magnitude
**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I have created or claimed an issue for this work as described in [Contributing Code](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md#contributing-code).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] Code is well documented with block comments where appropriate.
- [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
- [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
- [x] Code locally passes all tests in the `tests` package.
- [x] After pushing, PR passes all automated checks (`codespell`, `black`, `mypy`, and `tests`).
- [x] PR description links all relevant issues and follows this template.

---