### PR TITLE
[BUG] Hoist geometry queries out of pre-alloc loops

### DIFF
--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -295,24 +295,29 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # these arrays will be filled with data that describe the wake. Using this
         # method eliminates the need for computationally expensive on-the-fly
         # allocation and object copying.
+        first_problem: problems.SteadyProblem = self._get_steady_problem_at(0)
+        first_airplanes = first_problem.airplanes
+
+        # Loop through the first time step's Airplanes to gather their Wings.
+        first_wings: list[tuple[geometry.wing.Wing, ...]] = []
+        for airplane in first_airplanes:
+            first_wings.append(airplane.wings)
+
+        # Iterate through the Wings to get the total number of spanwise Panels.
+        # Panel topology is invariant across time steps.
+        num_spanwise_panels = 0
+        for this_wing_set in first_wings:
+            for this_wing in this_wing_set:
+                _this_wing_num_spanwise_panels = this_wing.num_spanwise_panels
+                assert _this_wing_num_spanwise_panels is not None
+
+                num_spanwise_panels += _this_wing_num_spanwise_panels
+
+        num_wing_panels = 0
+        for airplane in first_airplanes:
+            num_wing_panels += airplane.num_panels
+
         for step in range(self.num_steps):
-            this_problem: problems.SteadyProblem = self._get_steady_problem_at(step)
-            these_airplanes = this_problem.airplanes
-
-            # Loop through this time step's Airplanes to gather their Wings.
-            these_wings: list[tuple[geometry.wing.Wing, ...]] = []
-            for airplane in these_airplanes:
-                these_wings.append(airplane.wings)
-
-            # Iterate through the Wings to get the total number of spanwise Panels.
-            this_num_spanwise_panels = 0
-            for this_wing_set in these_wings:
-                for this_wing in this_wing_set:
-                    _this_wing_num_spanwise_panels = this_wing.num_spanwise_panels
-                    assert _this_wing_num_spanwise_panels is not None
-
-                    this_num_spanwise_panels += _this_wing_num_spanwise_panels
-
             # The number of wake RingVortices is the time step number multiplied by
             # the number of spanwise Panels. This works because the first time step
             # number is 0. If wake truncation is enabled, cap the number of
@@ -321,7 +326,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
             if self._max_wake_rows is not None:
                 this_num_chordwise_wake_rows = min(step, self._max_wake_rows)
             this_num_wake_ring_vortices = (
-                this_num_chordwise_wake_rows * this_num_spanwise_panels
+                this_num_chordwise_wake_rows * num_spanwise_panels
             )
 
             # Allocate the ndarrays for this time step.
@@ -365,19 +370,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # progress bar during the simulation initialization.
         approx_times = np.zeros(self.num_steps + 1, dtype=float)
         for step in range(1, self.num_steps):
-            this_problem = self._get_steady_problem_at(step)
-            these_airplanes = this_problem.airplanes
-
-            # Iterate through this time step's Airplanes to get the total number of
-            # Wing Panels.
-            num_wing_panels = 0
-            for airplane in these_airplanes:
-                num_wing_panels += airplane.num_panels
-
             # Calculate the total number of RingVortices analyzed during this step.
-            num_wing_ring_vortices = num_wing_panels
             num_wake_ring_vortices = self.list_num_wake_vortices[step]
-            num_ring_vortices = num_wing_ring_vortices + num_wake_ring_vortices
+            num_ring_vortices = num_wing_panels + num_wake_ring_vortices
 
             # The following constant multipliers were determined empirically. Thus
             # far, they seem to provide for adequately smooth progress bar updating.


### PR DESCRIPTION
# Description

Panel topology is invariant across time steps, so querying every time step's geometry during wake pre-allocation and progress bar estimation is redundant. Use step-0 geometry once instead. 

## Motivation

This fixes an incompatibility with the coupled solvers, whose future steps do not exist at pre allocation time.

## Relevant Issues

Related to Issue #28 (being addressed in PR #156) and Issue #66.

## Changes

* Pre-allocate wake arrays and perform progress bar estimation without iterating across all time steps.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.