### PR TITLE
Create unit tests for analyze_unsteady_trim

### DIFF
--- a/tests/unit/test_unsteady_trim.py
+++ b/tests/unit/test_unsteady_trim.py
@@ -1,0 +1,294 @@
+import unittest
+
+import pterasoftware as ps
+from tests.unit.fixtures import problem_fixtures
+
+
+class TestAnalyzeUnsteadyTrim(unittest.TestCase):
+    """This class contains unit tests for the analyze_unsteady_trim function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.problem = problem_fixtures.make_basic_unsteady_problem_fixture()
+
+    def test_problem_validation(self):
+        """Test problem parameter validation."""
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem="not a problem",
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+    def test_multiple_airplane_movements_validation(self):
+        """Test that only one AirplaneMovement is allowed."""
+
+        problem = problem_fixtures.make_multi_airplane_unsteady_problem_fixture()
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+    def test_boundsVCg__E_validation(self):
+        """Test boundsVCg__E parameter validation."""
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E="invalid",
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0,),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=("a", 10.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(10.0, 1.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(0.0, 10.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+    def test_alpha_bounds_validation(self):
+        """Test alpha_bounds parameter validation."""
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds="invalid",
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(1.0,),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=("a", 10.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(10.0, -10.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+    def test_beta_bounds_validation(self):
+        """Test beta_bounds parameter validation."""
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds="invalid",
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(1.0,),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=("a", 10.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(10.0, -10.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+            )
+
+    def test_boundsExternalFX_W_validation(self):
+        """Test boundsExternalFX_W parameter validation."""
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W="invalid",
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(1.0,),
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=("a", 10.0),
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(10.0, -10.0),
+            )
+
+    def test_objective_cut_off_validation(self):
+        """Test objective_cut_off parameter validation."""
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+                objective_cut_off=0.0,
+            )
+
+    def test_num_calls_validation(self):
+        """Test num_calls parameter validation."""
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+                num_calls=0,
+            )
+
+    def test_base_operating_point_parameter_bounds_validation(self):
+        """Test that the base operating point values must lie within the supplied
+        bounds.
+        """
+
+        base_operating_point = (
+            self.problem.movement.operating_point_movement.base_operating_point
+        )
+
+        with self.subTest(parameter="vCg__E"):
+            with self.assertRaises(ValueError):
+                ps.trim.analyze_unsteady_trim(
+                    problem=self.problem,
+                    boundsVCg__E=(
+                        base_operating_point.vCg__E + 1.0,
+                        base_operating_point.vCg__E + 10.0,
+                    ),
+                    alpha_bounds=(-20.0, 20.0),
+                    beta_bounds=(-20.0, 20.0),
+                    boundsExternalFX_W=(-1000.0, 1000.0),
+                )
+
+        with self.subTest(parameter="alpha"):
+            with self.assertRaises(ValueError):
+                ps.trim.analyze_unsteady_trim(
+                    problem=self.problem,
+                    boundsVCg__E=(1.0, 100.0),
+                    alpha_bounds=(
+                        base_operating_point.alpha + 1.0,
+                        base_operating_point.alpha + 10.0,
+                    ),
+                    beta_bounds=(-20.0, 20.0),
+                    boundsExternalFX_W=(-1000.0, 1000.0),
+                )
+
+        with self.subTest(parameter="beta"):
+            with self.assertRaises(ValueError):
+                ps.trim.analyze_unsteady_trim(
+                    problem=self.problem,
+                    boundsVCg__E=(1.0, 100.0),
+                    alpha_bounds=(-20.0, 20.0),
+                    beta_bounds=(
+                        base_operating_point.beta + 1.0,
+                        base_operating_point.beta + 10.0,
+                    ),
+                    boundsExternalFX_W=(-1000.0, 1000.0),
+                )
+
+        with self.subTest(parameter="externalFX_W"):
+            with self.assertRaises(ValueError):
+                ps.trim.analyze_unsteady_trim(
+                    problem=self.problem,
+                    boundsVCg__E=(1.0, 100.0),
+                    alpha_bounds=(-20.0, 20.0),
+                    beta_bounds=(-20.0, 20.0),
+                    boundsExternalFX_W=(
+                        base_operating_point.externalFX_W + 1.0,
+                        base_operating_point.externalFX_W + 10.0,
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_unsteady_trim.py
+++ b/tests/unit/test_unsteady_trim.py
@@ -1,3 +1,5 @@
+"""This module contains a class to test the analyze_unsteady_trim function."""
+
 import unittest
 
 import pterasoftware as ps
@@ -5,11 +7,12 @@ from tests.unit.fixtures import problem_fixtures
 
 
 class TestAnalyzeUnsteadyTrim(unittest.TestCase):
-    """This class contains unit tests for the analyze_unsteady_trim function."""
+    """A class with functions to test analyze_unsteady_trim."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        self.problem = problem_fixtures.make_basic_unsteady_problem_fixture()
+    @classmethod
+    def setUpClass(cls):
+        """Set up test fixtures once for all analyze_unsteady_trim tests."""
+        cls.problem = problem_fixtures.make_basic_unsteady_problem_fixture()
 
     def test_problem_validation(self):
         """Test problem parameter validation."""
