### PR TITLE
[BUG] Vectorize wake-point advection to fix free-wake regression

### DIFF
--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -1633,45 +1633,30 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # This is correct because it is currently the first time step.
                         next_wing.gridWrvp_GP1_CgP1 = np.copy(newRowWrvp_GP1_CgP1)
 
-                        # Initialize variables to hold the number of spanwise wake
-                        # RingVortex points.
-                        num_spanwise_points = num_spanwise_panels + 1
-
-                        # Initialize a new ndarray to hold the second new row of wake
-                        # RingVortex points (in the first Airplane's geometry axes,
-                        # relative to the first Airplane's CG).
-                        secondNewRowWrvp_GP1_CgP1 = np.zeros(
-                            (1, num_spanwise_panels + 1, 3), dtype=float
-                        )
-
-                        # Iterate through the spanwise points.
-                        for spanwise_point_id in range(num_spanwise_points):
-                            # Get the corresponding point from the first row.
-                            Wrvp_GP1_CgP1 = next_wing.gridWrvp_GP1_CgP1[
-                                0, spanwise_point_id
-                            ]
-                            assert Wrvp_GP1_CgP1 is not None
-
-                            # If the wake is prescribed, set the velocity at this
-                            # point to the freestream velocity (in the first
-                            # Airplane's geometry axes, observed from the Earth
-                            # frame). Otherwise, set the velocity to the solution
-                            # velocity at this point (in the first Airplane's
-                            # geometry axes, observed from the Earth frame).
-                            if self._prescribed_wake:
-                                vWrvp_GP1__E = self._currentVInf_GP1__E
-                            else:
-                                vWrvp_GP1__E = self.calculate_solution_velocity(
-                                    np.expand_dims(Wrvp_GP1_CgP1, axis=0),
-                                    bound_singularity_counts=bound_singularity_counts,
-                                    wake_singularity_counts=wake_singularity_counts,
-                                )
-
-                            # Update the second new row with the interpolated
-                            # position of the first point.
-                            secondNewRowWrvp_GP1_CgP1[0, spanwise_point_id] = (
-                                Wrvp_GP1_CgP1 + vWrvp_GP1__E * self.delta_time
+                        # If the wake is prescribed, the velocity at every point is
+                        # the freestream velocity (in the first Airplane's geometry
+                        # axes, observed from the Earth frame). Otherwise, batch one
+                        # solution-velocity call across all of the row's points.
+                        if self._prescribed_wake:
+                            vRowWrvp_GP1__E = self._currentVInf_GP1__E
+                        else:
+                            stackRowWrvp_GP1_CgP1 = next_wing.gridWrvp_GP1_CgP1.reshape(
+                                -1, 3
                             )
+                            stackVRowWrvp_GP1__E = self.calculate_solution_velocity(
+                                stackRowWrvp_GP1_CgP1,
+                                bound_singularity_counts=bound_singularity_counts,
+                                wake_singularity_counts=wake_singularity_counts,
+                            )
+                            vRowWrvp_GP1__E = stackVRowWrvp_GP1__E.reshape(
+                                next_wing.gridWrvp_GP1_CgP1.shape
+                            )
+
+                        # Build the second new row by advecting the first row.
+                        secondNewRowWrvp_GP1_CgP1 = (
+                            next_wing.gridWrvp_GP1_CgP1
+                            + vRowWrvp_GP1__E * self.delta_time
+                        )
 
                         # Update the next time step's Wing's grid of wake RingVortex
                         # points by vertically stacking the new second row below it.
@@ -1692,40 +1677,30 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # RingVortex points.
                         next_wing.gridWrvp_GP1_CgP1 = np.copy(_thisGridWrvp_GP1_CgP1)
 
-                        # Get the number of chordwise and spanwise points.
-                        num_chordwise_points = next_wing.gridWrvp_GP1_CgP1.shape[0]
-                        num_spanwise_points = next_wing.gridWrvp_GP1_CgP1.shape[1]
+                        # If the wake is prescribed, the velocity at every point is
+                        # the freestream velocity (in the first Airplane's geometry
+                        # axes, observed from the Earth frame). Otherwise, batch one
+                        # solution-velocity call across the entire aged grid.
+                        if self._prescribed_wake:
+                            vGridWrvp_GP1__E = self._currentVInf_GP1__E
+                        else:
+                            stackGridWrvp_GP1_CgP1 = (
+                                next_wing.gridWrvp_GP1_CgP1.reshape(-1, 3)
+                            )
+                            stackVGridWrvp_GP1__E = self.calculate_solution_velocity(
+                                stackGridWrvp_GP1_CgP1,
+                                bound_singularity_counts=bound_singularity_counts,
+                                wake_singularity_counts=wake_singularity_counts,
+                            )
+                            vGridWrvp_GP1__E = stackVGridWrvp_GP1__E.reshape(
+                                next_wing.gridWrvp_GP1_CgP1.shape
+                            )
 
-                        # Iterate through the chordwise and spanwise point positions.
-                        for chordwise_point_id in range(num_chordwise_points):
-                            for spanwise_point_id in range(num_spanwise_points):
-                                # Get the wake RingVortex point at this position.
-                                Wrvp_GP1_CgP1 = next_wing.gridWrvp_GP1_CgP1[
-                                    chordwise_point_id,
-                                    spanwise_point_id,
-                                ]
-
-                                # If the wake is prescribed, set the velocity at this
-                                # point to the freestream velocity (in the first
-                                # Airplane's geometry axes, observed from the Earth
-                                # frame). Otherwise, set the velocity to the solution
-                                # velocity at this point (in the first Airplane's
-                                # geometry axes, observed from the Earth frame).
-                                if self._prescribed_wake:
-                                    vWrvp_GP1__E = self._currentVInf_GP1__E
-                                else:
-                                    vWrvp_GP1__E = np.squeeze(
-                                        self.calculate_solution_velocity(
-                                            np.expand_dims(Wrvp_GP1_CgP1, axis=0),
-                                            bound_singularity_counts=bound_singularity_counts,
-                                            wake_singularity_counts=wake_singularity_counts,
-                                        )
-                                    )
-
-                                # Update this point with its interpolated position.
-                                next_wing.gridWrvp_GP1_CgP1[
-                                    chordwise_point_id, spanwise_point_id
-                                ] += (vWrvp_GP1__E * self.delta_time)
+                        # Advect the entire aged grid in one vector add.
+                        next_wing.gridWrvp_GP1_CgP1 = (
+                            next_wing.gridWrvp_GP1_CgP1
+                            + vGridWrvp_GP1__E * self.delta_time
+                        )
 
                         # Find the chordwise position of the Wing's trailing edge.
                         chordwise_panel_id = this_wing.num_chordwise_panels - 1

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -29,7 +29,6 @@ from . import (
     _transformations,
     _vortices,
     geometry,
-    movements,
     operating_point,
     problems,
 )
@@ -1555,11 +1554,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
         """Populates the locations of the next time step's Airplanes' wake RingVortex
         points.
 
-        **Notes:**
-
-        This method is not vectorized but its loops only consume 1.1% of the runtime, so
-        I have kept it as is for increased readability.
-
         :return: None
         """
         # Check that this isn't the last time step.
@@ -1572,11 +1566,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 self._current_step + 1
             )
             next_airplanes = next_problem.airplanes
