### PR TITLE
Consolidate private documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,12 +150,14 @@ Draw.webp
 * Moments.png
 * Moment Coefficients.png
 
-# This folder contains documentation files that shouldn't be uploaded.
-/docs/katz_plotkin_13_12/
-/docs/lambert_2015_2_3__2_4/
+# This symlink folder contains reference documentation that shouldn't be uploaded.
+/docs/private
 
 # This folder contains built documentation files that shouldn't be uploaded.
 /docs/website/_build/
 
 # This folder contains a copy of the Furo theme to use as a reference for customization.
 /docs/website/furo_src/
+
+# These are the Claude's documentation files to ignore.
+/docs/CLAUDE_*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,11 @@ Requires Python 3.11, but active development is done in 3.13
 - `experimental/`: Directory with experimental scripts and prototypes (not included in version control)
 - `docs/`: Directory with documentation files
   - `examples expected output/`: Example output files for verification
-  - `katz_plotkin_13_12/`: A recreation of Chapter 13.12, which describes the UVLM, from the textbook "Low-Speed Aerodynamics" by Katz and Plotkin (not included in version control)
-  - `lambert_2015_2_3__2_4/`: A recreation of Sections 2.3 and 2.4 from Thomas Lambert's thesis "Modeling of aerodynamic forces in flapping flight with the unsteady vortex lattice method" (not included in version control)
+  - `private/`: Directory with documentation not included in this repository's version control
+    - `katz_plotkin_12_2/`: A recreation of Chapter 12.2, which describes efficiently including the effects of symmetry and ground effect for vortex lattice methods, from the textbook "Low-Speed Aerodynamics" by Katz and Plotkin
+    - `katz_plotkin_13_12/`: A recreation of Chapter 13.12, which describes the UVLM, from the textbook "Low-Speed Aerodynamics" by Katz and Plotkin
+    - `katz_plotkin_d/`: A recreation of Appendix D, which includes example Fortran programs, from the textbook "Low-Speed Aerodynamics" by Katz and Plotkin
+    - `lambert_2015_2_3__2_4/`: A recreation of Sections 2.3 and 2.4 from Thomas Lambert's thesis "Modeling of aerodynamic forces in flapping flight with the unsteady vortex lattice method"
   - `website/`: Directory with the source files for generating the documentation website
   - `ANGLE_VECTORS_AND_TRANSFORMATIONS.md`: Conventions and definitions for angle vectors and transformations **READ BEFORE CONTRIBUTING ANY CODE, PARTICIPATING IN DISCUSSIONS REGARDING, OR PLANNING RELATED TO VECTOR-VALUED VARIABLES**
   - `AXES_POINTS_AND_FRAMES.md`: Conventions and definitions for axis systems, points, and reference points: **READ BEFORE CONTRIBUTING ANY CODE, PARTICIPATING IN DISCUSSIONS REGARDING, OR PLANNING RELATED TO VECTOR-VALUED VARIABLES**


### PR DESCRIPTION
# Description
This PR consolidates the non-version-controlled documentation in a new symlink directory.

## Motivation
There are several reference documentation files that are copyrighted material, and therefore can't be distributed in this public repository. However, they were clogging up the `docs` directory. This PR moves them to the new `docs/private` directory. Under the hood, this directory is actually a symlink to the root of a separate, private GitHub repository.

## Relevant Issues
None.

## Changes
- Update `.gitignore` with the new location of the private docs
- Also update `CLAUDE.md` to correctly reference the new location
- Add new private docs to the `CLAUDE.md`

## New Dependencies
None

## Change Magnitude
**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] Code is well documented with block comments where appropriate.
- [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
- [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
- [x] Code locally passes all tests in the `tests` package.
- [x] After pushing, PR passes all automated checks (`codespell`, `black`, `mypy`, and `tests`).
- [x] PR description links all relevant issues and follows this template.

---