### PR TITLE
Remove redundant wake age and initial core radius storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Before contributing, make sure to read through the [Contributing Guidelines](CON
 * Mohamed Abdulghany ([MohamedMG7](https://github.com/MohamedMG7))
 * Hang Haotian ([haotianh9](https://github.com/haotianh9))
 * Monisha Sikka ([20086080](https://github.com/20086080))
+* Cameron Hendrikse ([MonoChromatical](https://github.com/MonoChromatical))
 
 ### Supporters
 

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -770,16 +770,27 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     num_chordwise_wake_rows = min(step, self._max_wake_rows)
                 num_wing_wake_vortices = num_chordwise_wake_rows * _num_spanwise_panels
                 if num_wing_wake_vortices > 0:
-                    for wake_row in range(num_chordwise_wake_rows):
-                        start = (
-                            global_wake_ring_vortex_position
-                            + wake_row * _num_spanwise_panels
-                        )
-                        end = start + _num_spanwise_panels
-                        self._currentStackWakeRc0s[start:end] = wing_r_c0
-                        self._current_wake_vortex_ages[start:end] = (
-                            wake_row + 1
-                        ) * self.delta_time
+                    block_start = global_wake_ring_vortex_position
+                    block_end = block_start + num_wing_wake_vortices
+
+                    # The initial core radius is constant across this Wing's
+                    # wake block, so it fills in a single slice.
+                    self._currentStackWakeRc0s[block_start:block_end] = wing_r_c0
+
+                    # Each chordwise wake row is one delta_time older than the
+                    # row shed after it, so row index c (0-based, newest
+                    # first) has age (c + 1) * delta_time. Repeat each row's
+                    # age across that row's spanwise wake vortices to match
+                    # the block layout used by
+                    # _populate_next_airplanes_wake_vortices.
+                    row_ages = (
+                        np.arange(1, num_chordwise_wake_rows + 1, dtype=float)
+                        * self.delta_time
+                    )
+                    self._current_wake_vortex_ages[block_start:block_end] = np.repeat(
+                        row_ages, _num_spanwise_panels
+                    )
+
                     global_wake_ring_vortex_position += num_wing_wake_vortices
 
         if self._current_step > 0:

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -120,8 +120,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
         "_currentStackBlwrvp_GP1_CgP1",
         "list_num_wake_vortices",
         "_list_wake_vortex_strengths",
-        "_list_wake_vortex_ages",
-        "_list_wake_rc0s",
         "listStackBrwrvp_GP1_CgP1",
         "listStackFrwrvp_GP1_CgP1",
         "listStackFlwrvp_GP1_CgP1",
@@ -284,9 +282,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self._list_wake_vortex_strengths: list[np.ndarray] = [
             np.zeros(n, dtype=float) for n in wake_sizes_per_step
         ]
-        self._list_wake_vortex_ages: list[np.ndarray] = [
-            np.zeros(n, dtype=float) for n in wake_sizes_per_step
-        ]
         self.listStackBrwrvp_GP1_CgP1: list[np.ndarray] = [
             np.zeros((n, 3), dtype=float) for n in wake_sizes_per_step
         ]
@@ -298,9 +293,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
         ]
         self.listStackBlwrvp_GP1_CgP1: list[np.ndarray] = [
             np.zeros((n, 3), dtype=float) for n in wake_sizes_per_step
-        ]
-        self._list_wake_rc0s: list[np.ndarray] = [
-            np.zeros(n, dtype=float) for n in wake_sizes_per_step
         ]
 
         # The current and last time step's center bound line vortex points for the
@@ -343,9 +335,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self._currentStackBlwrvp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
 
         # The list attributes above (list_num_wake_vortices,
-        # _list_wake_vortex_strengths, _list_wake_vortex_ages,
-        # _list_wake_rc0s, listStack{Br,Fr,Fl,Bl}wrvp_GP1_CgP1) were
-        # pre-allocated above this block.
+        # _list_wake_vortex_strengths, listStack{Br,Fr,Fl,Bl}wrvp_GP1_CgP1)
+        # were pre-allocated above this block.
 
         self._currentStackBoundRc0s: np.ndarray = np.empty(0, dtype=float)
         self._currentStackWakeRc0s: np.ndarray = np.empty(0, dtype=float)
@@ -546,14 +537,17 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 self._current_wake_vortex_strengths = self._list_wake_vortex_strengths[
                     step
                 ]
-                self._current_wake_vortex_ages = self._list_wake_vortex_ages[step]
                 self._currentStackBrwrvp_GP1_CgP1 = self.listStackBrwrvp_GP1_CgP1[step]
                 self._currentStackFrwrvp_GP1_CgP1 = self.listStackFrwrvp_GP1_CgP1[step]
                 self._currentStackFlwrvp_GP1_CgP1 = self.listStackFlwrvp_GP1_CgP1[step]
                 self._currentStackBlwrvp_GP1_CgP1 = self.listStackBlwrvp_GP1_CgP1[step]
 
                 self._currentStackBoundRc0s = np.zeros(self.num_panels, dtype=float)
-                self._currentStackWakeRc0s = self._list_wake_rc0s[step]
+                num_wake_vortices = self.list_num_wake_vortices[step]
+                self._current_wake_vortex_ages = np.zeros(
+                    num_wake_vortices, dtype=float
+                )
+                self._currentStackWakeRc0s = np.zeros(num_wake_vortices, dtype=float)
 
                 self.stackSeedPoints_GP1_CgP1 = np.zeros((0, 3), dtype=float)
 
@@ -766,19 +760,27 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
                 # Set the wake characteristic core radius for every wake
                 # ring vortex contributed by this Wing at this step. The wake
-                # corner positions, strengths, and ages are already stored in
-                # the per step list arrays aliased to self._currentStack* in
-                # run() and populated by _populate_next_airplanes_wake_vortices.
+                # corner positions and strengths are stored in the per step list arrays
+                # aliased to self._currentStack* in run() and populated by
+                # _populate_next_airplanes_wake_vortices. Ages are derived from row
+                # position because each retained wake row is one delta_time older than
+                # the row before it.
                 num_chordwise_wake_rows = step
                 if self._max_wake_rows is not None:
                     num_chordwise_wake_rows = min(step, self._max_wake_rows)
                 num_wing_wake_vortices = num_chordwise_wake_rows * _num_spanwise_panels
                 if num_wing_wake_vortices > 0:
-                    end = global_wake_ring_vortex_position + num_wing_wake_vortices
-                    self._currentStackWakeRc0s[global_wake_ring_vortex_position:end] = (
-                        wing_r_c0
-                    )
-                    global_wake_ring_vortex_position = end
+                    for wake_row in range(num_chordwise_wake_rows):
+                        start = (
+                            global_wake_ring_vortex_position
+                            + wake_row * _num_spanwise_panels
+                        )
+                        end = start + _num_spanwise_panels
+                        self._currentStackWakeRc0s[start:end] = wing_r_c0
+                        self._current_wake_vortex_ages[start:end] = (
+                            wake_row + 1
+                        ) * self.delta_time
+                    global_wake_ring_vortex_position += num_wing_wake_vortices
 
         if self._current_step > 0:
             last_step = self._current_step - 1
@@ -1741,16 +1743,15 @@ class UnsteadyRingVortexLatticeMethodSolver:
             )
 
     def _populate_next_airplanes_wake_vortices(self) -> None:
-        """Populates the next time step's wake corner stacks, strengths, and ages.
+        """Populates the next time step's wake corner stacks and strengths.
 
         Each Wing's wake POINT grid (Wing.gridWrvp_GP1_CgP1) was already advected by
         _populate_next_airplanes_wake_vortex_points. This method derives the next step's
-        per wake-cell corner positions, strengths, and ages and writes them directly
-        into the per step list arrays. Strengths come from this step's solved bound ring
-        vortex strengths (for the new front row) and from this step's wake (for
-        inherited rows). Ages are delta_time for the new front row and (last age +
-        delta_time) for inherited rows. The oldest row of this step's wake is dropped
-        when truncation is in effect.
+        per wake-cell corner positions and strengths and writes them directly into the
+        per step list arrays. Strengths come from this step's solved bound ring vortex
+        strengths (for the new front row) and from this step's wake (for inherited
+        rows). The oldest row of this step's wake is dropped when truncation is in
+        effect.
 
         :return: None
         """
@@ -1770,7 +1771,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         # Output buffers for the next step.
         next_strengths = self._list_wake_vortex_strengths[next_step]
-        next_ages = self._list_wake_vortex_ages[next_step]
         next_stackFr = self.listStackFrwrvp_GP1_CgP1[next_step]
         next_stackFl = self.listStackFlwrvp_GP1_CgP1[next_step]
         next_stackBl = self.listStackBlwrvp_GP1_CgP1[next_step]
@@ -1780,7 +1780,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # When this_num_chordwise_rows is 0 (i.e. step 0 -> 1), they are zero
         # length and never indexed.
         this_strengths = self._list_wake_vortex_strengths[this_step]
-        this_ages = self._list_wake_vortex_ages[this_step]
 
         next_problem = self._get_steady_problem_at(next_step)
         for airplane_id, next_airplane in enumerate(next_problem.airplanes):
@@ -1835,7 +1834,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         te_panel_base : te_panel_base + wing_num_spanwise
                     ]
                 )
-                next_ages[front_start:front_end] = self.delta_time
 
                 # Inherited rows (c >= 1): aged versions of this step's rows
                 # 0 .. inherited_rows - 1. When wake truncation drops the
@@ -1862,9 +1860,6 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     next_strengths[new_start:new_end] = this_strengths[
                         old_start:old_end
                     ]
-                    next_ages[new_start:new_end] = (
-                        this_ages[old_start:old_end] + self.delta_time
-                    )
 
     def _calculate_current_movement_velocities_at_collocation_points(
         self,


### PR DESCRIPTION
# Description

Removes two redundant private wake-data lists from the unsteady ring VLM solver. Wake vortex strengths are still stored, but wake ages and wake initial core radii are now worked out when needed for the current step.

## Motivation

Issue #127  asks whether the private wake-data attributes in the unsteady VLM solver are all needed.

After tracing where the three lists were created, written to, and read from, I found that `_list_wake_vortex_strengths` still needs to be kept because the solver needs to remember the strength each wake row had when it was created.

However, `_list_wake_vortex_ages` and `_list_wake_rc0s` were storing values that can already be worked out:

* wake age can be worked out from the wake row number and `delta_time`
* wake initial core radius can be worked out from the wing's standard mean chord

## Relevant Issues

Closes #127.

## Changes

* Kept `_list_wake_vortex_strengths` because wake row strengths need to be remembered after each row is created.
* Removed `_list_wake_vortex_ages` from `__slots__` and `__init__`.
* Removed `_list_wake_rc0s` from `__slots__` and `__init__`.
* Updated `run()` to create current-step wake age and wake initial core-radius arrays when needed.
* Updated `_collapse_geometry()` to fill current-step wake ages from wake row number and `delta_time`.
* Updated `_collapse_geometry()` to fill current-step wake initial core radii from each wing's standard mean chord.
* Updated the wake vortex population docstring to match the new behaviour.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
