### PR TITLE
[FEATURE] Coupled Layer

### DIFF
--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -3,6 +3,7 @@
 This document describes the consistent pattern of immutability and lazy caching across the following core data and geometry classes in the Ptera Software codebase:
 
 - `CoreUnsteadyProblem` / `UnsteadyProblem`
+- `_CoupledUnsteadyProblem`
 - `CoreMovement` / `Movement`
 - `CoreAirplaneMovement` / `AirplaneMovement`
 - `CoreWingMovement` / `WingMovement`
@@ -124,6 +125,23 @@ Store collections as tuples internally to prevent external mutation via `.append
 | `finalRmsMomentCoefficients_W_CgP1`  | `list[np.ndarray]` | RMS moment coefficients            |
 
 **Note**: The mutable solver result lists are defined on `CoreUnsteadyProblem` and must remain mutable as they are populated after initialization by the solver. These are initialized as empty lists and appended to during the solve.
+
+## _CoupledUnsteadyProblem Class (`problems.py`)
+
+`_CoupledUnsteadyProblem` is a private middle-layer class that extends `CoreUnsteadyProblem`. It is the base for concrete subclasses (forthcoming `AeroelasticUnsteadyProblem` and `FreeFlightUnsteadyProblem`) whose geometry at each time step depends on the solver's results from the previous step. Unlike `UnsteadyProblem`, which builds all `SteadyProblem`s up front from a pre-generated `Movement`, the coupled subclasses grow their `SteadyProblem` collection one step at a time during the solve.
+
+All `CoreUnsteadyProblem` attributes (documented in the section above) are inherited unchanged. The additions are:
+
+### Attribute Classification
+
+#### Immutable (set in `__init__`, never modified)
+
+| Attribute         | Type                        | Notes                                                                                                                                                |
+|-------------------|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `movement`        | `CoreMovement`              | Source of `delta_time`, `num_steps`, `max_wake_rows`, and `lcm_period`                                                                               |
+| `steady_problems` | `tuple[SteadyProblem, ...]` | Read-only view of the `_steady_problems` backing list; returned tuple is frozen, but successive calls may return different-length tuples (see below) |
+
+**Note on `steady_problems`**: The parent class's `steady_problems` property is doubly immutable. The returned tuple is read-only and its value never changes over the lifetime of the `UnsteadyProblem`. On `_CoupledUnsteadyProblem`, the first guarantee still holds (callers cannot mutate the tuple), but the second does not. The backing slot `_steady_problems` is a `list[SteadyProblem]` seeded at init with a single entry built from `initial_airplanes` and `initial_operating_point`. Subclass `initialize_next_problem` overrides append to this list as each step is initialized during the solve, so calling `steady_problems` at different points can yield different-length tuples. External code that needs a consistent snapshot should read `steady_problems` once after the solver has completed.
 
 ## CoreMovement / Movement Class (`_core.py`, `movements/movement.py`)
 
@@ -651,4 +669,4 @@ Since `LineVortex` is an internal class whose endpoints ARE updated by parent vo
 
 ## Solver Classes (Not Covered Above)
 
-The three solver classes (`SteadyHorseshoeVortexLatticeMethodSolver`, `SteadyRingVortexLatticeMethodSolver`, and `UnsteadyRingVortexLatticeMethodSolver`) are intentionally omitted from the immutability and lazy caching patterns described in this document. Unlike the data and geometry classes above, the solver classes are algorithmic classes whose attributes are internal mutable working state in a procedural computation pipeline. They are not shared data that external code accesses or modifies, so immutable properties, set once enforcement, and lazy caching would add significant boilerplate with no meaningful safety benefit. The solver classes do still use `__slots__`, like all other classes in the package, to protect against dynamic attribute assignment typos.
+The four solver classes (`SteadyHorseshoeVortexLatticeMethodSolver`, `SteadyRingVortexLatticeMethodSolver`, `UnsteadyRingVortexLatticeMethodSolver`, and `CoupledUnsteadyRingVortexLatticeMethodSolver`) are intentionally omitted from the immutability and lazy caching patterns described in this document. Unlike the data and geometry classes above, the solver classes are algorithmic classes whose attributes are internal mutable working state in a procedural computation pipeline. They are not shared data that external code accesses or modifies, so immutable properties, set once enforcement, and lazy caching would add significant boilerplate with no meaningful safety benefit. The solver classes do still use `__slots__`, like all other classes in the package, to protect against dynamic attribute assignment typos.

--- a/pterasoftware/_core.py
+++ b/pterasoftware/_core.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import copy
 import math
 from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from . import _oscillation, _parameter_validation, _transformations, geometry
 from . import operating_point as operating_point_mod
+
+if TYPE_CHECKING:
+    from . import problems
 
 
 def lcm(a: float, b: float) -> float:
@@ -2361,3 +2365,22 @@ class CoreUnsteadyProblem:
     @property
     def max_wake_rows(self) -> int | None:
         return self._max_wake_rows
+
+    @property
+    def movement(self) -> CoreMovement:
+        # This stub lets the UnsteadyRingVortexLatticeMethodSolver access movement and
+        # steady_problems on any CoreUnsteadyProblem without knowing the concrete
+        # subclass.
+        raise NotImplementedError(
+            "Subclasses of CoreUnsteadyProblem must override the movement property."
+        )
+
+    @property
+    def steady_problems(self) -> tuple[problems.SteadyProblem, ...]:
+        # This stub lets the UnsteadyRingVortexLatticeMethodSolver access movement and
+        # steady_problems on any CoreUnsteadyProblem without knowing the concrete
+        # subclass.
+        raise NotImplementedError(
+            "Subclasses of CoreUnsteadyProblem must override the steady_problems "
+            "property."
+        )

--- a/pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py
@@ -1,0 +1,77 @@
+"""Contains the CoupledUnsteadyRingVortexLatticeMethodSolver class.
+
+**Contains the following classes:**
+
+CoupledUnsteadyRingVortexLatticeMethodSolver: A subclass of
+UnsteadyRingVortexLatticeMethodSolver that solves _CoupledUnsteadyProblems, whose
+geometry is initialized and updated step by step rather than being fully precomputed.
+
+**Contains the following functions:**
+
+None
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from . import _logging, problems
+from .unsteady_ring_vortex_lattice_method import UnsteadyRingVortexLatticeMethodSolver
+
+_logger = _logging.get_logger("_coupled_unsteady_ring_vortex_lattice_method")
+
+
+class CoupledUnsteadyRingVortexLatticeMethodSolver(
+    UnsteadyRingVortexLatticeMethodSolver
+):
+    """A subclass of UnsteadyRingVortexLatticeMethodSolver that solves
+    _CoupledUnsteadyProblems.
+
+    Geometry in a _CoupledUnsteadyProblem is determined step by step from the solver's
+    results at the previous step, so bound vortices cannot be initialized upfront. This
+    class inherits the parent's run() and initialize_step_geometry() unchanged and
+    overrides three hooks: _initialize_step_vortices (per step bound vortex init),
+    _pre_shed_hook (calls _CoupledUnsteadyProblem.initialize_next_problem between
+    steps), and _get_steady_problem_at (dynamic dispatch through the problem's
+    get_steady_problem accessor).
+
+    **Contains the following methods:**
+
+    None
+    """
+
+    __slots__ = ()
+
+    def __init__(self, unsteady_problem: problems._CoupledUnsteadyProblem) -> None:
+        """The initialization method.
+
+        :param unsteady_problem: The _CoupledUnsteadyProblem to be solved.
+        :return: None
+        """
+        if not isinstance(unsteady_problem, problems._CoupledUnsteadyProblem):
+            raise TypeError("unsteady_problem must be a _CoupledUnsteadyProblem.")
+        super().__init__(unsteady_problem)
+
+    @property
+    def _coupled_problem(self) -> problems._CoupledUnsteadyProblem:
+        """Type narrowed view of the inherited unsteady_problem attribute.
+
+        The parent stores unsteady_problem as a CoreUnsteadyProblem (widened to let
+        subclasses pass their own variants). __init__ validates that this subclass
+        always receives a _CoupledUnsteadyProblem, so the cast here is safe.
+
+        :return: The unsteady_problem narrowed to _CoupledUnsteadyProblem.
+        """
+        return cast(problems._CoupledUnsteadyProblem, self.unsteady_problem)
+
+    def _initialize_step_vortices(self, step: int) -> None:
+        _logger.debug(f"Initializing step {step}'s bound RingVortices.")
+        self._initialize_panel_vortices_at(step)
+
+    def _pre_shed_hook(self, step: int) -> None:
+        if step < self.num_steps - 1:
+            self._coupled_problem.initialize_next_problem(self)
+            self._initialize_panel_vortices_at(step + 1)
+
+    def _get_steady_problem_at(self, step: int) -> problems.SteadyProblem:
+        return self._coupled_problem.get_steady_problem(step)

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -260,7 +260,7 @@ class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
 
     __slots__ = (
         "_movement",
-        "coupled_steady_problems",
+        "_steady_problems",
     )
 
     def __init__(
@@ -294,9 +294,12 @@ class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
             lcm_period=self._movement.lcm_period,
         )
 
-        # Coupled-specific state: list of steady problems for each coupled step.
-        # We create an initial SteadyProblem using the provided initial geometry.
-        self.coupled_steady_problems: list[SteadyProblem] = [
+        # Coupled-specific state: a mutable list of SteadyProblems that grows as the
+        # solver advances. Subclass initialize_next_problem overrides append to this
+        # list; external code reads through the steady_problems tuple-view property to
+        # preserve the read-only contract inherited from UnsteadyProblem. Seed with a
+        # SteadyProblem built from the initial geometry so step zero is always ready.
+        self._steady_problems: list[SteadyProblem] = [
             SteadyProblem(
                 airplanes=initial_airplanes,
                 operating_point=initial_operating_point,
@@ -310,7 +313,7 @@ class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
 
     @property
     def steady_problems(self) -> tuple[SteadyProblem, ...]:
-        return tuple(self.coupled_steady_problems)
+        return tuple(self._steady_problems)
 
     def get_steady_problem(self, step: int) -> SteadyProblem:
         """Get the SteadyProblem at a given time step.
@@ -320,10 +323,10 @@ class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
         :return: The SteadyProblem at the specified time step.
         """
         step = _parameter_validation.int_in_range_return_int(
-            step, "step", 0, True, len(self.coupled_steady_problems), False
+            step, "step", 0, True, len(self._steady_problems), False
         )
 
-        return self.coupled_steady_problems[step]
+        return self._steady_problems[step]
 
     def initialize_next_problem(
         self, solver: CoupledUnsteadyRingVortexLatticeMethodSolver

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -13,19 +13,17 @@ None
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from . import _core, _parameter_validation, _transformations, geometry, movements
 from . import operating_point as operating_point_mod
 
-# TODO: Uncomment this block when adding type hints for
-#  _CoupledUnsteadyProblem.initialize_next_problem().
-# from typing import TYPE_CHECKING
-#
-# if TYPE_CHECKING:
-#     from .coupled_unsteady_ring_vortex_lattice_method import (
-#         CoupledUnsteadyRingVortexLatticeMethodSolver,
-#     )
+if TYPE_CHECKING:
+    from ._coupled_unsteady_ring_vortex_lattice_method import (
+        CoupledUnsteadyRingVortexLatticeMethodSolver,
+    )
 
 
 class SteadyProblem:
@@ -327,15 +325,15 @@ class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
 
         return self.coupled_steady_problems[step]
 
-    # TODO: Add a type hint for solver once the
-    #  _CoupledUnsteadyRingVortexLatticeMethodSolver stub is implemented.
-    def initialize_next_problem(self, solver) -> None:
+    def initialize_next_problem(
+        self, solver: CoupledUnsteadyRingVortexLatticeMethodSolver
+    ) -> None:
         """Initialize the next time step's SteadyProblem.
 
         Must be overridden by subclasses to compute the geometry for the next time step
         based on the solver's results.
 
-        :param solver: The _CoupledUnsteadyRingVortexLatticeMethodSolver instance
+        :param solver: The CoupledUnsteadyRingVortexLatticeMethodSolver instance
             providing aerodynamic data from the current time step.
         :return: None
         """

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -15,8 +15,17 @@ from __future__ import annotations
 
 import numpy as np
 
-from . import _core, _transformations, geometry, movements
+from . import _core, _parameter_validation, _transformations, geometry, movements
 from . import operating_point as operating_point_mod
+
+# TODO: Uncomment this block when adding type hints for
+#  _CoupledUnsteadyProblem.initialize_next_problem().
+# from typing import TYPE_CHECKING
+#
+# if TYPE_CHECKING:
+#     from .coupled_unsteady_ring_vortex_lattice_method import (
+#         CoupledUnsteadyRingVortexLatticeMethodSolver,
+#     )
 
 
 class SteadyProblem:
@@ -229,3 +238,105 @@ class UnsteadyProblem(_core.CoreUnsteadyProblem):
     @property
     def steady_problems(self) -> tuple[SteadyProblem, ...]:
         return self._steady_problems
+
+
+class _CoupledUnsteadyProblem(_core.CoreUnsteadyProblem):
+    """A class for coupled unsteady aerodynamics problems.
+
+    This class extends CoreUnsteadyProblem to manage SteadyProblems for coupled
+    simulations where the geometry at each time step depends on the solver's results
+    from previous time steps.
+
+    **Contains the following methods:**
+
+    movement: The CoreMovement that defines the motion parameters for this problem.
+
+    steady_problems: A tuple of SteadyProblems, one for each time step that has been
+    initialized so far.
+
+    get_steady_problem: Gets the SteadyProblem at a specified time step.
+
+    initialize_next_problem: Initializes the next time step's SteadyProblem. Must be
+    overridden by subclasses.
+    """
+
+    __slots__ = (
+        "_movement",
+        "coupled_steady_problems",
+    )
+
+    def __init__(
+        self,
+        movement: _core.CoreMovement,
+        initial_airplanes: list[geometry.airplane.Airplane],
+        initial_operating_point: operating_point_mod.OperatingPoint,
+    ) -> None:
+        """The initialization method.
+
+        Initializes the coupled unsteady problem with the first time step's geometry and
+        the motion parameters from the provided CoreMovement.
+
+        :param movement: A CoreMovement object that defines the motion parameters
+            (delta_time, num_steps, max_wake_rows, lcm_period) for this problem.
+        :param initial_airplanes: The list of Airplanes at the first time step.
+        :param initial_operating_point: The OperatingPoint at the first time step.
+        :return: None
+        """
+        self._movement = movement
+
+        # Delegate shared initialization (validation, first_averaging_step computation,
+        # load list initialization) to the core class. _CoupledUnsteadyProblems require
+        # per step results to feed the coupling hook, so only_final_results is always
+        # False.
+        super().__init__(
+            only_final_results=False,
+            delta_time=self._movement.delta_time,
+            num_steps=self._movement.num_steps,
+            max_wake_rows=self._movement.max_wake_rows,
+            lcm_period=self._movement.lcm_period,
+        )
+
+        # Coupled-specific state: list of steady problems for each coupled step.
+        # We create an initial SteadyProblem using the provided initial geometry.
+        self.coupled_steady_problems: list[SteadyProblem] = [
+            SteadyProblem(
+                airplanes=initial_airplanes,
+                operating_point=initial_operating_point,
+            )
+        ]
+
+    # --- Immutable: read only properties ---
+    @property
+    def movement(self) -> _core.CoreMovement:
+        return self._movement
+
+    @property
+    def steady_problems(self) -> tuple[SteadyProblem, ...]:
+        return tuple(self.coupled_steady_problems)
+
+    def get_steady_problem(self, step: int) -> SteadyProblem:
+        """Get the SteadyProblem at a given time step.
+
+        :param step: The time step index (zero indexed). Must be greater than or equal
+            to zero and less than the total number of time steps.
+        :return: The SteadyProblem at the specified time step.
+        """
+        step = _parameter_validation.int_in_range_return_int(
+            step, "step", 0, True, len(self.coupled_steady_problems), False
+        )
+
+        return self.coupled_steady_problems[step]
+
+    # TODO: Add a type hint for solver once the
+    #  _CoupledUnsteadyRingVortexLatticeMethodSolver stub is implemented.
+    def initialize_next_problem(self, solver) -> None:
+        """Initialize the next time step's SteadyProblem.
+
+        Must be overridden by subclasses to compute the geometry for the next time step
+        based on the solver's results.
+
+        :param solver: The _CoupledUnsteadyRingVortexLatticeMethodSolver instance
+            providing aerodynamic data from the current time step.
+        :return: None
+        """
+        raise NotImplementedError("Subclasses must implement initialize_next_problem.")

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -39,7 +39,6 @@ _logger = _logging.get_logger("unsteady_ring_vortex_lattice_method")
 
 # REFACTOR: Add unit tests for trapezoid-rule-based averages for the mean and RMS loads
 #  and load coefficients.
-# TEST: Consider adding unit tests for this function.
 # TEST: Assess how comprehensive this function's integration tests are and update or
 #  extend them if needed.
 class UnsteadyRingVortexLatticeMethodSolver:

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 
 from . import (
     _aerodynamics_functions,
+    _core,
     _functions,
     _logging,
     _panel,
@@ -127,13 +128,17 @@ class UnsteadyRingVortexLatticeMethodSolver:
         "ran",
     )
 
-    def __init__(self, unsteady_problem: problems.UnsteadyProblem) -> None:
+    def __init__(self, unsteady_problem: _core.CoreUnsteadyProblem) -> None:
         """The initialization method.
 
         :param unsteady_problem: The UnsteadyProblem to be solved.
         :return: None
         """
-        if not isinstance(unsteady_problem, problems.UnsteadyProblem):
+        # Guard direct instantiation of the base solver against coupled problems while
+        # allowing subclasses to pass their own CoreUnsteadyProblem variants via super().
+        if type(self) is UnsteadyRingVortexLatticeMethodSolver and not isinstance(
+            unsteady_problem, problems.UnsteadyProblem
+        ):
             raise TypeError("unsteady_problem must be an UnsteadyProblem.")
         self.unsteady_problem = unsteady_problem
 
@@ -2084,8 +2089,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
         num_steps_to_average = self.num_steps - self._first_averaging_step
 
         # Determine if this SteadyProblem's geometry is static or variable.
-        this_movement: movements.movement.Movement = self.unsteady_problem.movement
-        static = this_movement.static
+        static = self.unsteady_problem.movement.static
 
         # Initialize ndarrays to hold each Airplane's loads and load coefficients at
         # each of the time steps that calculated the loads.

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -404,10 +404,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
             bar_format="{desc}:{percentage:3.0f}% |{bar}| Elapsed: {elapsed}, "
             "Remaining: {remaining}",
         ) as bar:
-            # Initialize all the Airplanes' bound RingVortices.
-            _logger.debug("Initializing all Airplanes' bound RingVortices.")
-            self._initialize_panel_vortices()
-
             # Update the progress bar based on the initialization step's predicted
             # approximate, relative computing time.
             bar.update(n=float(approx_times[0]))
@@ -419,6 +415,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 # and OperatingPoint, and freestream velocity (in the first
                 # Airplane's geometry axes, observed from the Earth frame).
                 self._current_step = step
+
+                # Initialize this step's bound RingVortices. The default does an
+                # upfront init for all steps on step 0 and is a no-op thereafter;
+                # coupled subclasses override this hook to init one step at a time.
+                self._initialize_step_vortices(step)
                 current_problem: problems.SteadyProblem = self._get_steady_problem_at(
                     self._current_step
                 )
@@ -511,6 +512,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 self.panel_is_left_edge = np.zeros(self.num_panels, dtype=bool)
                 self.panel_is_right_edge = np.zeros(self.num_panels, dtype=bool)
 
+                # Hook: subclasses may reinitialize step-specific arrays here.
+                self._reinitialize_step_arrays_hook()
+
                 # Get the pre-allocated (but still all zero) arrays of wake
                 # information that are associated with this time step.
                 self._current_wake_vortex_strengths = self._list_wake_vortex_strengths[
@@ -559,6 +563,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     _logger.debug("Calculating forces and moments.")
                     self._calculate_loads()
 
+                # Hook: subclasses may inject work between load calculation and wake
+                # shedding (e.g. coupled problems update the next step's geometry
+                # from this step's solver results).
+                self._pre_shed_hook(step)
+
                 # Shed RingVortices into the wake.
                 _logger.debug("Shedding RingVortices into the wake.")
                 self._populate_next_airplanes_wake()
@@ -597,9 +606,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
             step, "step", 0, True, self.num_steps, False
         )
 
-        # Initialize bound RingVortices for all steps on the first call.
-        if step == 0:
-            self._initialize_panel_vortices()
+        # Initialize bound RingVortices. The base solver's hook does an upfront init
+        # for all steps when step is 0 and is a no-op otherwise; coupled subclasses
+        # override to initialize only the specified step.
+        self._initialize_step_vortices(step)
 
         # Set the current step and related state.
         self._current_step = step
@@ -612,6 +622,44 @@ class UnsteadyRingVortexLatticeMethodSolver:
         if step < self.num_steps - 1:
             self._populate_next_airplanes_wake_vortex_points()
             self._populate_next_airplanes_wake_vortices()
+
+    def _initialize_step_vortices(self, step: int) -> None:
+        """Initializes this time step's bound RingVortices.
+
+        The default implementation initializes bound RingVortices for all time steps
+        upfront on step 0 and is a no-op on subsequent steps. Coupled subclasses
+        override this to initialize only the given step, since their geometry is
+        determined dynamically from the solver's results at the previous step.
+
+        :param step: The time step to initialize.
+        :return: None
+        """
+        if step == 0:
+            _logger.debug("Initializing all Airplanes' bound RingVortices.")
+            self._initialize_panel_vortices()
+
+    def _reinitialize_step_arrays_hook(self) -> None:
+        """Hook for subclasses to reinitialize step specific arrays.
+
+        Called once per time step in run(), after the standard per step arrays are
+        reinitialized and before the wake arrays are retrieved. The default
+        implementation is a no op. Subclasses may override this to zero out or
+        reallocate feature specific arrays at the start of each step.
+
+        :return: None
+        """
+
+    def _pre_shed_hook(self, step: int) -> None:
+        """Hook for subclasses to inject work between load calculation and wake shed.
+
+        Called once per time step in run(), after this step's loads have been calculated
+        and before wake RingVortices are shed. The default implementation is a no op.
+        Coupled subclasses override this to update the next time step's geometry from
+        the current step's solver results.
+
+        :param step: The current time step.
+        :return: None
+        """
 
     def _initialize_panel_vortices(self) -> None:
         """Calculates the locations of the bound RingVortex vertices for all time steps,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -31,6 +31,12 @@ This package contains the following modules:
     test_core_unsteady_problem.py: This module contains classes to test
     CoreUnsteadyProblems.
 
+    test_coupled_unsteady_problem.py: This module contains classes to test
+    _CoupledUnsteadyProblems.
+
+    test_coupled_unsteady_ring_vortex_lattice_method.py: This module contains
+    classes to test CoupledUnsteadyRingVortexLatticeMethodSolvers.
+
     test_core_wing_cross_section_movement.py: This module contains classes to test
     CoreWingCrossSectionMovements.
 
@@ -73,6 +79,9 @@ This package contains the following modules:
     test_transformations.py: This module contains classes to test functions in the
     transformations module.
 
+    test_unsteady_ring_vortex_lattice_method.py: This module contains classes to
+    test UnsteadyRingVortexLatticeMethodSolvers.
+
     test_wing.py: This module contains classes to test Wings.
 
     test_wing_cross_section.py: This module contains classes to test WingCrossSections.
@@ -94,6 +103,8 @@ import tests.unit.test_core_operating_point_movement
 import tests.unit.test_core_unsteady_problem
 import tests.unit.test_core_wing_cross_section_movement
 import tests.unit.test_core_wing_movement
+import tests.unit.test_coupled_unsteady_problem
+import tests.unit.test_coupled_unsteady_ring_vortex_lattice_method
 import tests.unit.test_horseshoe_vortex
 import tests.unit.test_line_vortex
 import tests.unit.test_movement
@@ -108,6 +119,7 @@ import tests.unit.test_ring_vortex
 import tests.unit.test_serialization
 import tests.unit.test_slots
 import tests.unit.test_transformations
+import tests.unit.test_unsteady_ring_vortex_lattice_method
 import tests.unit.test_wing
 import tests.unit.test_wing_cross_section
 import tests.unit.test_wing_cross_section_movement

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -2,7 +2,12 @@
 
 import pterasoftware as ps
 
-from . import geometry_fixtures, movement_fixtures, operating_point_fixtures
+from . import (
+    core_movement_fixtures,
+    geometry_fixtures,
+    movement_fixtures,
+    operating_point_fixtures,
+)
 
 
 def make_basic_steady_problem_fixture():
@@ -105,3 +110,20 @@ def make_multi_airplane_unsteady_problem_fixture():
     )
 
     return multi_airplane_unsteady_problem_fixture
+
+
+def make_basic_coupled_unsteady_problem_fixture():
+    """This method makes a fixture that is a _CoupledUnsteadyProblem for general testing.
+
+    :return basic_coupled_unsteady_problem_fixture: _CoupledUnsteadyProblem
+        This is the _CoupledUnsteadyProblem configured for general testing.
+    """
+    # SteadyProblem sets GP1_CgP1 attributes on each Panel exactly once, so a fresh
+    # Airplane is required for every _CoupledUnsteadyProblem instance.
+    basic_coupled_unsteady_problem_fixture = ps.problems._CoupledUnsteadyProblem(
+        movement=core_movement_fixtures.make_static_core_movement_fixture(),
+        initial_airplanes=[geometry_fixtures.make_first_airplane_fixture()],
+        initial_operating_point=operating_point_fixtures.make_basic_operating_point_fixture(),
+    )
+
+    return basic_coupled_unsteady_problem_fixture

--- a/tests/unit/fixtures/solver_fixtures.py
+++ b/tests/unit/fixtures/solver_fixtures.py
@@ -2,6 +2,11 @@
 
 import pterasoftware as ps
 
+# noinspection PyProtectedMember
+from pterasoftware._coupled_unsteady_ring_vortex_lattice_method import (
+    CoupledUnsteadyRingVortexLatticeMethodSolver,
+)
+
 from . import problem_fixtures
 
 
@@ -51,5 +56,21 @@ def make_unsteady_ring_solver_fixture():
             unsteady_problem
         )
     )
+
+    return solver
+
+
+def make_coupled_unsteady_ring_solver_fixture():
+    """This method makes a fixture that is a
+    CoupledUnsteadyRingVortexLatticeMethodSolver for general testing.
+
+    :return solver: CoupledUnsteadyRingVortexLatticeMethodSolver
+        This is the CoupledUnsteadyRingVortexLatticeMethodSolver fixture.
+    """
+    coupled_unsteady_problem = (
+        problem_fixtures.make_basic_coupled_unsteady_problem_fixture()
+    )
+
+    solver = CoupledUnsteadyRingVortexLatticeMethodSolver(coupled_unsteady_problem)
 
     return solver

--- a/tests/unit/test_coupled_unsteady_problem.py
+++ b/tests/unit/test_coupled_unsteady_problem.py
@@ -1,0 +1,175 @@
+"""This module contains classes to test _CoupledUnsteadyProblems."""
+
+import unittest
+
+import pterasoftware as ps
+from tests.unit.fixtures import (
+    core_movement_fixtures,
+    geometry_fixtures,
+    operating_point_fixtures,
+    problem_fixtures,
+)
+
+
+class TestCoupledUnsteadyProblem(unittest.TestCase):
+    """This is a class with functions to test _CoupledUnsteadyProblems."""
+
+    def setUp(self):
+        """Set up a fresh _CoupledUnsteadyProblem for each test."""
+        self.movement = core_movement_fixtures.make_static_core_movement_fixture()
+        self.initial_airplane = geometry_fixtures.make_first_airplane_fixture()
+        self.initial_operating_point = (
+            operating_point_fixtures.make_basic_operating_point_fixture()
+        )
+        self.problem = ps.problems._CoupledUnsteadyProblem(
+            movement=self.movement,
+            initial_airplanes=[self.initial_airplane],
+            initial_operating_point=self.initial_operating_point,
+        )
+
+    def test_initialization_valid_parameters(self):
+        """Test _CoupledUnsteadyProblem initialization with valid parameters."""
+        self.assertIsInstance(self.problem, ps.problems._CoupledUnsteadyProblem)
+        self.assertIsInstance(self.problem, ps._core.CoreUnsteadyProblem)
+
+    def test_step_zero_seeded_from_initial_inputs(self):
+        """Test that coupled_steady_problems is seeded with one SteadyProblem built
+        from initial_airplanes and initial_operating_point.
+        """
+        self.assertEqual(len(self.problem.coupled_steady_problems), 1)
+        seed = self.problem.coupled_steady_problems[0]
+        self.assertIsInstance(seed, ps.problems.SteadyProblem)
+        self.assertEqual(seed.airplanes, (self.initial_airplane,))
+        self.assertIs(seed.operating_point, self.initial_operating_point)
+
+    def test_only_final_results_forced_false(self):
+        """Test that only_final_results is always False for coupled problems."""
+        self.assertFalse(self.problem.only_final_results)
+
+    def test_delta_time_from_movement(self):
+        """Test that delta_time is taken from the movement."""
+        self.assertEqual(self.problem.delta_time, self.movement.delta_time)
+
+    def test_num_steps_from_movement(self):
+        """Test that num_steps is taken from the movement."""
+        self.assertEqual(self.problem.num_steps, self.movement.num_steps)
+
+    def test_max_wake_rows_from_movement(self):
+        """Test that max_wake_rows is taken from the movement."""
+        self.assertEqual(self.problem.max_wake_rows, self.movement.max_wake_rows)
+
+    def test_lcm_period_from_movement(self):
+        """Test that lcm_period is taken from the movement by asserting the derived
+        first_averaging_step matches the static-movement formula (num_steps - 1).
+        """
+        self.assertEqual(self.movement.lcm_period, 0.0)
+        self.assertEqual(self.problem.first_averaging_step, self.movement.num_steps - 1)
+
+    def test_movement_property_returns_core_movement(self):
+        """Test that the movement property returns the provided CoreMovement."""
+        self.assertIs(self.problem.movement, self.movement)
+
+    def test_steady_problems_property_returns_tuple(self):
+        """Test that the steady_problems property returns a tuple view of
+        coupled_steady_problems.
+        """
+        steady_problems = self.problem.steady_problems
+        self.assertIsInstance(steady_problems, tuple)
+        self.assertEqual(len(steady_problems), 1)
+        self.assertIs(steady_problems[0], self.problem.coupled_steady_problems[0])
+
+    def test_steady_problems_property_reflects_appends(self):
+        """Test that appends to coupled_steady_problems are reflected in the
+        steady_problems tuple view on subsequent access.
+        """
+        self.assertEqual(len(self.problem.steady_problems), 1)
+
+        next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
+        self.problem.coupled_steady_problems.append(next_steady_problem)
+
+        self.assertEqual(len(self.problem.steady_problems), 2)
+        self.assertIs(self.problem.steady_problems[1], next_steady_problem)
+
+    def test_get_steady_problem_returns_requested_step(self):
+        """Test that get_steady_problem returns the SteadyProblem at the given
+        step.
+        """
+        self.assertIs(
+            self.problem.get_steady_problem(0),
+            self.problem.coupled_steady_problems[0],
+        )
+
+        next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
+        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.assertIs(self.problem.get_steady_problem(1), next_steady_problem)
+
+    def test_get_steady_problem_rejects_negative_step(self):
+        """Test that get_steady_problem raises for negative step values."""
+        with self.assertRaises(ValueError):
+            self.problem.get_steady_problem(-1)
+
+    def test_get_steady_problem_rejects_step_beyond_initialized(self):
+        """Test that get_steady_problem raises for a step index that has not yet
+        been initialized.
+        """
+        with self.assertRaises(ValueError):
+            self.problem.get_steady_problem(1)
+
+    def test_get_steady_problem_dynamic_bounds(self):
+        """Test that the valid range of get_steady_problem grows as new
+        SteadyProblems are appended to coupled_steady_problems.
+        """
+        with self.assertRaises(ValueError):
+            self.problem.get_steady_problem(1)
+
+        next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
+        self.problem.coupled_steady_problems.append(next_steady_problem)
+
+        self.assertIs(self.problem.get_steady_problem(1), next_steady_problem)
+
+    def test_initialize_next_problem_raises_not_implemented(self):
+        """Test that initialize_next_problem raises NotImplementedError on the
+        abstract middle class.
+        """
+        with self.assertRaises(NotImplementedError):
+            self.problem.initialize_next_problem(None)
+
+
+class TestCoupledUnsteadyProblemImmutability(unittest.TestCase):
+    """Tests for _CoupledUnsteadyProblem attribute immutability."""
+
+    def setUp(self):
+        """Set up a fresh _CoupledUnsteadyProblem for each immutability test."""
+        self.problem = problem_fixtures.make_basic_coupled_unsteady_problem_fixture()
+
+    def test_immutable_movement_property(self):
+        """Test that the movement property is read only."""
+        new_movement = core_movement_fixtures.make_static_core_movement_fixture()
+        with self.assertRaises(AttributeError):
+            self.problem.movement = new_movement
+
+    def test_immutable_steady_problems_property(self):
+        """Test that the steady_problems property is read only."""
+        with self.assertRaises(AttributeError):
+            self.problem.steady_problems = ()
+
+    def test_steady_problems_tuple_immutability(self):
+        """Test that the steady_problems tuple cannot be mutated."""
+        with self.assertRaises(AttributeError):
+            self.problem.steady_problems.append(
+                problem_fixtures.make_basic_steady_problem_fixture()
+            )
+
+    def test_coupled_steady_problems_list_is_mutable(self):
+        """Test that coupled_steady_problems remains mutable so solvers can
+        append the next step's SteadyProblem during the run loop.
+        """
+        next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
+        self.problem.coupled_steady_problems.append(next_steady_problem)
+
+        self.assertEqual(len(self.problem.coupled_steady_problems), 2)
+        self.assertIs(self.problem.coupled_steady_problems[1], next_steady_problem)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_coupled_unsteady_problem.py
+++ b/tests/unit/test_coupled_unsteady_problem.py
@@ -33,11 +33,11 @@ class TestCoupledUnsteadyProblem(unittest.TestCase):
         self.assertIsInstance(self.problem, ps._core.CoreUnsteadyProblem)
 
     def test_step_zero_seeded_from_initial_inputs(self):
-        """Test that coupled_steady_problems is seeded with one SteadyProblem built
-        from initial_airplanes and initial_operating_point.
+        """Test that _steady_problems is seeded with one SteadyProblem built from
+        initial_airplanes and initial_operating_point.
         """
-        self.assertEqual(len(self.problem.coupled_steady_problems), 1)
-        seed = self.problem.coupled_steady_problems[0]
+        self.assertEqual(len(self.problem._steady_problems), 1)
+        seed = self.problem._steady_problems[0]
         self.assertIsInstance(seed, ps.problems.SteadyProblem)
         self.assertEqual(seed.airplanes, (self.initial_airplane,))
         self.assertIs(seed.operating_point, self.initial_operating_point)
@@ -70,22 +70,22 @@ class TestCoupledUnsteadyProblem(unittest.TestCase):
         self.assertIs(self.problem.movement, self.movement)
 
     def test_steady_problems_property_returns_tuple(self):
-        """Test that the steady_problems property returns a tuple view of
-        coupled_steady_problems.
+        """Test that the steady_problems property returns a tuple view of the
+        _steady_problems backing list.
         """
         steady_problems = self.problem.steady_problems
         self.assertIsInstance(steady_problems, tuple)
         self.assertEqual(len(steady_problems), 1)
-        self.assertIs(steady_problems[0], self.problem.coupled_steady_problems[0])
+        self.assertIs(steady_problems[0], self.problem._steady_problems[0])
 
     def test_steady_problems_property_reflects_appends(self):
-        """Test that appends to coupled_steady_problems are reflected in the
-        steady_problems tuple view on subsequent access.
+        """Test that appends to _steady_problems are reflected in the steady_problems
+        tuple view on subsequent access.
         """
         self.assertEqual(len(self.problem.steady_problems), 1)
 
         next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
-        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.problem._steady_problems.append(next_steady_problem)
 
         self.assertEqual(len(self.problem.steady_problems), 2)
         self.assertIs(self.problem.steady_problems[1], next_steady_problem)
@@ -96,11 +96,11 @@ class TestCoupledUnsteadyProblem(unittest.TestCase):
         """
         self.assertIs(
             self.problem.get_steady_problem(0),
-            self.problem.coupled_steady_problems[0],
+            self.problem._steady_problems[0],
         )
 
         next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
-        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.problem._steady_problems.append(next_steady_problem)
         self.assertIs(self.problem.get_steady_problem(1), next_steady_problem)
 
     def test_get_steady_problem_rejects_negative_step(self):
@@ -117,13 +117,13 @@ class TestCoupledUnsteadyProblem(unittest.TestCase):
 
     def test_get_steady_problem_dynamic_bounds(self):
         """Test that the valid range of get_steady_problem grows as new
-        SteadyProblems are appended to coupled_steady_problems.
+        SteadyProblems are appended to _steady_problems.
         """
         with self.assertRaises(ValueError):
             self.problem.get_steady_problem(1)
 
         next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
-        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.problem._steady_problems.append(next_steady_problem)
 
         self.assertIs(self.problem.get_steady_problem(1), next_steady_problem)
 
@@ -160,15 +160,16 @@ class TestCoupledUnsteadyProblemImmutability(unittest.TestCase):
                 problem_fixtures.make_basic_steady_problem_fixture()
             )
 
-    def test_coupled_steady_problems_list_is_mutable(self):
-        """Test that coupled_steady_problems remains mutable so solvers can
-        append the next step's SteadyProblem during the run loop.
+    def test_private_steady_problems_list_is_mutable(self):
+        """Test that _steady_problems remains mutable so subclass
+        initialize_next_problem overrides can append the next step's SteadyProblem
+        during the run loop.
         """
         next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
-        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.problem._steady_problems.append(next_steady_problem)
 
-        self.assertEqual(len(self.problem.coupled_steady_problems), 2)
-        self.assertIs(self.problem.coupled_steady_problems[1], next_steady_problem)
+        self.assertEqual(len(self.problem._steady_problems), 2)
+        self.assertIs(self.problem._steady_problems[1], next_steady_problem)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_coupled_unsteady_ring_vortex_lattice_method.py
+++ b/tests/unit/test_coupled_unsteady_ring_vortex_lattice_method.py
@@ -1,0 +1,88 @@
+"""This module contains classes to test CoupledUnsteadyRingVortexLatticeMethodSolvers."""
+
+import unittest
+
+import pterasoftware as ps
+
+# noinspection PyProtectedMember
+from pterasoftware._coupled_unsteady_ring_vortex_lattice_method import (
+    CoupledUnsteadyRingVortexLatticeMethodSolver,
+)
+from tests.unit.fixtures import problem_fixtures, solver_fixtures
+
+
+class TestCoupledUnsteadyRingVortexLatticeMethodSolver(unittest.TestCase):
+    """This is a class with functions to test
+    CoupledUnsteadyRingVortexLatticeMethodSolvers.
+    """
+
+    def setUp(self):
+        """Set up a fresh problem and solver for each test."""
+        self.solver = solver_fixtures.make_coupled_unsteady_ring_solver_fixture()
+        self.problem = self.solver.unsteady_problem
+
+    def test_initialization_accepts_coupled_unsteady_problem(self):
+        """Test that initialization accepts a _CoupledUnsteadyProblem."""
+        self.assertIsInstance(self.solver, CoupledUnsteadyRingVortexLatticeMethodSolver)
+        self.assertIsInstance(
+            self.solver,
+            ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver,
+        )
+        self.assertIs(self.solver.unsteady_problem, self.problem)
+
+    def test_initialization_rejects_plain_unsteady_problem(self):
+        """Test that initialization raises TypeError for a plain UnsteadyProblem."""
+        plain_unsteady_problem = problem_fixtures.make_basic_unsteady_problem_fixture()
+        with self.assertRaises(TypeError):
+            CoupledUnsteadyRingVortexLatticeMethodSolver(plain_unsteady_problem)
+
+    def test_initialization_rejects_non_problem_types(self):
+        """Test that initialization raises TypeError for non-problem inputs."""
+        invalid_inputs = ["not_a_problem", 123, [1, 2, 3], {"key": "value"}]
+        for invalid in invalid_inputs:
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(TypeError):
+                    CoupledUnsteadyRingVortexLatticeMethodSolver(invalid)
+
+    def test_initialization_rejects_none(self):
+        """Test that initialization raises TypeError for None."""
+        with self.assertRaises(TypeError):
+            CoupledUnsteadyRingVortexLatticeMethodSolver(None)
+
+    def test_coupled_problem_property_narrows_unsteady_problem(self):
+        """Test that the _coupled_problem property returns the same object as
+        unsteady_problem, narrowed to _CoupledUnsteadyProblem.
+        """
+        self.assertIs(self.solver._coupled_problem, self.solver.unsteady_problem)
+        self.assertIsInstance(
+            self.solver._coupled_problem, ps.problems._CoupledUnsteadyProblem
+        )
+
+    def test_get_steady_problem_at_dispatches_through_coupled_problem(self):
+        """Test that _get_steady_problem_at dispatches through
+        _CoupledUnsteadyProblem.get_steady_problem rather than the cached tuple.
+
+        The parent solver captures steady_problems as a tuple snapshot at
+        construction time. The coupled subclass must dispatch through the
+        accessor so appends to coupled_steady_problems are visible at later
+        steps.
+        """
+        self.assertEqual(len(self.solver.steady_problems), 1)
+
+        next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
+        self.problem.coupled_steady_problems.append(next_steady_problem)
+
+        self.assertEqual(len(self.solver.steady_problems), 1)
+        self.assertIs(self.solver._get_steady_problem_at(1), next_steady_problem)
+
+    def test_inherits_empty_slots(self):
+        """Test that the subclass declares __slots__ = () so it does not gain an
+        instance __dict__ that would defeat the parent's __slots__.
+        """
+        self.assertEqual(CoupledUnsteadyRingVortexLatticeMethodSolver.__slots__, ())
+        with self.assertRaises(AttributeError):
+            self.solver.not_a_real_attribute = 42
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_coupled_unsteady_ring_vortex_lattice_method.py
+++ b/tests/unit/test_coupled_unsteady_ring_vortex_lattice_method.py
@@ -64,13 +64,13 @@ class TestCoupledUnsteadyRingVortexLatticeMethodSolver(unittest.TestCase):
 
         The parent solver captures steady_problems as a tuple snapshot at
         construction time. The coupled subclass must dispatch through the
-        accessor so appends to coupled_steady_problems are visible at later
-        steps.
+        accessor so appends to the problem's _steady_problems backing list are
+        visible at later steps.
         """
         self.assertEqual(len(self.solver.steady_problems), 1)
 
         next_steady_problem = problem_fixtures.make_basic_steady_problem_fixture()
-        self.problem.coupled_steady_problems.append(next_steady_problem)
+        self.problem._steady_problems.append(next_steady_problem)
 
         self.assertEqual(len(self.solver.steady_problems), 1)
         self.assertIs(self.solver._get_steady_problem_at(1), next_steady_problem)

--- a/tests/unit/test_unsteady_ring_vortex_lattice_method.py
+++ b/tests/unit/test_unsteady_ring_vortex_lattice_method.py
@@ -1,0 +1,87 @@
+"""This module contains classes to test UnsteadyRingVortexLatticeMethodSolvers."""
+
+import unittest
+from unittest.mock import patch
+
+import pterasoftware as ps
+from tests.unit.fixtures import problem_fixtures, solver_fixtures
+
+
+class TestUnsteadyRingVortexLatticeMethodSolver(unittest.TestCase):
+    """This is a class with functions to test UnsteadyRingVortexLatticeMethodSolvers."""
+
+    def test_initialization_accepts_unsteady_problem(self):
+        """Test that initialization accepts an UnsteadyProblem."""
+        solver = solver_fixtures.make_unsteady_ring_solver_fixture()
+        self.assertIsInstance(
+            solver,
+            ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver,
+        )
+
+    def test_initialization_rejects_coupled_unsteady_problem(self):
+        """Test that initialization on the base solver raises TypeError for a
+        _CoupledUnsteadyProblem, while still allowing the coupled subclass to
+        pass one through super().
+        """
+        coupled_problem = problem_fixtures.make_basic_coupled_unsteady_problem_fixture()
+        with self.assertRaises(TypeError):
+            ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(
+                coupled_problem
+            )
+
+    def test_initialization_rejects_non_problem_types(self):
+        """Test that initialization raises TypeError for non-problem inputs."""
+        invalid_inputs = [None, "not_a_problem", 123, [1, 2, 3], {"key": "value"}]
+        for invalid in invalid_inputs:
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(TypeError):
+                    ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(
+                        invalid
+                    )
+
+
+class TestUnsteadyRingVortexLatticeMethodSolverHookDefaults(unittest.TestCase):
+    """Tests for the default implementations of the three solver extension hooks
+    added to support coupled subclasses: _initialize_step_vortices,
+    _reinitialize_step_arrays_hook, and _pre_shed_hook.
+    """
+
+    def setUp(self):
+        """Set up a fresh solver for each hook-default test."""
+        self.solver = solver_fixtures.make_unsteady_ring_solver_fixture()
+
+    def test_initialize_step_vortices_initializes_all_on_step_zero(self):
+        """Test that the default _initialize_step_vortices initializes bound
+        vortices for all steps when called with step == 0.
+        """
+        with patch.object(
+            type(self.solver), "_initialize_panel_vortices", autospec=True
+        ) as mock_init:
+            self.solver._initialize_step_vortices(0)
+        mock_init.assert_called_once_with(self.solver)
+
+    def test_initialize_step_vortices_is_noop_for_later_steps(self):
+        """Test that the default _initialize_step_vortices is a no-op for any
+        step greater than 0.
+        """
+        later_steps = [1, 2, self.solver.num_steps - 1]
+        with patch.object(
+            type(self.solver), "_initialize_panel_vortices", autospec=True
+        ) as mock_init:
+            for step in later_steps:
+                self.solver._initialize_step_vortices(step)
+        mock_init.assert_not_called()
+
+    def test_reinitialize_step_arrays_hook_default_is_noop(self):
+        """Test that the default _reinitialize_step_arrays_hook is a no-op."""
+        self.assertIsNone(self.solver._reinitialize_step_arrays_hook())
+
+    def test_pre_shed_hook_default_is_noop(self):
+        """Test that the default _pre_shed_hook is a no-op for all steps."""
+        for step in [0, 1, self.solver.num_steps - 1]:
+            with self.subTest(step=step):
+                self.assertIsNone(self.solver._pre_shed_hook(step))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

This PR extracts an abstract `Coupled*` middle layer from the problem and solver hierarchies so that upcoming feature work (single-airplane free flight and aeroelasticity) can build on a shared step-by-step orchestration layer instead of each feature reimplementing the loop. The middle layer is intentionally incomplete on its own: it establishes the shape of the contract (`initialize_next_problem` as the step-to-step hook) and the machinery to run the parent UVLM loop coupled to that contract, but concrete subclasses land in follow-up PRs.

Much of this code was manually extracted from @JonahJ27's work on PR #156 rather than written from scratch. @JonahJ27 is tagged as co-author on the commits. In addition, I've nailed down a few other design decisions, added unit tests for the new classes and attributes, and updated the docs.

## Motivation

Two features, aeroelasticity (PR #156) and free flight (branch `feature/free_flight`), both need the UVLM solver to advance one step at a time, build the next step's `SteadyProblem` from the previous step's results, and loop. Their current branches each define a `CoupledUnsteadyProblem` / coupled solver pair with incompatible interfaces, and each duplicates the UVLM `run()` method to inject coupling. Without a shared middle layer, merging either feature forces the other to rewrite to match. Extracting the shared pieces here removes that double cost and unblocks both features to rebase onto main cleanly.

The foundation this builds on landed in PR #160: `Core*` movement classes in `_core.py`, `CoreUnsteadyProblem`, and `_get_steady_problem_at(step)` dispatch on the parent UVLM solver. This PR adds the next layer up.

## Relevant Issues

Incidentally, this PR addresses the unit testing portion of #136.

## Changes

- Added `_CoupledUnsteadyProblem(CoreUnsteadyProblem)` to `problems.py` as an abstract middle-layer class. Owns the mutable `_steady_problems: list[SteadyProblem]` backing slot, seeds step 0 from `initial_airplanes` and `initial_operating_point`, exposes a `get_steady_problem(step)` accessor with dynamic bounds, and provides property overrides for `movement` and `steady_problems` (the latter returns a read-only tuple view of the backing list). `initialize_next_problem(solver)` raises `NotImplementedError`. Subclasses must implement it.
- Added `CoupledUnsteadyRingVortexLatticeMethodSolver(UnsteadyRingVortexLatticeMethodSolver)` in a new private module `pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py`. Inherits the parent's `run()` and `initialize_step_geometry()` unchanged and overrides three hooks to inject coupled behavior (see next bullet). Declares `__slots__ = ()` to avoid silently defeating the parent's `__slots__`. Exposes a `_coupled_problem` property that narrows the inherited `unsteady_problem` to `_CoupledUnsteadyProblem` via `typing.cast`.
- Added three new hooks on the parent `UnsteadyRingVortexLatticeMethodSolver` so the coupled subclass can share the parent's run loop rather than duplicating it:
    - `_initialize_step_vortices(step)`: default initializes bound vortices for all steps on step 0 and is a no-op afterwards; coupled subclasses override to initialize per step.
    - `_reinitialize_step_arrays_hook()`: no-op extension point for feature subclasses to reset step-specific arrays.
    - `_pre_shed_hook(step)`: default no-op; coupled subclasses call `_CoupledUnsteadyProblem.initialize_next_problem(self)` here between steps.
- Widened `UnsteadyRingVortexLatticeMethodSolver.__init__` to accept `CoreUnsteadyProblem` (previously required `UnsteadyProblem`) so subclasses can pass their own variants through `super().__init__`. Added a `type(self) is UnsteadyRingVortexLatticeMethodSolver and not isinstance(..., UnsteadyProblem)` guard that still rejects direct misuse of the base solver with a `_CoupledUnsteadyProblem`.
- Added `NotImplementedError` property stubs for `movement` and `steady_problems` on `CoreUnsteadyProblem` so that the shared UVLM solver code can reach through either `UnsteadyProblem` or a coupled subclass without knowing which.
- Added unit tests:
    - `tests/unit/test_coupled_unsteady_problem.py` (19 tests): construction, property views, `get_steady_problem` dynamic bounds, `initialize_next_problem` `NotImplementedError`, immutability.
    - `tests/unit/test_coupled_unsteady_ring_vortex_lattice_method.py` (7 tests): init accept / reject, `_coupled_problem` cast, `_get_steady_problem_at` dispatch, empty `__slots__`.
    - `tests/unit/test_unsteady_ring_vortex_lattice_method.py` (7 tests): `_CoupledUnsteadyProblem` rejection on the base solver plus the three new hook defaults.
    - Registered all three modules in `tests/unit/__init__.py` and added `make_basic_coupled_unsteady_problem_fixture` / `make_coupled_unsteady_ring_solver_fixture` to the shared fixture modules.
- Added a `_CoupledUnsteadyProblem` section to `docs/CLASSES_AND_IMMUTABILITY.md` with its attribute classification and a note flagging that the `steady_problems` tuple view is frozen per call but successive calls may return different-length tuples as the solver initializes new steps. Widened the Solver Classes paragraph for the fourth solver.

### Notes for the aeroelasticity rebase

@JonahJ27: Flagging the structural differences between this extracted middle layer and the version currently on `feature/aeroelasticity-ptera-merge`, so nothing surprises you during the rebase:

- Problem-class name and privacy: the middle layer is named `_CoupledUnsteadyProblem` (leading underscore) and lives in public `problems.py`. Your `AeroelasticUnsteadyProblem` should extend `_CoupledUnsteadyProblem`. The underscore indicates it's internal scaffolding, not a user-facing class. Import path: `from pterasoftware.problems import _CoupledUnsteadyProblem`.
- Solver-class module path changed: the coupled solver lives in `pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py` (private module, public class name). Your `AeroelasticSolver` imports shift to `from pterasoftware._coupled_unsteady_ring_vortex_lattice_method import CoupledUnsteadyRingVortexLatticeMethodSolver`.
- Middle layer is abstract: `_CoupledUnsteadyProblem.initialize_next_problem` raises `NotImplementedError`. You already plan to override it in `AeroelasticUnsteadyProblem`, so no change required. Just noting that the no-op default from PR #161 is gone.
- Accumulation moved from solver to problem: your previous `solver.steady_problems_data_storage: list[...]` worked, but putting the growing list on `_CoupledUnsteadyProblem` instead has two benefits. The problem already has to expose `steady_problems` to satisfy the inherited `UnsteadyProblem` contract used by `output.py`, `_serialization.py`, and the solver's own `_get_steady_problem_at` dispatch, so keeping a parallel accumulator on the solver was redundant. `_CoupledUnsteadyProblem` now owns the backing list at `self._steady_problems`, and the public `steady_problems` tuple property views it. Your `initialize_next_problem` override on `AeroelasticUnsteadyProblem` appends newly constructed `SteadyProblem`s to `self._steady_problems`.
- `run()` shouldn't need duplicating: the parent UVLM `run()` is now hook-friendly. The coupled solver overrides three hooks instead of copying the run loop:
    - `_initialize_step_vortices(step)`: bound-vortex init for the current step. The coupled base already implements this by delegating to `_initialize_panel_vortices_at(step)`. Override further in `AeroelasticSolver` only if you need additional per-step vortex work.
    - `_reinitialize_step_arrays_hook()`: reset step-specific solver arrays between steps. The coupled base is a no-op; this is the place to put aeroelastic per-step state resets if you need them.
    - `_pre_shed_hook(step)`: called after loads are computed, before the wake shed. The coupled base calls `_coupled_problem.initialize_next_problem(self)` and re-initializes the next step's vortices here. Any work you had in the middle of your duplicated `run()` between load computation and wake shed will likely move here. Any SLEP / moment-processing work that needs to happen specifically for aeroelasticity stays inside `AeroelasticSolver`.
- `__slots__` on subclasses: `CoupledUnsteadyRingVortexLatticeMethodSolver` declares `__slots__ = ()`, which means your `AeroelasticSolver` must declare its own `__slots__` (either `()` or the tuple of any new slots it needs). Leaving `__slots__` undeclared on the subclass gives the instance a `__dict__` and silently defeats the parent's slots.
- Type-narrowing pattern for subclasses: `CoupledUnsteadyRingVortexLatticeMethodSolver` exposes `_coupled_problem` as a `typing.cast` narrowed view of the inherited `unsteady_problem` attribute. `AeroelasticSolver` can follow the same pattern to expose an `_aeroelastic_problem` property narrowed to `AeroelasticUnsteadyProblem`, avoiding repeated `cast` calls in method bodies.
- Base solver now accepts `CoreUnsteadyProblem`: `UnsteadyRingVortexLatticeMethodSolver.__init__` widened to accept any `CoreUnsteadyProblem` so subclasses can chain through `super().__init__`. A `type(self) is ...` guard still rejects direct instantiation of the base solver with a `_CoupledUnsteadyProblem`. I don't think you'll need to modify either. Tag me in a comment if there's an edge case I didn't consider.
- `CoreUnsteadyProblem` property stubs: `movement` and `steady_problems` now raise `NotImplementedError` on the `CoreUnsteadyProblem` base and are overridden by both `UnsteadyProblem` and `_CoupledUnsteadyProblem`. `AeroelasticUnsteadyProblem` inherits the `_CoupledUnsteadyProblem` overrides, so no action needed.
- Documentation template for `AeroelasticUnsteadyProblem`: the new `_CoupledUnsteadyProblem` section in `docs/CLASSES_AND_IMMUTABILITY.md` is the shape `AeroelasticUnsteadyProblem` should follow. Treat its "Immutable" table as the starting point; your aeroelastic class mainly adds `AeroelasticStructuralModel` and any per-step structural state.

## Dependency Updates

None.

## Change Magnitude

**Moderate:** Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.