### PR TITLE
[BUG] Fix mypy errors and prune mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -14,70 +14,12 @@ follow_imports = normal
 # Show error codes.
 show_error_codes = True
 
-# Ignore errors in particular modules (for now).
-[mypy-pterasoftware.geometry.__init__]
-ignore_errors = False
-[mypy-pterasoftware.geometry._meshing]
-ignore_errors = False
-[mypy-pterasoftware.geometry.airfoil]
-ignore_errors = False
-[mypy-pterasoftware.geometry.airplane]
-ignore_errors = False
-[mypy-pterasoftware.geometry.wing]
-ignore_errors = False
-[mypy-pterasoftware.geometry.wing_cross_section]
-ignore_errors = False
-[mypy-pterasoftware.movement.__init__]
-ignore_errors = False
-[mypy-pterasoftware.movement._functions]
-ignore_errors = False
-[mypy-pterasoftware.movement.airplane_movement]
-ignore_errors = False
-[mypy-pterasoftware.movement.movement]
-ignore_errors = False
-[mypy-pterasoftware.movement.operating_point_movement]
-ignore_errors = False
-[mypy-pterasoftware.movement.wing_cross_section_movement]
-ignore_errors = False
-[mypy-pterasoftware.movement.wing_movement]
-ignore_errors = False
-[mypy-pterasoftware.__init__]
-ignore_errors = False
-[mypy-pterasoftware._aerodynamics]
-ignore_errors = False
-[mypy-pterasoftware._functions]
-ignore_errors = False
-[mypy-pterasoftware._panel]
-ignore_errors = False
-[mypy-pterasoftware._parameter_validation]
-ignore_errors = False
-[mypy-pterasoftware._transformations]
-ignore_errors = False
-[mypy-pterasoftware.convergence]
-ignore_errors = False
-[mypy-pterasoftware.operating_point]
-ignore_errors = False
-[mypy-pterasoftware.output]
-ignore_errors = False
-[mypy-pterasoftware.problems]
-ignore_errors = False
-[mypy-pterasoftware.steady_horseshoe_vortex_lattice_method]
-ignore_errors = False
-[mypy-pterasoftware.steady_ring_vortex_lattice_method]
-ignore_errors = False
-[mypy-pterasoftware.trim]
-ignore_errors = False
-[mypy-pterasoftware.unsteady_ring_vortex_lattice_method]
-ignore_errors = False
-
 # Ignore third-party libraries without type stubs.
 [mypy-numba.*]
 ignore_missing_imports = True
 [mypy-tqdm.*]
 ignore_missing_imports = True
 [mypy-pyvista.*]
-ignore_missing_imports = True
-[mypy-cmocean.*]
 ignore_missing_imports = True
 [mypy-webp.*]
 ignore_missing_imports = True

--- a/pterasoftware/geometry/airplane.py
+++ b/pterasoftware/geometry/airplane.py
@@ -617,7 +617,7 @@ class Airplane:
             symmetric_bounds=False,
         )
 
-        plotter.add_actor(AxesGCg)  # type: ignore[arg-type]
+        plotter.add_actor(AxesGCg)
 
         for wing_id, wing in enumerate(self._wings):
             wing_num = wing_id + 1
@@ -651,7 +651,7 @@ class Airplane:
                 symmetric_bounds=False,
             )
 
-            plotter.add_actor(AxesWLerWcs1Lp1_G_Cg)  # type: ignore[arg-type]
+            plotter.add_actor(AxesWLerWcs1Lp1_G_Cg)
 
             these_airfoilOutlines_G_Cg = airfoilOutlines_G_Cg[wing_id]
             these_airfoilMcls_G_Cg = airfoilMcls_G_Cg[wing_id]
@@ -709,7 +709,7 @@ class Airplane:
                         symmetric_bounds=False,
                     )
 
