### PR TITLE
[BUG] Clean up sources of test output noise

### DIFF
--- a/pterasoftware/steady_ring_vortex_lattice_method.py
+++ b/pterasoftware/steady_ring_vortex_lattice_method.py
@@ -64,6 +64,7 @@ class SteadyRingVortexLatticeMethodSolver:
         "reynolds_numbers",
         "num_airplanes",
         "num_panels",
+        "num_trailing_edge_panels",
         "vInf_GP1__E",
         "stackFreestreamWingInfluences__E",
         "_gridWingWingInfluences__E",
@@ -116,9 +117,13 @@ class SteadyRingVortexLatticeMethodSolver:
         self.reynolds_numbers = self._steady_problem.reynolds_numbers
         self.num_airplanes = len(self.airplanes)
         self.num_panels = 0
+        self.num_trailing_edge_panels = 0
         airplane: geometry.airplane.Airplane
         for airplane in self.airplanes:
             self.num_panels += airplane.num_panels
+            for wing in airplane.wings:
+                assert wing.num_spanwise_panels is not None
+                self.num_trailing_edge_panels += wing.num_spanwise_panels
 
         # Initialize attributes to hold aerodynamic data that pertains to this
         # simulation.
@@ -158,21 +163,25 @@ class SteadyRingVortexLatticeMethodSolver:
         self.stackLbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackBbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
 
-        # Initialize variables that will hold data which characterizes this Panels'
-        # horseshoe vortex. If the Panel does not have a horseshoe vortex, these values
-        # will not be updated. However, this does not adversely affect the results,
-        # because the default horseshoe vortex strength is zero. The default
-        # coordinates will also be updated by the collapse geometry method for Panels
-        # that have a horseshoe vortex.
-        # TODO: Compact the horseshoe vortex arrays to only contain trailing edge
-        #  Panels. The current num_panels sized arrays waste ~93% of the expanded
-        #  kernel computation and produce phantom degenerate filament singularities
-        #  at non trailing edge positions.
-        self._stackBrhvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
-        self._stackFrhvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
-        self._stackFlhvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
-        self._stackBlhvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
-        self._horseshoe_vortex_strengths = np.zeros(self.num_panels, dtype=float)
+        # Initialize variables that will hold data which characterizes the trailing
+        # edge Panels' horseshoe vortices. These arrays are sized by the number of
+        # trailing edge Panels, in trailing edge order, since non trailing edge Panels
+        # do not carry a horseshoe vortex.
+        self._stackBrhvp_GP1_CgP1 = np.zeros(
+            (self.num_trailing_edge_panels, 3), dtype=float
+        )
+        self._stackFrhvp_GP1_CgP1 = np.zeros(
+            (self.num_trailing_edge_panels, 3), dtype=float
+        )
+        self._stackFlhvp_GP1_CgP1 = np.zeros(
+            (self.num_trailing_edge_panels, 3), dtype=float
+        )
+        self._stackBlhvp_GP1_CgP1 = np.zeros(
+            (self.num_trailing_edge_panels, 3), dtype=float
+        )
+        self._horseshoe_vortex_strengths = np.zeros(
+            self.num_trailing_edge_panels, dtype=float
+        )
 
         self._stackRc0s = np.zeros(self.num_panels, dtype=float)
 
@@ -251,6 +260,11 @@ class SteadyRingVortexLatticeMethodSolver:
         # Initialize a variable to hold the global position of the Panel as we
         # iterate through them.
         global_panel_position = 0
+
+        # Initialize a variable to hold the trailing edge position as we encounter
+        # trailing edge Panels. This indexes the trailing edge sized horseshoe
+        # vortex arrays.
+        te_position = 0
 
         # Iterate through each Airplane's Wings.
         airplane: geometry.airplane.Airplane
@@ -338,21 +352,16 @@ class SteadyRingVortexLatticeMethodSolver:
                             # legs extend downstream along the freestream. The
                             # strength is initialized to 1.0 and will be replaced
                             # after the strength solve.
