### PR TITLE
[BUG] Missing steady solvers streamlines flag

### DIFF
--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -459,9 +459,10 @@ def analyze_steady_convergence(
 
             convergence_logger.info("\t\t\tStarting simulation...")
 
-            # Run the steady solver and time how long it takes to execute.
+            # Run the steady solver and time how long it takes to execute. Skip the
+            # streamline trace since it does not affect convergence metrics.
             iter_start = time.time()
-            this_solver.run()
+            this_solver.run(calculate_streamlines=False)
             iter_stop = time.time()
             this_iter_time = iter_stop - iter_start
 

--- a/pterasoftware/steady_horseshoe_vortex_lattice_method.py
+++ b/pterasoftware/steady_horseshoe_vortex_lattice_method.py
@@ -142,11 +142,19 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         self.ran = False
 
-    def run(self) -> None:
+    def run(self, calculate_streamlines: bool | np.bool_ = True) -> None:
         """Runs the solver on the SteadyProblem.
 
+        :param calculate_streamlines: Determines whether to calculate the streamlines
+            emanating from the back of the wing after running the solver. Can be a bool
+            or a numpy bool and will be converted internally to a bool. The default is
+            True.
         :return: None
         """
+        calculate_streamlines = _parameter_validation.boolLike_return_bool(
+            calculate_streamlines, "calculate_streamlines"
+        )
+
         # Compute the horseshoe vortex geometries and collapse them, along with each
         # Panel's per panel scalars, into 1D ndarrays of attributes.
         _logger.debug("Collapsing the geometry.")
@@ -173,9 +181,10 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
         self._calculate_loads()
 
         # Solve for the location of the streamlines coming off the Wings' trailing
-        # edges.
-        _logger.debug("Calculating streamlines.")
-        _functions.calculate_streamlines(self)
+        # edges, if requested.
+        if calculate_streamlines:
+            _logger.debug("Calculating streamlines.")
+            _functions.calculate_streamlines(self)
 
         # Mark that the solver has run.
         self.ran = True

--- a/pterasoftware/steady_ring_vortex_lattice_method.py
+++ b/pterasoftware/steady_ring_vortex_lattice_method.py
@@ -196,11 +196,19 @@ class SteadyRingVortexLatticeMethodSolver:
 
         self.ran = False
 
-    def run(self) -> None:
+    def run(self, calculate_streamlines: bool | np.bool_ = True) -> None:
         """Runs the solver on the SteadyProblem.
 
+        :param calculate_streamlines: Determines whether to calculate the streamlines
+            emanating from the back of the wing after running the solver. Can be a bool
+            or a numpy bool and will be converted internally to a bool. The default is
+            True.
         :return: None
         """
+        calculate_streamlines = _parameter_validation.boolLike_return_bool(
+            calculate_streamlines, "calculate_streamlines"
+        )
+
         # Compute the bound ring vortex and trailing edge horseshoe vortex geometries
         # and collapse them, along with each Panel's per panel scalars, into 1D
         # ndarrays of attributes.
@@ -228,9 +236,10 @@ class SteadyRingVortexLatticeMethodSolver:
         self._calculate_loads()
 
         # Solve for the location of the streamlines coming off the Wings' trailing
-        # edges.
-        _logger.debug("Calculating streamlines.")
-        _functions.calculate_streamlines(self)
+        # edges, if requested.
+        if calculate_streamlines:
+            _logger.debug("Calculating streamlines.")
+            _functions.calculate_streamlines(self)
 
         # Mark that the solver has run.
         self.ran = True

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -358,10 +358,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
             Set to False to use a free-wake, which may be more accurate but will make
             the fun method significantly slower. Can be a bool or a numpy bool and will
             be converted internally to a bool. The default is True.
-        :param calculate_streamlines: Set this to True to calculate streamlines
-            emanating from the back of the wing after running the solver. It can be a
-            bool or a numpy bool and will be converted internally to a bool. The default
-            is True.
+        :param calculate_streamlines: Determines whether to calculate the streamlines
+            emanating from the back of the wing after running the solver. Can be a bool
+            or a numpy bool and will be converted internally to a bool. The default is
+            True.
         :param show_progress: Set this to True to show the TQDM progress bar. For
             showing the progress bar and displaying log statements, set up logging using
             the setup_logging function. It can be a bool or a numpy bool and will be


### PR DESCRIPTION
# Description

Adds the missing optional `calculate_streamlines` flag to the two steady solvers' `run` methods, mirroring the flag that already exists on the unsteady solver. The default is `True`, so existing callers see no change. The steady convergence loop opts out with `calculate_streamlines=False`, matching the unsteady convergence loop.

## Motivation

The unsteady solver has long allowed callers to skip the post-solve streamline trace when only loads are needed. The steady solvers had no equivalent escape hatch, which forced wasted work in any context that does not consume the streamline output. This PR closes that gap and applies it in the one obvious place inside the package, the steady convergence loop.

## Relevant Issues

None.

## Changes

* Add `calculate_streamlines: bool | np.bool_ = True` to `SteadyHorseshoeVortexLatticeMethodSolver.run` and `SteadyRingVortexLatticeMethodSolver.run`, validated via `_parameter_validation.boolLike_return_bool` and gating the existing `_functions.calculate_streamlines(self)` call.
* Reword the unsteady solver's existing `calculate_streamlines` docstring to use the "Determines whether to..." boolean pattern from the docstring style guide, matching the new steady docstrings.
* Pass `calculate_streamlines=False` to the steady solver inside `analyze_steady_convergence`, matching what `analyze_unsteady_convergence` already does.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
