### PR TITLE
Remove unused `ages` parameter from `HorseshoeVortex` velocity functions

### DIFF
--- a/pterasoftware/_aerodynamics_functions.py
+++ b/pterasoftware/_aerodynamics_functions.py
@@ -298,7 +298,6 @@ def collapsed_velocities_from_horseshoe_vortices(
     strengths: np.ndarray,
     r_c0s: np.ndarray,
     singularity_counts: np.ndarray,
-    ages: np.ndarray | None = None,
     nu: float = 0.0,
 ) -> np.ndarray:
     """Takes in a group of points and the attributes of a group of HorseshoeVortices and
@@ -333,10 +332,6 @@ def collapsed_velocities_from_horseshoe_vortices(
         counts of singularity events. Index mapping: [0] degenerate filament, [1] vertex
         start proximity, [2] vertex end proximity, [3] collinearity. Counts are
         incremented in place and accumulate across all three legs.
-    :param ages: For bound HorseshoeVortices, this must be None. For HorseshoeVortices
-        that have been shed into the wake, it must be a (M,) ndarray of floats
-        representing the ages of the M HorseshoeVortices in seconds. The default is
-        None.
     :param nu: A non negative float representing the kinematic viscosity of the fluid.
         The units are in meters squared per second. The default is 0.0.
     :return: A (N,3) ndarray of floats for the cumulative induced velocity at each of
@@ -366,7 +361,7 @@ def collapsed_velocities_from_horseshoe_vortices(
             strengths=strengths,
             r_c0s=r_c0s,
             singularity_counts=singularity_counts,
-            ages=ages,
+            ages=None,
             nu=nu,
         )
     return stackVInd_GP1__E
@@ -384,7 +379,6 @@ def expanded_velocities_from_horseshoe_vortices(
     strengths: np.ndarray,
     r_c0s: np.ndarray,
     singularity_counts: np.ndarray,
-    ages: np.ndarray | None = None,
     nu: float = 0.0,
 ) -> np.ndarray:
     """Takes in a group of points and the attributes of a group of HorseshoeVortices and
@@ -419,10 +413,6 @@ def expanded_velocities_from_horseshoe_vortices(
         counts of singularity events. Index mapping: [0] degenerate filament, [1] vertex
         start proximity, [2] vertex end proximity, [3] collinearity. Counts are
         incremented in place and accumulate across all three legs.
-    :param ages: For bound HorseshoeVortices, this must be None. For HorseshoeVortices
-        that have been shed into the wake, it must be a (M,) ndarray of floats
-        representing the ages of the M HorseshoeVortices in seconds. The default is
-        None.
     :param nu: A non negative float representing the kinematic viscosity of the fluid.
         The units are in meters squared per second. The default is 0.0.
     :return: A (N,M,3) ndarray of floats for the induced velocity at each of the N
@@ -452,7 +442,7 @@ def expanded_velocities_from_horseshoe_vortices(
             strengths=strengths,
             r_c0s=r_c0s,
             singularity_counts=singularity_counts,
-            ages=ages,
+            ages=None,
             nu=nu,
         )
     return gridVInd_GP1__E

--- a/pterasoftware/steady_horseshoe_vortex_lattice_method.py
+++ b/pterasoftware/steady_horseshoe_vortex_lattice_method.py
@@ -323,7 +323,6 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                 strengths=np.ones(self.num_panels, dtype=float),
                 r_c0s=self._stackRc0s,
                 singularity_counts=singularity_counts,
-                ages=None,
                 nu=self.operating_point.nu,
             )
         )
@@ -348,7 +347,6 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                     strengths=np.ones(self.num_panels, dtype=float),
                     r_c0s=self._stackRc0s,
                     singularity_counts=singularity_counts,
-                    ages=None,
                     nu=self.operating_point.nu,
                 )
             )
@@ -446,7 +444,6 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                 strengths=self._vortex_strengths,
                 r_c0s=self._stackRc0s,
                 singularity_counts=bound_singularity_counts,
-                ages=None,
                 nu=self.operating_point.nu,
             )
         )
@@ -471,7 +468,6 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                     strengths=self._vortex_strengths,
                     r_c0s=self._stackRc0s,
                     singularity_counts=bound_singularity_counts,
-                    ages=None,
                     nu=self.operating_point.nu,
                 )
             )

--- a/pterasoftware/steady_ring_vortex_lattice_method.py
+++ b/pterasoftware/steady_ring_vortex_lattice_method.py
@@ -410,7 +410,6 @@ class SteadyRingVortexLatticeMethodSolver:
                 strengths=self._horseshoe_vortex_strengths,
                 r_c0s=self._stackRc0s,
                 singularity_counts=singularity_counts,
-                ages=None,
                 nu=self.operating_point.nu,
             )
         )
@@ -454,7 +453,6 @@ class SteadyRingVortexLatticeMethodSolver:
                     strengths=self._horseshoe_vortex_strengths,
                     r_c0s=self._stackRc0s,
                     singularity_counts=singularity_counts,
-                    ages=None,
                     nu=self.operating_point.nu,
                 )
             )
@@ -596,7 +594,6 @@ class SteadyRingVortexLatticeMethodSolver:
                 strengths=self._horseshoe_vortex_strengths,
                 r_c0s=self._stackRc0s,
                 singularity_counts=bound_singularity_counts,
-                ages=None,
                 nu=self.operating_point.nu,
             )
         )
@@ -640,7 +637,6 @@ class SteadyRingVortexLatticeMethodSolver:
                     strengths=self._horseshoe_vortex_strengths,
                     r_c0s=self._stackRc0s,
                     singularity_counts=bound_singularity_counts,
-                    ages=None,
                     nu=self.operating_point.nu,
                 )
             )


### PR DESCRIPTION
# Description

Remove the `ages` parameter from `collapsed_velocities_from_horseshoe_vortices` and `expanded_velocities_from_horseshoe_vortices` and update all call sites accordingly.

## Motivation


The `ages` parameter was not used for horseshoe vortex calculations and was already marked with a `TODO` comment.
Removing it simplifies the public API and avoids passing an unused argument while keeping behavior unchanged.

## Relevant Issues

Closes #125

## Changes

- Removed ages parameter from `collapsed_velocities_from_horseshoe_vortices`
- Removed ages parameter from `expanded_velocities_from_horseshoe_vortices`
- Updated all call sites to remove the unused argument

## New Dependencies

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

---

# Checklist

- [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
- [x] My branch is based on `main` and is up to date with the upstream `main` branch.
- [x] All calculations use S.I. units.
- [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
- [x] Code is well documented with block comments where appropriate.
- [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
- [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
- [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
- [x] Code locally passes all tests in the `tests` package.
- [x] After pushing, PR passes all automated checks (`codespell`, `black`, `mypy`, and `tests`).
- [x] PR description links all relevant issues and follows this template.

---