### PR TITLE
[BUG] Fix free flight wake convection

### DIFF
--- a/pterasoftware/_transformations.py
+++ b/pterasoftware/_transformations.py
@@ -711,7 +711,19 @@ def alpha_and_beta_from_vInf_BP1(
         return float("nan"), float("nan")
 
     vInfX_BP1__E, vInfY_BP1__E, vInfZ_BP1__E = vInf_BP1__E
-    alpha = float(np.rad2deg(np.arctan2(-vInfZ_BP1__E, -vInfX_BP1__E)))
-    sin_beta = float(np.clip(vInfY_BP1__E / vCg__E, -1.0, 1.0))
-    beta = float(np.rad2deg(np.arcsin(sin_beta)))
+
+    # Invert the wind axes construction defined in docs/AXES_POINTS_AND_FRAMES.md and
+    # implemented by OperatingPoint. In that convention the CG velocity in body axes (the
+    # negated freestream, vCg_BP1__E = -vInf_BP1__E) has components
+    #   x: vCg__E * cos(alpha) * cos(beta)
+    #   y: vCg__E * cos(alpha) * sin(beta)
+    #   z: vCg__E * sin(alpha)
+    # so alpha follows from the body z component (arcsin) and beta from the body x and y
+    # components (arctan2). Extracting them in this order, rather than the more common
+    # textbook order that swaps which angle uses arcsin, keeps this function the exact
+    # inverse of OperatingPoint. Deriving alpha and beta here and storing them back on an
+    # OperatingPoint then reproduces the original freestream.
+    sin_alpha = float(np.clip(-vInfZ_BP1__E / vCg__E, -1.0, 1.0))
+    alpha = float(np.rad2deg(np.arcsin(sin_alpha)))
+    beta = float(np.rad2deg(np.arctan2(-vInfY_BP1__E, -vInfX_BP1__E)))
     return alpha, beta

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -1744,6 +1744,20 @@ class UnsteadyRingVortexLatticeMethodSolver:
                                 next_wing.gridWrvp_GP1_CgP1.shape
                             )
 
