### PR TITLE
Create unit tests for _functions.py

### DIFF
--- a/pterasoftware/_functions.py
+++ b/pterasoftware/_functions.py
@@ -67,7 +67,6 @@ def log_unexpected_singularity_counts(
     )
 
 
-# TEST: Consider adding unit tests for this function.
 def cosspace(
     minimum: float, maximum: float, n_points: int = 50, endpoint: bool = True
 ) -> np.ndarray:
@@ -98,7 +97,6 @@ def cosspace(
     return mean + amp * np.cos(np.linspace(np.pi, 0, n_points, endpoint=endpoint))
 
 
-# TEST: Consider adding unit tests for this function.
 @njit(cache=True, fastmath=False)
 def numba_centroid_of_quadrilateral(
     frontLeftPoint_A_a: np.ndarray,
@@ -495,7 +493,6 @@ def calculate_steady_freestream_wing_influences(
     )
 
 
-# TEST: Consider adding unit tests for this function.
 @njit(cache=True, fastmath=False)
 def numba_1d_explicit_cross(
     stackVectors1_A: np.ndarray, stackVectors2_A: np.ndarray
@@ -539,7 +536,6 @@ def numba_1d_explicit_cross(
     return stackCrossProducts
 
 
-# TEST: Consider adding unit tests for this function.
 @njit(cache=True, fastmath=False)
 def interp_between_points(
     stackStartPoints_A_a: np.ndarray,

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -43,6 +43,8 @@ This package contains the following modules:
     test_core_wing_movement.py: This module contains classes to test
     CoreWingMovements.
 
+    test_functions.py: This module contains classes to test shared utility functions.
+
     test_horseshoe_vortex.py: This module contains classes to test HorseshoeVortices.
 
     test_line_vortex.py: This module contains classes to test LineVortices.
@@ -105,6 +107,7 @@ import tests.unit.test_core_wing_cross_section_movement
 import tests.unit.test_core_wing_movement
 import tests.unit.test_coupled_unsteady_problem
 import tests.unit.test_coupled_unsteady_ring_vortex_lattice_method
+import tests.unit.test_functions
 import tests.unit.test_horseshoe_vortex
 import tests.unit.test_line_vortex
 import tests.unit.test_movement

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,3 +1,5 @@
+"""This module contains classes to test shared utility functions."""
+
 import unittest
 
 import numpy as np

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,0 +1,349 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# noinspection PyProtectedMember
+from pterasoftware import _functions
+
+
+class TestCosspace(unittest.TestCase):
+    """Tests for the cosspace function."""
+
+    def test_includes_endpoints(self):
+        """Cosspace should include minimum and maximum by default."""
+        points = _functions.cosspace(0.0, 10.0, n_points=5)
+
+        self.assertAlmostEqual(points[0], 0.0)
+        self.assertAlmostEqual(points[-1], 10.0)
+
+    def test_excludes_endpoint_when_requested(self):
+        """Cosspace should exclude maximum when endpoint=False."""
+        points = _functions.cosspace(
+            0.0,
+            10.0,
+            n_points=5,
+            endpoint=False,
+        )
+
+        self.assertAlmostEqual(points[0], 0.0)
+        self.assertLess(points[-1], 10.0)
+
+    def test_returns_correct_number_of_points(self):
+        """Cosspace should return the requested number of points."""
+        points = _functions.cosspace(0.0, 1.0, n_points=17)
+
+        self.assertEqual(len(points), 17)
+
+    def test_spacing_is_symmetric(self):
+        """Cosspace output should be symmetric about the midpoint."""
+        points = _functions.cosspace(-1.0, 1.0, n_points=9)
+
+        npt.assert_allclose(points, -points[::-1], atol=1e-14)
+
+    def test_single_point(self):
+        """Single-point cosspace should return the minimum value."""
+        points = _functions.cosspace(2.0, 8.0, n_points=1)
+
+        npt.assert_allclose(points, np.array([2.0]), atol=1e-14)
+
+
+class TestNumbaCentroidOfQuadrilateral(unittest.TestCase):
+    """Tests for the numba_centroid_of_quadrilateral function."""
+
+    def test_unit_square_in_xy_plane(self):
+        """Centroid of a unit square should be at its geometric center."""
+        front_left = np.array([0.0, 1.0, 0.0])
+        front_right = np.array([1.0, 1.0, 0.0])
+        back_left = np.array([0.0, 0.0, 0.0])
+        back_right = np.array([1.0, 0.0, 0.0])
+
+        centroid = _functions.numba_centroid_of_quadrilateral(
+            front_left,
+            front_right,
+            back_left,
+            back_right,
+        )
+
+        expected = np.array([0.5, 0.5, 0.0])
+
+        npt.assert_allclose(centroid, expected, atol=1e-14)
+
+    def test_translated_quadrilateral(self):
+        """Centroid should translate consistently with the input points."""
+        front_left = np.array([2.0, 3.0, 4.0])
+        front_right = np.array([4.0, 3.0, 4.0])
+        back_left = np.array([2.0, 1.0, 4.0])
+        back_right = np.array([4.0, 1.0, 4.0])
+
+        centroid = _functions.numba_centroid_of_quadrilateral(
+            front_left,
+            front_right,
+            back_left,
+            back_right,
+        )
+
+        expected = np.array([3.0, 2.0, 4.0])
+
+        npt.assert_allclose(centroid, expected, atol=1e-14)
+
+    def test_nonplanar_quadrilateral(self):
+        """Centroid should equal the average of all vertex coordinates."""
+        front_left = np.array([0.0, 0.0, 0.0])
+        front_right = np.array([2.0, 0.0, 1.0])
+        back_left = np.array([0.0, 2.0, 2.0])
+        back_right = np.array([2.0, 2.0, 3.0])
+
+        centroid = _functions.numba_centroid_of_quadrilateral(
+            front_left,
+            front_right,
+            back_left,
+            back_right,
+        )
+
+        expected = np.array([1.0, 1.0, 1.5])
+
+        npt.assert_allclose(centroid, expected, atol=1e-14)
+
+    def test_identical_points(self):
+        """Centroid of identical points should equal that point."""
+        point = np.array([1.5, -2.0, 3.25])
+
+        centroid = _functions.numba_centroid_of_quadrilateral(
+            point,
+            point,
+            point,
+            point,
+        )
+
+        npt.assert_allclose(centroid, point, atol=1e-14)
+
+
+class TestNumba1dExplicitCross(unittest.TestCase):
+    """Tests for the numba_1d_explicit_cross function."""
+
+    def test_known_cross_products(self):
+        """Cross products should match analytically known results."""
+        vectors1 = np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+
+        vectors2 = np.array(
+            [
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+
+        cross_products = _functions.numba_1d_explicit_cross(
+            vectors1,
+            vectors2,
+        )
+
+        expected = np.array(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+
+        npt.assert_allclose(cross_products, expected, atol=1e-14)
+
+    def test_parallel_vectors(self):
+        """Parallel vectors should produce zero cross products."""
+        vectors1 = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [2.0, 4.0, 6.0],
+            ]
+        )
+
+        vectors2 = np.array(
+            [
+                [2.0, 4.0, 6.0],
+                [1.0, 2.0, 3.0],
+            ]
+        )
+
+        cross_products = _functions.numba_1d_explicit_cross(
+            vectors1,
+            vectors2,
+        )
+
+        expected = np.zeros((2, 3))
+
+        npt.assert_allclose(cross_products, expected, atol=1e-14)
+
+    def test_matches_numpy_cross(self):
+        """Cross products should match numpy.cross."""
+        vectors1 = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [-1.0, 4.0, 0.5],
+                [2.5, -3.0, 1.0],
+            ]
+        )
+
+        vectors2 = np.array(
+            [
+                [4.0, 5.0, 6.0],
+                [2.0, -1.0, 3.0],
+                [0.0, 2.0, -4.0],
+            ]
+        )
+
+        cross_products = _functions.numba_1d_explicit_cross(
+            vectors1,
+            vectors2,
+        )
+
+        expected = np.cross(vectors1, vectors2)
+
+        npt.assert_allclose(cross_products, expected, atol=1e-14)
+
+    def test_empty_input(self):
+        """Empty vector stacks should return an empty array."""
+        vectors1 = np.empty((0, 3))
+        vectors2 = np.empty((0, 3))
+
+        cross_products = _functions.numba_1d_explicit_cross(
+            vectors1,
+            vectors2,
+        )
+
+        expected = np.empty((0, 3))
+
+        npt.assert_allclose(cross_products, expected, atol=1e-14)
+
+
+class TestInterpBetweenPoints(unittest.TestCase):
+    """Tests for the interp_between_points function."""
+
+    def test_single_pair_linear_interpolation(self):
+        """Interpolated points should lie linearly between a point pair."""
+        start_points = np.array([[0.0, 0.0, 0.0]])
+        end_points = np.array([[10.0, 0.0, 0.0]])
+
+        norm_spacings = np.array([0.0, 0.5, 1.0])
+
+        interpolated_points = _functions.interp_between_points(
+            start_points,
+            end_points,
+            norm_spacings,
+        )
+
+        expected = np.array(
+            [
+                [
+                    [0.0, 0.0, 0.0],
+                    [5.0, 0.0, 0.0],
+                    [10.0, 0.0, 0.0],
+                ]
+            ]
+        )
+
+        npt.assert_allclose(interpolated_points, expected, atol=1e-14)
+
+    def test_multiple_point_pairs(self):
+        """Interpolation should work independently for multiple point pairs."""
+        start_points = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0],
+            ]
+        )
+
+        end_points = np.array(
+            [
+                [2.0, 0.0, 0.0],
+                [3.0, 3.0, 3.0],
+            ]
+        )
+
+        norm_spacings = np.array([0.0, 0.5, 1.0])
+
+        interpolated_points = _functions.interp_between_points(
+            start_points,
+            end_points,
+            norm_spacings,
+        )
+
+        expected = np.array(
+            [
+                [
+                    [0.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0],
+                    [2.0, 0.0, 0.0],
+                ],
+                [
+                    [1.0, 1.0, 1.0],
+                    [2.0, 2.0, 2.0],
+                    [3.0, 3.0, 3.0],
+                ],
+            ]
+        )
+
+        npt.assert_allclose(interpolated_points, expected, atol=1e-14)
+
+    def test_zero_spacing_returns_start_points(self):
+        """Zero normalized spacing should return the start points."""
+        start_points = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+            ]
+        )
+
+        end_points = np.array(
+            [
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+            ]
+        )
+
+        norm_spacings = np.array([0.0])
+
+        interpolated_points = _functions.interp_between_points(
+            start_points,
+            end_points,
+            norm_spacings,
+        )
+
+        expected = start_points[:, np.newaxis, :]
+
+        npt.assert_allclose(interpolated_points, expected, atol=1e-14)
+
+    def test_unit_spacing_returns_end_points(self):
+        """Unit normalized spacing should return the end points."""
+        start_points = np.array(
+            [
+                [1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0],
+            ]
+        )
+
+        end_points = np.array(
+            [
+                [7.0, 8.0, 9.0],
+                [10.0, 11.0, 12.0],
+            ]
+        )
+
+        norm_spacings = np.array([1.0])
+
+        interpolated_points = _functions.interp_between_points(
+            start_points,
+            end_points,
+            norm_spacings,
+        )
+
+        expected = end_points[:, np.newaxis, :]
+
+        npt.assert_allclose(interpolated_points, expected, atol=1e-14)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