@@ -215,6 +218,16 @@ class TestAnalyzeUnsteadyTrim(unittest.TestCase):
                 objective_cut_off=0.0,
             )
 
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+                objective_cut_off=-1.0,
+            )
+
     def test_num_calls_validation(self):
         """Test num_calls parameter validation."""
 
@@ -226,6 +239,26 @@ class TestAnalyzeUnsteadyTrim(unittest.TestCase):
                 beta_bounds=(-20.0, 20.0),
                 boundsExternalFX_W=(-1000.0, 1000.0),
                 num_calls=0,
+            )
+
+        with self.assertRaises(TypeError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+                num_calls=1.5,
+            )
+
+        with self.assertRaises(ValueError):
+            ps.trim.analyze_unsteady_trim(
+                problem=self.problem,
+                boundsVCg__E=(1.0, 100.0),
+                alpha_bounds=(-20.0, 20.0),
+                beta_bounds=(-20.0, 20.0),
+                boundsExternalFX_W=(-1000.0, 1000.0),
+                num_calls=-1,
             )
 
     def test_base_operating_point_parameter_bounds_validation(self):


### PR DESCRIPTION
# Description

Add unit tests for analyze_unsteady_trim in trim.py covering parameter validation and operating point bounds validation.

These tests improve confidence in the trim analysis interface by verifying that invalid inputs are correctly rejected before optimization or solver execution begins.

## Motivation

analyze_unsteady_trim contains extensive validation logic for user-supplied parameters and operating point constraints. These checks are critical because they prevent invalid optimization searches and ensure that trim analysis is only performed on well-defined UnsteadyProblem configurations.

The function was previously flagged with # TEST comments but did not have dedicated unit test coverage. Adding focused validation tests makes future refactoring safer and helps ensure that documented parameter requirements remain enforced.

## Relevant Issues

Resolves unit testing component of #137.

## Changes

Added dedicated unit tests for analyze_unsteady_trim in test_unsteady_trim.py.

The following validation behavior is now tested:

1. test_problem_validation - Invalid problem parameter type raises TypeError.

2. test_multiple_airplane_movements_validation - Multiple AirplaneMovement objects raise ValueError.

3. test_boundsVCg__E_validation - Test boundsVCg__E parameter validation:

- Invalid type
- Incorrect tuple length
- Non-numeric values
- Descending bounds
- Non-positive values

4. test_alpha_bounds_validation - Test alpha_bounds parameter validation:

- Invalid type
- Incorrect tuple length
- Non-numeric values
- Descending bounds

5. test_beta_bounds_validation - Test beta_bounds parameter validation:

- Invalid type
- Incorrect tuple length
- Non-numeric values
- Descending bounds

6. test_boundsExternalFX_W_validation - Test boundsExternalFX_W parameter validation:

- Invalid type
- Incorrect tuple length
- Non-numeric values
- Descending bounds

7. test_objective_cut_off_validation - Test objective_cut_off parameter validation.

8. test_num_calls_validation - Test num_calls parameter validation.

9. test_base_operating_point_parameter_bounds_validation - Test that the base operating point values must lie within the supplied boundss:

- vCg__E
- alpha
- beta
- externalFX_W

   must lie within the user-supplied search bounds.

Testing Methodology

Tests use existing fixtures from tests.unit.fixtures.problem_fixtures to construct valid UnsteadyProblem instances.

The testing approach focuses on:

- Parameter validation
- Boundary condition validation
- Verification of documented input requirements
- Error handling through assertRaises

The tests intentionally avoid executing the optimization routines or aerodynamic solver, allowing validation logic to be tested in isolation as true unit tests.

## Dependency Updates
None

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