-                            self._stackBrhvp_GP1_CgP1[global_panel_position] = (
+                            self._stackBrhvp_GP1_CgP1[te_position] = (
                                 Brrvp_GP1_CgP1 + infinite_leg_offset_GP1
                             )
-                            self._stackFrhvp_GP1_CgP1[global_panel_position] = (
-                                Brrvp_GP1_CgP1
-                            )
-                            self._stackFlhvp_GP1_CgP1[global_panel_position] = (
-                                Blrvp_GP1_CgP1
-                            )
-                            self._stackBlhvp_GP1_CgP1[global_panel_position] = (
+                            self._stackFrhvp_GP1_CgP1[te_position] = Brrvp_GP1_CgP1
+                            self._stackFlhvp_GP1_CgP1[te_position] = Blrvp_GP1_CgP1
+                            self._stackBlhvp_GP1_CgP1[te_position] = (
                                 Blrvp_GP1_CgP1 + infinite_leg_offset_GP1
                             )
-                            self._horseshoe_vortex_strengths[global_panel_position] = (
-                                1.0
-                            )
+                            self._horseshoe_vortex_strengths[te_position] = 1.0
+                            te_position += 1
 
                         global_panel_position += 1
 
@@ -389,12 +398,12 @@ class SteadyRingVortexLatticeMethodSolver:
 
         # Find the 2D ndarray of normalized velocities (in the first Airplane's
         # geometry axes, observed from the Earth frame) induced at every Panel's
-        # collocation point by every horseshoe vortex. The answer is normalized
-        # because the solver's list of horseshoe vortex strengths was initialized to
-        # 1.0 for locations which have a horseshoe vortex, and zeros everywhere else.
-        # The strengths at the positions with a horseshoe vortex will be updated once
-        # the correct vortex strengths are calculated. The positions elsewhere will
-        # remain zero.
+        # collocation point by every trailing edge Panel's horseshoe vortex. The
+        # answer is normalized because the horseshoe vortex strengths were
+        # initialized to 1.0 and will be updated once the correct vortex strengths
+        # are calculated. The result has shape (num_panels, num_trailing_edge_panels,
+        # 3) and is later scatter added into the ring contribution at the trailing
+        # edge columns.
         gridHorseshoeNormVIndCpp_GP1__E = (
             _aerodynamics_functions.expanded_velocities_from_horseshoe_vortices(
                 stackP_GP1_CgP1=self.stackCpp_GP1_CgP1,
@@ -458,22 +467,6 @@ class SteadyRingVortexLatticeMethodSolver:
             )
 
         unexpected_singularity_counts = np.copy(singularity_counts)
-
-        # Subtract the expected degenerate filament count before logging. Non
-        # trailing edge Panels have phantom all zero horseshoe vortex vertices,
-        # producing 3 degenerate legs each (right, front, left) per horseshoe
-        # wrapper call. When an image surface is defined, the image horseshoe
-        # call doubles the expected count.
-        num_trailing_edge_panels = 0
-        for airplane in self.airplanes:
-            for wing in airplane.wings:
-                assert wing.num_spanwise_panels is not None
-                num_trailing_edge_panels += wing.num_spanwise_panels
-        num_horseshoe_calls = 2 if surfaceReflect_T_act_GP1_CgP1 is not None else 1
-        expected_degenerate = (
-            num_horseshoe_calls * 3 * (self.num_panels - num_trailing_edge_panels)
-        )
-        unexpected_singularity_counts[0] -= expected_degenerate
         _functions.log_unexpected_singularity_counts(
             _logger,
             logging.ERROR,
@@ -481,9 +474,12 @@ class SteadyRingVortexLatticeMethodSolver:
             unexpected_singularity_counts,
         )
 
-        gridNormVIndCpp_GP1__E = (
-            gridRingNormVIndCpp_GP1__E + gridHorseshoeNormVIndCpp_GP1__E
-        )
+        # Fold the trailing edge sized horseshoe contribution into the ring grid at
+        # the trailing edge columns. For non trailing edge columns the ring grid is
+        # untouched.
+        gridRingNormVIndCpp_GP1__E[
+            :, self.panel_is_trailing_edge, :
+        ] += gridHorseshoeNormVIndCpp_GP1__E
 
         # Take the batch dot product of the normalized induced velocities (in the
         # first Airplane's geometry axes, observed from the Earth frame) with each
@@ -492,7 +488,7 @@ class SteadyRingVortexLatticeMethodSolver:
         # the Earth frame).
         self._gridWingWingInfluences__E = np.einsum(
             "...k,...k->...",
-            gridNormVIndCpp_GP1__E,
+            gridRingNormVIndCpp_GP1__E,
             np.expand_dims(self.stackUnitNormals_GP1, axis=1),
         )
 
@@ -507,10 +503,10 @@ class SteadyRingVortexLatticeMethodSolver:
         )
 
         # Mirror the trailing edge entries of the solved strengths into the
-        # horseshoe vortex strength array. Non trailing edge entries remain zero.
-        self._horseshoe_vortex_strengths[self.panel_is_trailing_edge] = (
-            self._vortex_strengths[self.panel_is_trailing_edge]
-        )
+        # trailing edge sized horseshoe vortex strength array.
+        self._horseshoe_vortex_strengths = self._vortex_strengths[
+            self.panel_is_trailing_edge
+        ]
 
     def calculate_solution_velocity(
         self,
@@ -778,17 +774,13 @@ class SteadyRingVortexLatticeMethodSolver:
 
         unexpected_bound_singularity_counts = np.copy(bound_singularity_counts)
 
-        # Subtract expected structural singularity counts before logging. For
+        # Subtract expected structural collinearity counts before logging. For
         # each Wing with C chordwise and S spanwise Panels, the four leg center
         # evaluations produce (8 * C * S - 2 * C - 2 * S) collinearity
         # singularities from ring vortex self and adjacent shared edge pairs.
         # Each trailing edge Panel's back leg center is also collinear with the
         # corresponding wake horseshoe vortex's finite leg, adding S per Wing.
-        # Non trailing edge Panels have phantom all zero horseshoe vortex vertices,
-        # producing 3 degenerate legs each per horseshoe wrapper call, times 4
-        # calculate_solution_velocity calls.
         expected_collinearity = 0
-        num_trailing_edge_panels = 0
         for airplane in self.airplanes:
             for wing in airplane.wings:
                 num_chordwise = wing.num_chordwise_panels
@@ -797,9 +789,6 @@ class SteadyRingVortexLatticeMethodSolver:
                 n = num_chordwise * num_spanwise
                 expected_collinearity += 8 * n - 2 * num_chordwise - 2 * num_spanwise
                 expected_collinearity += num_spanwise
-                num_trailing_edge_panels += num_spanwise
-        expected_degenerate = 4 * 3 * (self.num_panels - num_trailing_edge_panels)
-        unexpected_bound_singularity_counts[0] -= expected_degenerate
         unexpected_bound_singularity_counts[3] -= expected_collinearity
         _functions.log_unexpected_singularity_counts(
             _logger,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,7 +10,15 @@ This package contains the following directories:
 
 This package contains the following modules:
     __init__.py: This module is this package's initialization script.
+
+    _test_environment.py: This module quiets known sources of test run noise
+    (serialization dirty tree warnings, tqdm progress bars, and the VTK
+    headless display warning). It is imported first so its side effects take
+    effect before any pterasoftware, pyvista, or tqdm module loads.
 """
 
+# Must be the first import so environment variables are set before any other
+# module reads them.
+import tests._test_environment  # noqa: F401
 import tests.integration
 import tests.unit

--- a/tests/_test_environment.py
+++ b/tests/_test_environment.py
@@ -1,0 +1,109 @@
+"""Configures the test process to quiet known sources of test run noise.
+
+Three categories of noise are addressed here:
+
+1. Two pterasoftware._serialization warnings about uncommitted git state. These
+   are correct in production but always fire during test runs because tests are
+   commonly executed on a dirty working tree.
+
+2. tqdm progress bars from solver runs invoked through paths that do not
+   forward a show_progress=False parameter (such as the convergence and trim
+   helpers). Setting TQDM_DISABLE=1 in the environment disables every tqdm
+   instance in the process without requiring per call site changes.
+
+3. The VTK "bad X server connection" warning that fires on Linux when no X
+   display is reachable (typically over SSH without X11 forwarding). When this
+   is detected, the process is switched to PyVista off-screen mode. On macOS,
+   Windows, and Linux sessions with a working display (including CI runs that
+   use pyvista/setup-headless-display-action to provide xvfb), no change is
+   made and plotters render normally.
+
+Importing this module installs the three suppressions as side effects. It is
+imported as the first line of tests/__init__.py so the configuration is in
+place before any pterasoftware, pyvista, or tqdm module loads.
+"""
+
+import logging
+import os
+import sys
+
+_SUPPRESSED_SERIALIZATION_MESSAGES = frozenset(
+    {
+        "The current working tree has uncommitted changes.",
+        (
+            "The file was saved with uncommitted changes (_dirty=true). The "
+            "_commit hash may not fully represent the code state at save time."
+        ),
+    }
+)
+
+
+class _SuppressDirtyProvenanceWarnings(logging.Filter):
+    """Drops the two known pterasoftware._serialization dirty tree warnings."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.getMessage() not in _SUPPRESSED_SERIALIZATION_MESSAGES
+
+
+def _install_serialization_log_filter() -> None:
+    logger = logging.getLogger("pterasoftware._serialization")
+    for existing in logger.filters:
+        if isinstance(existing, _SuppressDirtyProvenanceWarnings):
+            return
+    logger.addFilter(_SuppressDirtyProvenanceWarnings())
+
+
+def _disable_tqdm_progress_bars() -> None:
+    """Forces every tqdm instance to be silent.
+
+    Setting TQDM_DISABLE=1 only takes effect when the caller passes
+    disable=None. pterasoftware passes disable=not show_progress, which is an
+    explicit False whenever show_progress is True (the default for several
+    helpers like convergence and trim). Monkey-patching tqdm.__init__ ensures
+    disable=True regardless of caller intent.
+    """
+    os.environ.setdefault("TQDM_DISABLE", "1")
+    try:
+        import tqdm
+    except ImportError:
+        return
+
+    original_init = tqdm.tqdm.__init__
+
+    def _silent_init(self, *args, **kwargs):
+        kwargs["disable"] = True
+        return original_init(self, *args, **kwargs)
+
+    tqdm.tqdm.__init__ = _silent_init
+
+
+def _enable_pyvista_off_screen_if_no_display() -> None:
+    """Switches PyVista to off-screen and silences VTK warnings on headless Linux.
+
+    PyVista off-screen mode prevents window creation, but VTK still emits a
+    "bad X server connection" warning from its render window constructor on
+    Linux when DISPLAY is unset, even with off-screen enabled. Dropping the
+    VTK stderr verbosity to ERROR suppresses that warning while keeping
+    genuine VTK errors visible. This is scoped to headless Linux only;
+    sessions with a display and other platforms are left untouched.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    if os.environ.get("DISPLAY"):
+        return
+    os.environ.setdefault("PYVISTA_OFF_SCREEN", "true")
+    try:
+        import pyvista as pv
+    except ImportError:
+        return
+    pv.OFF_SCREEN = True
+    try:
+        from vtkmodules.vtkCommonCore import vtkLogger
+    except ImportError:
+        return
+    vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_ERROR)
+
+
+_install_serialization_log_filter()
+_disable_tqdm_progress_bars()
+_enable_pyvista_off_screen_if_no_display()


### PR DESCRIPTION
# Description

This PR cleans up five sources of noise in the test output: two real bugs in `SteadyRingVortexLatticeMethodSolver`, plus three environment-level noises that always fire during local or headless test runs. Together they bring the test suite from a wall of warnings and progress bars down to silent green output.

## Motivation

Running the test suite produced enough noise that legitimate warnings were easy to miss:

* `calculate_streamlines: ... degenerate filament=N` fired on every streamline-exercising test, caused by phantom all-zero horseshoe vortex entries on non-trailing-edge `Panels` in `SteadyRingVortexLatticeMethodSolver`. Investigation revealed those phantoms also masked a latent factor-of-2 undercount in `_calculate_loads`'s `expected_degenerate` subtraction when an image surface is defined.
* `pterasoftware._serialization` warnings about uncommitted git state fired on every dev run, since tests are routinely run against a dirty working tree.
* tqdm progress bars from `convergence` and `trim` runs interleaved with test dots, because those helpers default `show_solver_progress=True` and pass `disable=not show_progress` explicitly, which bypasses the `TQDM_DISABLE` env var.
* The VTK `bad X server connection` warning fired from `vtkXOpenGLRenderWindow` whenever tests were run over SSH without X forwarding, even with PyVista off-screen mode enabled.

## Relevant Issues

* Fixes #145 and fixes #105.

## Changes

* Resize horseshoe vortex arrays in `SteadyRingVortexLatticeMethodSolver` from `num_panels` to `num_trailing_edge_panels`, eliminating phantom entries. The new AIC build uses a scatter-add into trailing edge columns of the ring grid, which preserves the existing `(num_panels, num_panels)` Kutta-coupled system bit-for-bit. The `_calculate_loads` and `_calculate_wing_wing_influences` `expected_degenerate` corrections are removed since they no longer have phantoms to cancel. The latent factor-of-2 bug under image surfaces disappears with them.
* Add `tests/_test_environment.py`, a private test-only helper that installs three suppressions at import time:
    * A `logging.Filter` on the `pterasoftware._serialization` logger that drops the two known dirty-tree warning strings by exact match.
    * A `tqdm.tqdm.__init__` monkey-patch that forces `disable=True` regardless of caller intent.
    * A `vtkLogger.SetStderrVerbosity(VERBOSITY_ERROR)` call scoped to Linux without `DISPLAY`, so windowed local sessions and CI runs (which use `pyvista/setup-headless-display-action` for xvfb) still surface every VTK message.
* Wire the helper as the first import in `tests/__init__.py` so its side effects run before any `pterasoftware`, `pyvista`, or `tqdm` module loads.
* Byte equality was verified end-to-end on the steady ring VLM example (matching SHA-256 across the AIC, vortex strengths, padded horseshoe strengths, streamlines, and per-panel loads) for both the no-image and image-surface configurations before and after the refactor.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `black`, `codespell`, and `isort` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.