Add targeted unit tests for four utility functions in `_functions.py` that were previously flagged with `# TEST` comments.

These tests improve confidence in the mathematical utility layer of Ptera Software by validating interpolation, centroid calculation, cosine spacing, and vector cross-product behavior using deterministic analytical cases.

## Motivation

The flagged utility functions perform low-level numerical and geometric operations that are reused throughout the codebase. Although relatively compact, they contain mathematical logic where regressions or subtle numerical errors could propagate into higher-level aerodynamic calculations.

Adding focused unit tests improves maintainability and makes future refactoring safer by validating expected numerical behavior in isolation.

## Relevant Issues

Closes #146.

## Changes

Added dedicated unit tests in `test_functions.py` for the following utility functions in `_functions.py`:

- `cosspace`
- `numba_centroid_of_quadrilateral`
- `numba_1d_explicit_cross`
- `interp_between_points`

### `TestCosspace`

* Verifies minimum and maximum endpoints are included by default.
* Verifies endpoint exclusion behavior when `endpoint=False`.
* Verifies correct number of output points.
* Verifies symmetry properties of cosine spacing.
* Verifies single-point edge-case behavior.

### `TestNumbaCentroidOfQuadrilateral`

* Verifies centroid computation for a unit square.
* Verifies translation consistency.
* Verifies centroid calculation for nonplanar quadrilaterals.
* Verifies identical-point edge case behavior.

### `TestNumba1dExplicitCross`

* Verifies analytically known cross product results.
* Verifies parallel vectors produce zero cross products.
* Verifies agreement with `numpy.cross`.
* Verifies empty-input behavior.

### `TestInterpBetweenPoints`

* Verifies linear interpolation between point pairs.
* Verifies interpolation across multiple point pairs.
* Verifies zero normalized spacing returns start points.
* Verifies unit normalized spacing returns end points.

### Testing Methodology

Tests are deterministic and numerically validated using analytical expectations and invariant-based checks. The testing approach focuses on:

* Known geometric and vector identities.
* Numerical correctness using `numpy.testing.assert_allclose`.
* Edge-case handling.
* Reproducible fixed-input validation rather than randomized testing.
* Tight tolerances (`atol=1e-14`) were used where appropriate to ensure numerical precision.

## Dependency Updates

None.

## Change Magnitude

**Minor:** Adds focused unit tests for existing utility functions without modifying runtime behavior.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.