+                        # The wake points are stored in the first Airplane's geometry
+                        # axes, which rotate with the body. Apply the apparent velocity
+                        # from body rotation (omega cross r), just as is done at the
+                        # collocation points and bound line vortex leg centers, so the
+                        # wake convects with the fluid velocity relative to the rotating
+                        # body frame. Without this term, a nonzero body rate would carry
+                        # the wake along with the body instead of leaving it fixed in the
+                        # Earth frame. When the solver does not model body rotation, this
+                        # is a no-op.
+                        vRowWrvp_GP1__E = self._apply_body_rate(
+                            next_wing.gridWrvp_GP1_CgP1,
+                            vRowWrvp_GP1__E,
+                        )
+
                         # Build the second new row by advecting the first row.
                         secondNewRowWrvp_GP1_CgP1 = (
                             next_wing.gridWrvp_GP1_CgP1
@@ -1787,6 +1801,20 @@ class UnsteadyRingVortexLatticeMethodSolver:
                             vGridWrvp_GP1__E = stackVGridWrvp_GP1__E.reshape(
                                 next_wing.gridWrvp_GP1_CgP1.shape
                             )
+
+                        # The wake points are stored in the first Airplane's geometry
+                        # axes, which rotate with the body. Apply the apparent velocity
+                        # from body rotation (omega cross r), just as is done at the
+                        # collocation points and bound line vortex leg centers, so the
+                        # wake convects with the fluid velocity relative to the rotating
+                        # body frame. Without this term, a nonzero body rate would carry
+                        # the wake along with the body instead of leaving it fixed in the
+                        # Earth frame. When the solver does not model body rotation, this
+                        # is a no-op.
+                        vGridWrvp_GP1__E = self._apply_body_rate(
+                            next_wing.gridWrvp_GP1_CgP1,
+                            vGridWrvp_GP1__E,
+                        )
 
                         # Advect the entire aged grid in one vector add.
                         next_wing.gridWrvp_GP1_CgP1 = (

--- a/tests/unit/test_transformations.py
+++ b/tests/unit/test_transformations.py
@@ -5,6 +5,8 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
+import pterasoftware as ps
+
 # noinspection PyProtectedMember
 from pterasoftware import _transformations
 
@@ -2120,7 +2122,9 @@ class TestAlphaAndBetaFromVInfBP1(unittest.TestCase):
         npt.assert_allclose(beta, 0.0, atol=1e-14)
 
     def test_positive_beta(self):
-        """Tests that freestream with positive right component yields positive beta.
+        """Tests that a freestream with a leftward body-y component (the relative wind
+        coming from the right) yields positive beta, per the wind axes convention in
+        docs/AXES_POINTS_AND_FRAMES.md.
 
         :return: None
         """
@@ -2128,7 +2132,7 @@ class TestAlphaAndBetaFromVInfBP1(unittest.TestCase):
         expected_beta = 8.0
         beta_rad = np.deg2rad(expected_beta)
         vInf_BP1__E = np.array(
-            [-vCg__E * np.cos(beta_rad), vCg__E * np.sin(beta_rad), 0.0]
+            [-vCg__E * np.cos(beta_rad), -vCg__E * np.sin(beta_rad), 0.0]
         )
 
         alpha, beta = _transformations.alpha_and_beta_from_vInf_BP1(vInf_BP1__E, vCg__E)
@@ -2137,7 +2141,8 @@ class TestAlphaAndBetaFromVInfBP1(unittest.TestCase):
         npt.assert_allclose(beta, expected_beta, atol=1e-14)
 
     def test_negative_beta(self):
-        """Tests that freestream with positive left component yields negative beta.
+        """Tests that a freestream with a rightward body-y component (the relative wind
+        coming from the left) yields negative beta.
 
         :return: None
         """
@@ -2145,13 +2150,77 @@ class TestAlphaAndBetaFromVInfBP1(unittest.TestCase):
         expected_beta = -3.0
         beta_rad = np.deg2rad(expected_beta)
         vInf_BP1__E = np.array(
-            [-vCg__E * np.cos(beta_rad), vCg__E * np.sin(beta_rad), 0.0]
+            [-vCg__E * np.cos(beta_rad), -vCg__E * np.sin(beta_rad), 0.0]
         )
 
         alpha, beta = _transformations.alpha_and_beta_from_vInf_BP1(vInf_BP1__E, vCg__E)
 
         npt.assert_allclose(alpha, 0.0, atol=1e-14)
         npt.assert_allclose(beta, expected_beta, atol=1e-14)
+
+    def test_coupled_alpha_and_beta(self):
+        """Tests recovery when both alpha and beta are nonzero, which the single-angle
+        tests do not exercise and where an incorrect decomposition order would cross-
+        contaminate the two angles.
+
+        The CG velocity in body axes (the negated freestream,
+        vCg_BP1__E = -vInf_BP1__E) for the wind axes convention has components
+        vCg__E * cos(alpha) * cos(beta), vCg__E * cos(alpha) * sin(beta), and
+        vCg__E * sin(alpha). Build the freestream for a known alpha and beta and confirm
+        both are recovered exactly.
+
+        :return: None
+        """
+        vCg__E = 10.0
+        expected_alpha = 6.0
+        expected_beta = -15.0
+        alpha_rad = np.deg2rad(expected_alpha)
+        beta_rad = np.deg2rad(expected_beta)
+        vCg_BP1__E = vCg__E * np.array(
+            [
+                np.cos(alpha_rad) * np.cos(beta_rad),
+                np.cos(alpha_rad) * np.sin(beta_rad),
+                np.sin(alpha_rad),
+            ]
+        )
+        vInf_BP1__E = -vCg_BP1__E
+
+        alpha, beta = _transformations.alpha_and_beta_from_vInf_BP1(vInf_BP1__E, vCg__E)
+
+        npt.assert_allclose(alpha, expected_alpha, atol=1e-13)
+        npt.assert_allclose(beta, expected_beta, atol=1e-13)
+
+    def test_round_trip_consistent_with_operating_point(self):
+        """Tests that this function exactly inverts the OperatingPoint's alpha and beta
+        to freestream mapping, so the two share a single convention.
+
+        The free flight state update derives alpha and beta from the body velocity with
+        this function and stores them on a new OperatingPoint, which rebuilds its
+        freestream from them. If the two conventions disagree, that round trip corrupts
+        the freestream every time step. Build OperatingPoints across a grid of alpha and
+        beta, take each one's freestream in body axes, and confirm this function recovers
+        the original alpha and beta.
+
+        :return: None
+        """
+        vCg__E = 13.0
+        for alpha_in in [-12.0, -5.0, 0.0, 7.0, 14.0]:
+            for beta_in in [-25.0, -8.0, 0.0, 6.0, 20.0]:
+                op = ps.operating_point.OperatingPoint(
+                    rho=1.225, vCg__E=vCg__E, alpha=alpha_in, beta=beta_in
+                )
+                vInf_BP1__E = _transformations.apply_T_to_vectors(
+                    op.T_pas_GP1_CgP1_to_BP1_CgP1,
+                    op.vInf_GP1__E,
+                    is_position=False,
+                )
+
+                alpha_out, beta_out = _transformations.alpha_and_beta_from_vInf_BP1(
+                    vInf_BP1__E, vCg__E
+                )
+
+                npt.assert_allclose(alpha_out, alpha_in, atol=1e-12)
+                npt.assert_allclose(beta_out, beta_in, atol=1e-12)
 
     def test_zero_speed_returns_nan(self):
         """Tests that zero speed yields NaN for both alpha and beta.


### PR DESCRIPTION
# Description

This pull request fixes two bugs that corrupted the free flight wake under nonzero body rates. First, the unsteady solver's wake convection omitted the apparent velocity from body rotation (omega cross r), so a nonzero body rate carried the wake along with the rotating body instead of convecting it relative to the rotating frame. Second, `alpha_and_beta_from_vInf_BP1` decomposed the freestream incorrectly with respect to the conventions defined in `docs/AXES_POINTS_AND_FRAMES.md` and implemented by `OperatingPoint`. Because the free flight state update derives alpha and beta with this function and stores them on a new `OperatingPoint`, the mismatch corrupted the reconstructed freestream every time step, driving the wake to drift in the Earth frame and producing a spurious yaw and sideslip divergence.

## Motivation

Free flight simulations with nonzero body rates showed the wake drifting in the Earth frame and the airplane diverging in yaw and sideslip. Both behaviors are numerical artifacts, not physics: one from the missing body-rate term in the wake convection, and one from the alpha and beta extraction silently using a different convention than the rest of the package. With these fixes, the wake stays fixed in the Earth frame as the body rotates, and the alpha and beta round trip through `OperatingPoint` is exact. Steady and zero-rate results are unchanged, as the body-rate term is a no-op when the solver does not model body rotation.

## Relevant Issues

None.

## Changes

* Applied the body-rate term (omega cross r) to the free wake convection in `UnsteadyRingVortexLatticeMethodSolver`, matching the treatment already used at the collocation points and bound line vortex leg centers. The term applies to both the new trailing-edge wake row and the advection of the aged wake grid.
* Rewrote the angle extraction in `alpha_and_beta_from_vInf_BP1` to be the exact inverse of the `OperatingPoint` wind axes construction: alpha from the body z component via arcsin, and beta from the body x and y components via arctan2. The previous decomposition returned a sign-flipped sideslip and cross-contaminated alpha and beta when both were nonzero.
* Corrected the single-angle beta unit tests, which encoded the sign-flipped convention, and clarified their docstrings.
* Added a coupled-angle unit test for `alpha_and_beta_from_vInf_BP1`, since single-angle cases cannot detect a wrong decomposition order.
* Added a round-trip unit test confirming that `alpha_and_beta_from_vInf_BP1` exactly inverts the `OperatingPoint` alpha and beta to freestream mapping across a grid of angles.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