-
-            # Get the current Airplanes' combined number of Wings.
-            num_wings = 0
-            for airplane in self.current_airplanes:
-                num_wings += len(airplane.wings)
 
             # Iterate through this time step's Airplanes' successor objects.
             for airplane_id, next_airplane in enumerate(next_airplanes):


### PR DESCRIPTION
# Description

Restore free-wake performance in `UnsteadyRingVortexLatticeMethodSolver` by batching wake-vertex velocity queries in `_populate_next_airplanes_wake_vortex_points` instead of calling `calculate_solution_velocity` once per vertex.

## Motivation

When the Biot-Savart kernels were parallelized, every call to `calculate_solution_velocity` began paying a per-call parallel-dispatch overhead. The wake-point advection path in `_populate_next_airplanes_wake_vortex_points` invoked that function once per wake vertex (passing a single point via `np.expand_dims`), so the dispatch cost compounded across the entire wake grid and caused a large performance regression in free-wake simulations. Prescribed-wake runs were unaffected because they read `_currentVInf_GP1__E` directly. Batching all wake vertices into a single solution-velocity call amortizes the overhead and recovers the lost performance without changing the numerical result.

## Relevant Issues

None.

## Changes

* Vectorize the second-row wake advection on the first time step by reshaping the row to `(N, 3)`, issuing one `calculate_solution_velocity` call, and advecting with a single vector add.
* Vectorize the aged-grid wake advection on subsequent time steps the same way, replacing a doubly-nested loop over chordwise and spanwise points.
* Tidy the surrounding method ahead of the vectorization by removing an unused `movements` import, an unused `num_wings` accumulator, and a stale docstring note claiming the method is not vectorized.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
