### PR TITLE
Fixing `LICENSE.md`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,3 @@
-# License
-
-This project is licensed under the MIT License. See below for the full license text.
-
----
-
 MIT License
 
 Copyright (c) 2026 Cameron Urban

--- a/docs/website/LICENSE.md
+++ b/docs/website/LICENSE.md
@@ -1,2 +1,8 @@
+# License
+
+This project is licensed under the MIT License. See below for the full license text.
+
+---
+
 ```{include} ../../LICENSE.md
 ```


### PR DESCRIPTION
# Description
Move the license preamble to `docs/website/LICENSE.md` from the root `LICENSE.md` file so GitHub properly recognizes the license type.

## Motivation
When we created the Read the Docs website, we added a markdown header and paragraph above the main license text in the root `LICENSE.md` file. This was for stylistic purposes regarding the page where the website displayed the license. However, this inadvertently broke how GitHub recognizes what license the repository uses (the MIT license).

## Relevant Issues
None

## Changes
- Remove the preamble header and paragraph from `LICENSE.md`
- Add the preamble to `docs/website/LICENSE.md` so that the Read the Docs website retains it

## New Dependencies
None

## Change Magnitude
**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] Code is well documented with block comments where appropriate.
- [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
- [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
- [x] Code locally passes all tests in the `tests` package.
- [x] After pushing, PR passes all automated checks (`codespell`, `black`, `mypy`, and `tests`).
- [x] PR description links all relevant issues and follows this template.

---