-                    plotter.add_actor(AxesWcsLp_G_Cg)  # type: ignore[arg-type]
+                    plotter.add_actor(AxesWcsLp_G_Cg)
 
             if wing.panels is not None:
                 # Initialize empty arrays to hold the Panels' vertices and faces

--- a/pterasoftware/geometry/wing.py
+++ b/pterasoftware/geometry/wing.py
@@ -1346,7 +1346,7 @@ class Wing:
             symmetric_bounds=False,
         )
 
-        plotter.add_actor(AxesGCg)  # type: ignore[arg-type]
+        plotter.add_actor(AxesGCg)
 
         _T_pas_G_Cg_to_Wn_Ler = self.T_pas_G_Cg_to_Wn_Ler
         assert _T_pas_G_Cg_to_Wn_Ler is not None
@@ -1379,7 +1379,7 @@ class Wing:
             symmetric_bounds=False,
         )
 
-        plotter.add_actor(AxesWLerWcs1Lp1_G_Cg)  # type: ignore[arg-type]
+        plotter.add_actor(AxesWLerWcs1Lp1_G_Cg)
 
         _T_pas_Wn_Ler_to_G_Cg = self.T_pas_Wn_Ler_to_G_Cg
         assert _T_pas_Wn_Ler_to_G_Cg is not None
@@ -1441,7 +1441,7 @@ class Wing:
                     symmetric_bounds=False,
                 )
 
-                plotter.add_actor(AxesWcsLp_G_Cg)  # type: ignore[arg-type]
+                plotter.add_actor(AxesWcsLp_G_Cg)
 
         if self.panels is not None:
             # Initialize empty arrays to hold the Panels' vertices and faces.

--- a/pterasoftware/geometry/wing_cross_section.py
+++ b/pterasoftware/geometry/wing_cross_section.py
@@ -642,7 +642,7 @@ class WingCrossSection:
                 tip_length=(0.2, 0.2, 0.2),
                 symmetric_bounds=False,
             )
-            plotter.add_actor(AxesWcsLpWcspLpp_Wcsp_lpp)  # type: ignore[arg-type]
+            plotter.add_actor(AxesWcsLpWcspLpp_Wcsp_lpp)
         else:
             AxesWcsLp_Wcsp_lpp = pv.AxesAssembly(
                 x_label="WcsX@Lp",
@@ -697,8 +697,8 @@ class WingCrossSection:
                 tip_length=(0.2, 0.2, 0.2),
                 symmetric_bounds=False,
             )
-            plotter.add_actor(AxesWcsLp_Wcsp_lpp)  # type: ignore[arg-type]
-            plotter.add_actor(AxesWcspLpp)  # type: ignore[arg-type]
+            plotter.add_actor(AxesWcsLp_Wcsp_lpp)
+            plotter.add_actor(AxesWcspLpp)
 
         plotter.enable_parallel_projection()  # type: ignore[call-arg]
 

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -731,6 +731,7 @@ def animate(
             full_screen=False,
             auto_close=False,
         )
+        assert plotter.ren_win is not None
         plotter.ren_win.SetWindowName("Rendering speed not to scale.")
     else:
         plotter.show(


### PR DESCRIPTION
# Description

With `mypy` version 1.20, the type-checking CI action is throwing several small warnings that didn't appear with version 1.19. This PR fixes those small errors so the CI passes clean.

## Motivation

The latest version of `mypy` raises several errors, blocking pre-existing PRs (e.g., #166) from passing the CI checks.

## Relevant Issues

None.

## Changes

* Drop nine unused `arg`-type pragmas on PyVista `add_actor` calls (newer stubs accept `AxesAssembly` directly) and add an explicit `None` assert before `plotter.ren_win.SetWindowName` so `mypy` can verify the post-show invariant.
* Prune the per-module `mypy.ini` block, a leftover from gradual `mypy` adoption where every section now just restates the default and several module names point at renamed or deleted modules.
* Drop the now-unused `cmocean` section from `mypy.ini`.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.