### PR TITLE
[BUG] Fix two unenforced CI checks

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           ignore_words_file: .codespell-ignore.txt
-          skip: "*/_build/*,*.dat,docs/_static/benchmarks/*.html"
+          skip: "*/_build/*,*.dat,*/docs/_static/benchmarks/*.html"

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
-        continue-on-error: true
         with:
           ignore_words_file: .codespell-ignore.txt
-          skip: "*/_build/*,*.dat"
+          skip: "*/_build/*,*.dat,docs/_static/benchmarks/*.html"

--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -35,7 +35,6 @@ jobs:
           - { hook: check-vcs-permalinks,                 name: vcs-permalinks }
           - { hook: check-executables-have-shebangs,      name: exec-shebangs }
           - { hook: check-shebang-scripts-are-executable, name: shebang-execs }
-          - { hook: check-added-large-files,              name: large-files }
           - { hook: debug-statements,                     name: debug-statements }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,10 @@ repos:
     hooks:
       - id: codespell
         name: checker  codespell
+        # The rendered HTML reports embed base64-encoded TTFs. Random byte sequences in
+        # the base64 stream collide with codespell's small typo dictionary (e.g., AEr,
+        # ABL, gEs), so exclude the reports tree where these blobs live.
+        exclude: ^docs/_static/benchmarks/.*\.html$
   - repo: local
     hooks:
       - id: ascii-only


### PR DESCRIPTION
# Description

Fix two CI checks that were silently passing on every PR.

## Motivation

The `codespell` workflow had `continue-on-error: true`, so misspellings never failed CI. Separately, the `check-added-large-files` row in the `pre-commit-hooks` matrix was a no-op because the hook filters its candidate set by `git diff --staged --diff-filter=A`, which is empty after a fresh CI checkout. Both checks were green for the wrong reasons.

## Relevant Issues

None.

## Changes

* Remove `continue-on-error: true` from `.github/workflows/codespell.yml` so codespell failures fail CI.
* Add `*/docs/_static/benchmarks/*.html` to codespell's workflow `skip:` list and a matching `exclude:` on the pre-commit codespell hook. The rendered Plotly reports embed base64-encoded TTFs whose random byte sequences collide with codespell's typo dictionary.
* Remove the `check-added-large-files` row from the `pre-commit-hooks` workflow matrix. The hook stays in `.pre-commit-config.yaml` so local commits are still guarded, where the staging filter does the right thing.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
