### PR TITLE
[FEATURE] Add slash commands and labels

### DIFF
--- a/.claude/commands/analyze-webp.md
+++ b/.claude/commands/analyze-webp.md
@@ -1,0 +1,42 @@
+---
+description: Analyze a static or animated WebP file by viewing its metadata and rendered frames
+---
+
+# Analyze a WebP
+
+Inspect the WebP file given in the arguments and answer any question that accompanies it. If the arguments contain no question, summarize what the file shows and call out anything that looks wrong.
+
+The Read tool only ever shows the first frame of a WebP file, so never judge an animated WebP by Reading it directly. Use `scripts/analyze_webp.py`, which renders frames to PNG files for viewing.
+
+Arguments: $ARGUMENTS
+
+## Steps
+
+1. **Probe the file** to learn whether it is static or animated, its frame count, its dimensions, its duration, and whether it has transparency:
+   ```bash
+   python -u scripts/analyze_webp.py <file> info
+   ```
+   If multiple files were given, analyze each one in turn with these same steps.
+2. **Render and view the frames.** The script prints the path of each PNG it saves; view them with the Read tool.
+    - For a static file (1 frame), render it on its own:
+      ```bash
+      python -u scripts/analyze_webp.py <file> frames 0
+      ```
+    - For an animated file, render a contact sheet of frames sampled evenly across the animation:
+      ```bash
+      python -u scripts/analyze_webp.py <file> sheet
+      ```
+      The default samples 9 frames into a 3 x 3 grid, which is usually sufficient on its own to answer the question. To inspect more frames, render multiple sheets over sub-ranges with `--first` and `--last` rather than raising `--count` on one sheet; tiles much smaller than the default grid's are illegible.
+3. **Drill down only where needed.** The sheet's tiles render at about two-thirds of these models' native viewing resolution, so they carry nearly as much visible detail as full-resolution renders; do not rerender frames individually just because they appeared as tiles. Reserve full-resolution renders for when a specific tile shows something that genuinely needs closer inspection (an apparent artifact, fine text, a subtle geometry question) and name that reason before rendering:
+   ```bash
+   python -u scripts/analyze_webp.py <file> frames <index> [<index> ...]
+   ```
+4. **Check contrast against a specific background if asked.** Both `sheet` and `frames` accept `--background <color>` (any matplotlib color specification, such as `black` or `#1a2b3c`), which composites the pixels inside each frame over that color instead of keeping their alpha. Use this when the question involves how the content will look on a particular background, for example whether a transparent animation stays legible on a dark page.
+5. **Answer.** Address the question from the arguments (or summarize the file), citing specific frame indices and timestamps as evidence.
+
+## Interpreting the rendered PNGs
+
+- Light red strictly means "not part of any frame": it fills the margins, the labels' background, and any unused grid cells. It never appears inside a frame's rectangle unless the frame itself contains that color.
+- Without `--background`, pixels inside each frame keep the original file's alpha values. Transparent regions inside a frame therefore display as whatever background the viewer composites them over (typically white in the Read tool), and are NOT visually distinguishable from opaque pixels of that same color. To determine whether the file has transparency, rely on the `info` subcommand's alpha statistics, not on the rendered PNGs.
+- With `--background`, pixels inside each frame are opaque and show exactly how the frame composites over that color.
+- Each tile's label gives its frame index and, for animated files, its timestamp in seconds.

--- a/.claude/commands/check-unit-tests-redundancy.md
+++ b/.claude/commands/check-unit-tests-redundancy.md
@@ -15,14 +15,15 @@ Follow these steps carefully and track your progress:
 - [ ] Identify redundant tests (same behavior tested multiple times)
 - [ ] Identify tests that could be consolidated
 - [ ] Document findings in a redundancy report
+- [ ] Present the report to the user and get confirmation before removing anything
 - [ ] Remove or consolidate redundant tests
 - [ ] Update `__init__.py` files if any files were removed
 
 ## Omissions
 
 Please do NOT:
-- Run or debug any tests you create
-- Reformat any files with black
+- Run or debug any tests
+- Reformat any files; formatting is handled later through pre-commit by the debug command
 
 These steps are both handled by other slash commands.
 
@@ -58,7 +59,8 @@ These steps are both handled by other slash commands.
    - [test_name_1] and [test_name_2] could be parameterized: [reason]
    - ...
    ```
-5. **Remove or consolidate** redundant tests and fixtures:
+5. **Present the report, then remove or consolidate** redundant tests and fixtures:
+    - First show the user the redundancy report and wait for confirmation before deleting or consolidating anything
     - Delete clearly redundant tests
     - Consolidate tests that verify the same thing
     - Keep the most comprehensive version when consolidating

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -13,12 +13,11 @@ Generate a commit message for the current staged changes, then create the commit
     - `git diff --staged` to see staged changes
     - This sequencer-state check, to detect an in-progress merge, cherry-pick, revert, or rebase:
       ```bash
-      gp() { git rev-parse --git-path "$1"; }
       state=""
-      if [ -f "$(gp MERGE_HEAD)" ]; then state="merge"; fi
-      if [ -f "$(gp CHERRY_PICK_HEAD)" ]; then state="cherry-pick"; fi
-      if [ -f "$(gp REVERT_HEAD)" ]; then state="revert"; fi
-      if [ -d "$(gp rebase-merge)" ] || [ -d "$(gp rebase-apply)" ]; then state="rebase"; fi
+      if [ -f "$(git rev-parse --git-path MERGE_HEAD)" ]; then state="merge"; fi
+      if [ -f "$(git rev-parse --git-path CHERRY_PICK_HEAD)" ]; then state="cherry-pick"; fi
+      if [ -f "$(git rev-parse --git-path REVERT_HEAD)" ]; then state="revert"; fi
+      if [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; then state="rebase"; fi
       if [ -n "$state" ]; then echo "IN-PROGRESS: $state"; else echo "CLEAN"; fi
       ```
     - Do not stage additional files.
@@ -48,7 +47,8 @@ Generate a commit message for the current staged changes, then create the commit
    body="Your body text here, one long line per paragraph."
    fold -s -w 72 <<<"$body" | awk -v s="$subject" '
    BEGIN { print s; print "" }
-   { sub(/ +$/, ""); if ($0 ~ /[^ -~]/) bad = 1; if (length($0) > max) max = length($0); print }
+   /[^ -~]/ { bad = 1 }
+   { sub(/ +$/, ""); if (length > max) max = length; print }
    END {
      print ""
      sfail = 0
@@ -61,6 +61,7 @@ Generate a commit message for the current staged changes, then create the commit
    ```
    The output is the full message (subject, blank line, wrapped body) followed by a blank line and one status line per check.
    - Avoid the `!` character anywhere in this call (write `sfail == 0`, not `!sfail`); the harness escapes `!` in Bash commands, which corrupts the awk program.
+   - Do not reference awk fields by their numbered forms (a dollar sign followed by a digit) in this snippet; slash-command argument substitution replaces those tokens with the command's arguments (empty when none are passed) and silently corrupts the program. The body loop instead uses awk's implicit current record: a bare `/regex/` pattern, bare `length`, and bare `print` all operate on the whole record without naming it.
    - If any check prints `FAIL`, fix the message and re-run this step before proceeding.
    - Use the wrapped body lines verbatim as the final body text; the status lines after the final blank line are feedback, not message content. The `awk` stage strips the trailing space that `fold -s` leaves at each break point; every resulting line is 72 characters or fewer. This is a hard limit.
    - `fold` hard-splits any token longer than 72 characters (e.g., a long URL). If the body contains such a token, place it on its own line, exclude that line from wrapping, and let it exceed the limit.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -8,12 +8,23 @@ Generate a commit message for the current staged changes, then create the commit
 
 ## Steps
 
-1. **Gather context** by running these git commands in parallel:
+1. **Gather context** by running these commands in parallel:
     - `git status` to see all changed and untracked files
     - `git diff --staged` to see staged changes
+    - This sequencer-state check, to detect an in-progress merge, cherry-pick, revert, or rebase:
+      ```bash
+      gp() { git rev-parse --git-path "$1"; }
+      state=""
+      if [ -f "$(gp MERGE_HEAD)" ]; then state="merge"; fi
+      if [ -f "$(gp CHERRY_PICK_HEAD)" ]; then state="cherry-pick"; fi
+      if [ -f "$(gp REVERT_HEAD)" ]; then state="revert"; fi
+      if [ -d "$(gp rebase-merge)" ] || [ -d "$(gp rebase-apply)" ]; then state="rebase"; fi
+      if [ -n "$state" ]; then echo "IN-PROGRESS: $state"; else echo "CLEAN"; fi
+      ```
     - Do not stage additional files.
     - Stop and warn the user if there are no staged changes.
     - Stop and warn the user if you see staged changes that likely contain secrets (e.g., `.env`, credentials, etc.).
+    - Stop and warn the user if the sequencer-state check prints anything other than `CLEAN`. Git has already prepared a commit message for this operation (e.g., `Merge branch ...`, `Revert "..."` with its `This reverts commit <SHA>.` line, or a cherry-pick's original message), and committing with `-m` would silently discard it. Tell the user which operation is in progress and that the correct way to conclude it is `git merge --continue`, `git cherry-pick --continue`, `git revert --continue`, or `git rebase --continue` respectively (or plain `git commit --no-edit` for a merge), all of which preserve the prepared message. Do not generate a message or commit.
 2. **Draft the commit message** following these rules:
 
    ### Subject line
@@ -26,28 +37,35 @@ Generate a commit message for the current staged changes, then create the commit
    ### Body (only if needed for non-trivial changes)
 
     - Separate from the subject with one blank line.
-    - Wrap every line at 72 characters. This is a hard limit.
+    - Draft each paragraph as one single long line, with a blank line between paragraphs. Wrapping happens mechanically in the next step; do not wrap by hand.
     - Explain *why* the change was made, not *what* was changed (the diff shows that).
     - Use complete sentences ending with periods, each of which written using an imperative mood.
 
-   Do not include a footer or co-authorship line.
-3. **Validate the subject line** by checking its length with `awk`:
+   The entire message (subject and body) must contain only printable ASCII characters. Do not include a footer or co-authorship line.
+3. **Validate and wrap the message** in a single Bash call. These tools run without permission prompts, so this step costs the user nothing:
    ```bash
-   awk 'BEGIN { s = "Your subject line here"; if (length(s) > 50) print "FAIL: subject is " length(s) " chars (max 50)"; else print "OK: " length(s) " chars" }'
+   subject="Your subject line here"
+   body="Your body text here, one long line per paragraph."
+   fold -s -w 72 <<<"$body" | awk -v s="$subject" '
+   BEGIN { print s; print "" }
+   { sub(/ +$/, ""); if ($0 ~ /[^ -~]/) bad = 1; if (length($0) > max) max = length($0); print }
+   END {
+     print ""
+     sfail = 0
+     if (length(s) > 50) { print "FAIL: subject is " length(s) " chars (max 50)"; sfail = 1 }
+     if (s ~ /[^ -~]/) { print "FAIL: subject contains non-ASCII characters"; sfail = 1 }
+     if (sfail == 0) print "OK: subject is " length(s) " chars and ASCII-only"
+     if (bad == 1) print "FAIL: body contains non-ASCII characters"
+     else print "OK: body wrapped at 72 chars and ASCII-only (" NR " lines, longest is " max " chars)"
+   }'
    ```
-   If it exceeds 50 characters, shorten it and re-check before proceeding.
-4. **Wrap the body** (if present) using Python's `textwrap` module:
-   ```bash
-   python -c "import textwrap; print(textwrap.fill('''Your body text here.''', width=72))"
-   ```
-   Use the wrapped output as the final body text.
-5. **Present the draft** to the user by displaying the full commit message, then use the `AskUserQuestion` tool to ask "How would you like to proceed with this commit message?" with options:
-    - "Commit as-is" (description: "Create the commit with the message shown above")
-    - "Edit message" (description: "Provide feedback so I can revise the message")
-    - "Abort" (description: "Cancel the commit entirely")
-
-   If the user selects "Edit message", ask them for feedback, revise the message accordingly, then repeat from step 3 (validate, wrap, and present the updated draft again). If the user selects "Abort", stop and inform the user that the commit was cancelled.
-6. **Create the commit** using a heredoc to preserve formatting:
+   The output is the full message (subject, blank line, wrapped body) followed by a blank line and one status line per check.
+   - Avoid the `!` character anywhere in this call (write `sfail == 0`, not `!sfail`); the harness escapes `!` in Bash commands, which corrupts the awk program.
+   - If any check prints `FAIL`, fix the message and re-run this step before proceeding.
+   - Use the wrapped body lines verbatim as the final body text; the status lines after the final blank line are feedback, not message content. The `awk` stage strips the trailing space that `fold -s` leaves at each break point; every resulting line is 72 characters or fewer. This is a hard limit.
+   - `fold` hard-splits any token longer than 72 characters (e.g., a long URL). If the body contains such a token, place it on its own line, exclude that line from wrapping, and let it exceed the limit.
+   - If there is no body, drop the `fold` stage and run only the subject checks inside an awk `BEGIN` block.
+4. **Create the commit** using a heredoc to preserve formatting:
    ```bash
    git commit -m "$(cat <<'EOF'
    Subject line here (50 characters or less)
@@ -56,7 +74,7 @@ Generate a commit message for the current staged changes, then create the commit
    EOF
    )"
    ```
-7. **Verify** by running `git status` after the commit completes.
+   The step 3 output has already displayed the full message to the user. The permission prompt for `git commit` shows the exact heredoc and serves as the user's review gate: approving it creates the commit. If the user denies the prompt, treat any feedback they give as revision input, update the message accordingly, and repeat from step 3. If they deny without feedback, stop and inform the user that the commit was cancelled.
 
 ## Important Reminders
 

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,98 @@
+---
+description: Draft a pull request that strictly follows the repository template, then open it with the GitHub CLI
+---
+
+# Create a Pull Request
+
+Draft a pull request for the current branch whose body strictly follows `.github/pull_request_template.md`, then open it with `gh pr create`.
+
+This command takes two independent, optional inputs through its argument, in any order. They are unrelated: setting one has no effect on the other.
+
+- A base branch name, which is any token other than `draft`. If omitted, the base defaults to `main`.
+- The literal keyword `draft`, which opens the PR as a draft. If omitted, the PR is opened ready for review.
+
+Examples: `/create-pr` (base `main`, ready), `/create-pr develop` (base `develop`, ready), `/create-pr draft` (base `main`, draft), and `/create-pr develop draft` (base `develop`, draft).
+
+## Environment constraints
+
+- `git push` is denied in this environment, so this command cannot push the branch. The branch must already exist on the remote and be up to date. If it is not, stop and ask the user to push, then re-run.
+- `gh api` is denied. Use only the `gh pr` porcelain subcommands. Do not fall back to the REST or GraphQL API.
+- The title and body must contain only printable ASCII characters. Do not add a footer or any "Generated with" or "Co-Authored-By" line.
+
+## Steps
+
+1. **Gather context** by running these read-only commands (all run without permission prompts):
+    - `git status -sb` to read the current branch and its upstream state from the first line:
+        - `## <branch>` with no `...<remote>` segment means the branch has no upstream. Stop: tell the user to push the branch first.
+        - `...<remote> [gone]` means the upstream was deleted. Stop: tell the user to push the branch first.
+        - `...<remote> [ahead N]` or `[ahead N, behind M]` means there are unpushed local commits. Stop: tell the user to push first so the PR includes them.
+        - `...<remote>` with no `ahead`/`gone` marker means the branch is pushed and current. Proceed.
+        - If the branch is the base branch itself (e.g., `main`), stop: a PR cannot be opened from the base onto itself.
+    - `gh pr list --head <branch> --state open` to check for an existing open PR for this branch. If one exists, stop and report its number and URL rather than opening a duplicate.
+    - `git log --oneline <base>..HEAD` to see the commits the PR will contain. If this is empty, stop: there is nothing to propose.
+    - `git diff --stat <base>...HEAD` and `git diff <base>...HEAD` to understand the actual changes. Base the description and the `Changes` bullets on this diff, not on the commit messages alone.
+    - Read `.github/pull_request_template.md` so the body reproduces its exact, current section structure.
+2. **Choose and verify the title** following the template's title rules and this repository's conventions:
+    - Sentence case, no trailing period.
+    - Set the prefix from the current branch name: if it begins with `feature/`, prefix the title with `[FEATURE] `; if it begins with `bug/`, prefix it with `[BUG] `; otherwise use no prefix. Each prefix applies if and only if the branch carries the matching prefix, and these are the only two prefixes.
+    - A title may state an outcome (e.g., "[FEATURE] Add free flight simulations").
+    - The entire title, including any `[FEATURE]` or `[BUG]` prefix, must be at most 42 characters. Verify its length and ASCII-only content with a single awk call (this runs without a permission prompt, so it costs the user nothing):
+      ```bash
+      title="Your title here"
+      awk -v s="$title" 'BEGIN {
+        fail = 0
+        if (length(s) > 42) { print "FAIL: title is " length(s) " chars (max 42)"; fail = 1 }
+        if (s ~ /[^ -~]/) { print "FAIL: title contains non-ASCII characters"; fail = 1 }
+        if (fail == 0) print "OK: title is " length(s) " chars and ASCII-only"
+      }'
+      ```
+      Avoid the `!` character anywhere in this call (write `fail == 0`, not `!fail`); the harness escapes `!` in Bash commands, which corrupts the awk program. If the check prints `FAIL`, shorten the title and re-run this check before proceeding.
+3. **Draft the body** by reproducing every section heading from the template in order and replacing each placeholder with real content. Do not copy the template's instructional placeholder prose, and do not omit, rename, or reorder sections. Match the level of detail seen in this repository's substantive PRs.
+
+   Apply these writing conventions throughout the body:
+    - Do not hard-wrap. Write each paragraph and bullet as a single continuous line; this repository never hard-wraps Markdown and GitHub reflows it for display. This is the opposite of the commit-message convention, which wraps at 72 characters.
+    - Consult `docs/WRITING_STYLE.md` and follow its conventions for tone, terminology, and mechanics.
+    - Enclose every file, path, directory, module, package, class, object, function, method, attribute, and any other identifier or inline code in backticks (for example, `_transformations.py`, `OperatingPoint`, and `alpha_and_beta_from_vInf_BP1`).
+
+   Fill each section as follows:
+    - **Description**: One or two prose paragraphs describing what the change does, scaled to its magnitude. For a small change, a few sentences, noting backward compatibility when relevant (e.g., a new default that leaves existing callers unaffected). For a larger change, a fuller paragraph covering the mechanism and the scope, including anything deliberately left out of scope.
+    - **Motivation**: A genuine paragraph explaining why the change is needed and the problem it solves, never a throwaway line. For a bug fix, characterize the symptom, distinguish a numerical or incidental artifact from intended behavior, and state what behavior is left unchanged.
+    - **Relevant Issues**: Use GitHub's closing syntax: `Fixes #<n>` for a bug, `Closes #<n>` for a feature. Link only genuinely related issues. If there are none, write `None.`
+    - **Changes**: The most detailed section. One bullet per logical change. Name the specific modules, classes, functions, and methods touched (in backticks, per the conventions above), and state precisely what changed in each. Include quantitative results where they apply. Aim for roughly 3 to 5 bullets for a minor change and 8 to 12 for a moderate or major one. Be concrete; avoid vague bullets like "fixed a bug".
+    - **Dependency Updates**: List any new or version-changed runtime or dev dependencies with their constraints, derived from changes to `requirements*.txt`, `setup.cfg`, or `pyproject.toml`. If none changed, write `None.`
+    - **Change Magnitude**: Choose exactly one of Major, Moderate, or Minor by the nature of the change, not its line count. Major is significant new functionality, a behavior change, or broad impact. Moderate is a medium feature or refactor without large-scale impact (even a large refactor that preserves behavior is Moderate). Minor is a bug fix, small enhancement, or documentation update. Keep only the chosen bolded line and its description; delete the other two lines and the instruction sentence.
+    - **Checklist**: Reproduce every item. Mark `[x]` only for items that are genuinely satisfied or not applicable; never blanket-check. Verify each locally checkable item against the actual state (for example, formatting, docstrings, type hints, and, only if you actually ran them, the local test suite). Always leave unchecked (`[ ]`) every item that asserts a GitHub action or the ReadTheDocs build check passes (the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` actions; the `mypy` action; the `tests` actions; and the ReadTheDocs build check). Those workflows are not triggered until the PR is created, so however certain you are that they will pass, they have not actually run yet and the box stays empty. If the listed set of actions does not match the repository's actual workflows, edit the affected line to match reality, but still leave it unchecked.
+4. **Choose labels, assignee, and draft status**:
+    - Read `.github/labels.yml`, the canonical label set, and pick the applicable labels from it. If the title carries a `[FEATURE]` or `[BUG]` prefix, include the matching `feature` or `bug` label accordingly.
+    - Always assign the PR to the current user with `--assignee "@me"`. The `@me` token resolves to whoever `gh` is authenticated as.
+    - Do not attach a milestone or a project, and do not request any reviewers. Never pass `--milestone`, `--project`, or `--reviewer`.
+    - Open the PR as a draft only if the argument requested it; otherwise open it ready for review.
+5. **Present the draft** in your reply: the chosen base branch, title, full body, selected labels, assignee, and whether it is a draft. This is the user's review opportunity.
+6. **Open the PR** with a single command. Provide the body on stdin via a quoted heredoc so its backticks and markdown are preserved literally and the permission prompt shows the user the exact body as a final review gate:
+   ```bash
+   gh pr create \
+     --base main \
+     --title "Your title here" \
+     --assignee "@me" \
+     --label "label-one" --label "label-two" \
+     --body-file - <<'EOF'
+   # Description
+
+   ...full body following the template...
+   EOF
+   ```
+    - Repeat `--label` once per label. Add `--draft` if requested. The head branch defaults to the current branch, so `--head` is not needed. Do not add `--milestone`, `--project`, or `--reviewer`.
+    - The `gh pr create` permission prompt is the final gate. If the user denies it, treat any feedback as revision input, update the draft, and repeat from step 5. If they deny without feedback, stop and report that no PR was opened.
+7. **Confirm** by reporting the new PR's URL, which `gh pr create` prints on success.
+
+## Important Reminders
+
+- Never push, and never use `--no-verify` or any flag that bypasses checks. If the branch is not pushed and current, stop and ask the user to push.
+- Never use `gh api`; stick to the `gh pr` porcelain.
+- Follow `.github/pull_request_template.md` exactly: every section, in order, with real content.
+- Set the title prefix from the branch name (`feature/` gives `[FEATURE]`, `bug/` gives `[BUG]`, otherwise none), and keep the whole title, prefix included, to at most 42 characters, verified with the awk check.
+- Never check a checklist item that asserts a GitHub action or the ReadTheDocs build passes; those run only after the PR is created, so they have not run yet. Leave every such item `[ ]`, no matter how certain the outcome.
+- Keep the title and body ASCII-only, with no footer or co-authorship line.
+- The body is Markdown: do not hard-wrap it, follow `docs/WRITING_STYLE.md`, and backtick every identifier, path, and inline code span.
+- Do not open a PR from the base branch, and do not open a duplicate when one already exists for the branch.
+- Do not attach a milestone or project, and do not request reviewers. Always self-assign with `--assignee "@me"`, which targets whoever `gh` is authenticated as.

--- a/.claude/commands/debug-unit-tests-and-fixtures.md
+++ b/.claude/commands/debug-unit-tests-and-fixtures.md
@@ -21,7 +21,7 @@ If there's ANY possibility you've found a real bug based on the source code logi
 Follow these steps carefully and track your progress:
 
 - [ ] Identify which test files correspond to `$ARGUMENTS`
-- [ ] Run the relevant tests and capture output
+- [ ] Run the relevant tests with unittest, per `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`, and read the output
 - [ ] For each failure, analyze the source code logic
 - [ ] Check documentation/docstrings for intended behavior
 - [ ] Determine if failure indicates test error or source bug
@@ -29,16 +29,17 @@ Follow these steps carefully and track your progress:
 - [ ] STOP and alert user if potential source bug found
 - [ ] Verify all tests pass after fixes
 - [ ] Document any assumptions or edge cases discovered
-- [ ] If you've modified any modules, reformat them using black
+- [ ] If you've modified any modules, reformat them through pre-commit (see `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`)
 
 ## Detailed Steps
 
 1. **Identify test files** for `$ARGUMENTS`:
     - Find corresponding test files in `tests/unit/`
     - Note any fixture dependencies
-2. **Run initial tests**:
-    - Capture and analyze the full output
-    - Note all failures and their error messages
+2. **Run initial tests** following `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md` (Ptera Software uses `unittest`, not pytest):
+    - Run the module's tests with `python -u -m unittest tests.unit.test_module_name -v`, or a single test with `python -u -m unittest tests.unit.test_module_name.TestClass.test_method -v`. The `-u` flag keeps output streaming.
+    - Let the output stream directly into the conversation; never pipe it through `tail`, `head`, `grep`, or any other filter.
+    - Capture and analyze the full output, noting all failures and their error messages.
 3. **For EACH test failure**:
    a. **Read the failing test carefully**:
       - Understand what the test is trying to verify
@@ -87,7 +88,7 @@ Follow these steps carefully and track your progress:
     - Run all tests for the module
     - Confirm all tests pass
 6. **Reformatting**:
-    - If you've modified any files, run black to reformat them
+    - If you've modified any files, reformat them through pre-commit, never a bare formatter: `pre-commit run --files <paths>`. This runs black, isort, and docformatter together with the exact versions CI uses, per `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`.
 
 ## Analysis Guidelines
 
@@ -131,4 +132,4 @@ Before considering debugging complete:
 - [ ] All potential bugs have been flagged to user
 - [ ] Changes are documented with reasoning
 - [ ] Edge cases discovered are documented
-- [ ] If any modules have been updated, they've also been reformatted using black
+- [ ] If any modules have been updated, they've been reformatted through pre-commit (`pre-commit run --files <paths>`)

--- a/.claude/commands/delete-unused-fixtures.md
+++ b/.claude/commands/delete-unused-fixtures.md
@@ -1,94 +1,55 @@
 ---
-description: Find and delete unused fixtures from a specified fixture module
+description: Find and delete unused fixtures and dead setUp attributes across the whole test suite with scripts/find_unused_fixtures.py
 ---
 
 # Delete Unused Fixtures
 
-Find and delete unused fixtures for `$ARGUMENTS`.
+Find and remove unused test fixtures and dead `setUp`/`setUpClass` attributes across the entire test suite, driving `scripts/find_unused_fixtures.py`. This command takes no argument: the script scans the whole suite at once (both `tests/unit/` and `tests/integration/`), which is necessary because a fixture defined in one module is routinely used by tests in another.
 
-## Important: Cross-Module Usage
+## What the script detects
 
-Fixtures may be used by tests in ANY module, not just the corresponding test file. For example, `wing_movement.py` has fixtures in `wing_movement_fixtures.py` and tests in `test_wing_movement.py`. However, fixtures from `wing_movement_fixtures.py` might also be used by `test_airplane_movement.py`. You MUST search the entire `tests/` directory for usage.
+The script parses the suite with the `ast` module instead of grepping for names, so it resolves each call to the specific fixture definition it refers to and does not raise false matches on coincidentally shared names. It reports three categories:
 
-## Progress Tracking
+- **Directly unused fixtures**: `make_*` fixture functions never called anywhere under `tests/`.
+- **Transitively unused fixtures**: fixtures called only by other unused fixtures. Removing the directly unused ones can expose these, so the analysis iterates to a fixed point.
+- **Dead `setUp`/`setUpClass` attributes**: attributes assigned in a test class's `setUp` or `setUpClass` that no test method, and no other `setUp` attribute, ever reads.
 
-Follow these steps carefully and track your progress:
-- [ ] Read the fixture file for the module specified in `$ARGUMENTS`
-- [ ] Extract all fixture function names (functions that don't start with `_`)
-- [ ] For each fixture, search the entire `tests/` directory for usage
-- [ ] Identify fixtures with zero usages (excluding their own definition)
-- [ ] Generate an unused fixtures report
-- [ ] Delete unused fixtures from the file
-- [ ] Update imports in `tests/unit/fixtures/__init__.py` if needed
+## Why deletion is safe for `__init__.py`
 
-## Omissions
+Both `tests/unit/fixtures/__init__.py` and `tests/integration/fixtures/__init__.py` import fixture *modules* (`import tests.unit.fixtures.foo_fixtures`), not individual fixture functions. Deleting a fixture function from a module therefore never breaks an `__init__.py` import, and you do not edit any `__init__.py` after deleting fixtures. The only reason to touch an `__init__.py` would be to drop an entire fixture module that has become empty, which this command does not do.
 
-Please do NOT:
-- Run or debug any tests you create
-- Reformat any files with black
+## Environment constraints
 
-These steps are both handled by other slash commands.
+- The script's verification modes run the full test suite under `coverage` (pinned in `requirements_dev.txt`). This takes several minutes. Always invoke the script with `python -u` so its output streams, and never pipe the run through `tail`, `head`, `grep`, or any other filter, per `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`.
+- The script never modifies a file until you pass `--delete-verified`. The plain run and `--verify` leave every file untouched.
 
-## Detailed Steps
+## Steps
 
-1. **Read the fixture file** for the module specified in `$ARGUMENTS`:
-    - Note all public function names (fixture functions)
-    - Ignore private functions (those starting with `_`)
-2. **For each fixture function**, search for usage:
-   Use the Grep tool to search the entire `tests/` directory:
+1. **Report.** Run the script with no flags to list candidates without changing anything:
+   ```bash
+   python -u scripts/find_unused_fixtures.py
    ```
-   pattern: fixture_function_name
-   path: tests/
-   output_mode: files_with_matches
+   It prints the three categories above with each candidate's file and line, then a summary count. It exits non-zero whenever any candidate is found; that is expected and is not an error.
+2. **Present the candidates** to the user: the directly unused fixtures, the transitively unused fixtures, and the dead `setUp` attributes, each with its location. If the report is empty, report that the suite is clean and stop.
+3. **Optionally preview the verification.** If the user wants to see which candidates survive verification before authorizing any deletion, run the dry-run verification, which deletes each candidate in memory, runs the full suite under coverage, checks that all tests still pass, that the set of discoverable test IDs is unchanged, and that coverage does not drop, then restores every file:
+   ```bash
+   python -u scripts/find_unused_fixtures.py --verify
    ```
-
-   A fixture is USED if it appears in any file OTHER than:
-    - Its own fixture file (the definition)
-    - `__init__.py` files (just imports)
-3. **Classify each fixture**:
-    - **Used**: Found in at least one test file
-    - **Unused**: Only found in its definition and/or `__init__.py` imports
-4. **Generate an unused fixtures report**:
+   Report which candidates it confirmed and which it flagged as false positives (a candidate whose name surfaces in a failing traceback after deletion).
+4. **Delete, on confirmation.** Only after the user confirms, run the deletion pass. It re-runs the same verification, deletes only the candidates that pass, excludes any false positives, and restores files if verification fails outright:
+   ```bash
+   python -u scripts/find_unused_fixtures.py --delete-verified
    ```
-   UNUSED FIXTURES REPORT for [fixture_file]
-
-   UNUSED (will be deleted):
-   - [fixture_name]: no usages found in test files
-
-   USED (keeping):
-   - [fixture_name]: used in [list of test files]
-
-   SUMMARY:
-   - Total fixtures: [N]
-   - Used: [N]
-   - Unused: [N]
+5. **Reformat the touched files** through pre-commit, never a bare formatter, per `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`. Find the modified files with `git status -sb`, then:
+   ```bash
+   pre-commit run --files <each modified fixture or test file>
    ```
-5. **Delete unused fixtures**:
-    - Remove the function definitions from the fixture file
-    - Remove any imports that were only used by deleted fixtures
-    - Keep the file structure clean (no orphaned blank lines)
-6. **Update `tests/unit/fixtures/__init__.py`**:
-    - Remove imports for deleted fixtures
-    - Update the module docstring if needed
+6. **Re-scan for newly exposed candidates.** Removing a fixture can leave another one unused. The deletion pass reports whether new candidates were exposed; if so, repeat from step 1 until a report comes back clean.
 
-## Efficiency Tips
+## Important Reminders
 
-- Use Grep with `output_mode: files_with_matches` for fast searching
-- Search for multiple fixtures in parallel when possible
-- Don't read test files unless you need to verify ambiguous matches
-
-## Error Handling
-
-- If a fixture name is common (e.g., `valid_wing`), verify the grep matches are actual usages, not coincidental string matches
-- If uncertain whether a fixture is used, keep it and flag for manual review
-- If the fixture file doesn't exist, report the error and stop
-
-## Quality Checklist
-
-Before finalizing:
-- [ ] Searched the ENTIRE `tests/` directory, not just corresponding test file
-- [ ] Verified each "unused" fixture truly has no usages
-- [ ] Generated the unused fixtures report
-- [ ] Removed only unused fixtures
-- [ ] Updated `__init__.py` imports
-- [ ] No useful fixtures were accidentally deleted
+- This command operates on the whole suite and takes no argument; do not try to scope it to a single module.
+- Never edit an `__init__.py` after deleting fixtures: the fixture packages import modules, not individual functions, so a deleted fixture cannot break an import.
+- Always show the user the report, and the verification result if you ran one, before any deletion. The script only mutates files under `--delete-verified`.
+- Run the script with `python -u` and never pipe it through a filter; the verification suite can run for minutes and its output must stay visible.
+- Reformat modified files with `pre-commit run --files`, never a bare formatter.

--- a/.claude/commands/make-unit-tests-and-fixtures.md
+++ b/.claude/commands/make-unit-tests-and-fixtures.md
@@ -13,18 +13,19 @@ Follow these steps carefully and track your progress:
 - [ ] Understand the structure of each public class and function
 - [ ] Search the codebase for other relevant files
 - [ ] Read and understand any relevant files found
+- [ ] Read the style docs: `docs/CODE_STYLE.md`, `docs/TYPE_HINT_AND_DOCSTRING_STYLE.md`, and `docs/WRITING_STYLE.md`
 - [ ] Read `tests/unit/test_wing_cross_section_movement.py` for examples of test patterns
 - [ ] Read `tests/unit/fixtures/wing_cross_section_movement_fixtures.py` for examples of fixture patterns
 - [ ] Understand how `movements/wing_cross_section_movement.py` informs design of example tests and fixtures
 - [ ] Create comprehensive tests and fixtures for each public class/function in `$ARGUMENTS`
-- [ ] Review the tests and fixtures to verify they follow style guidelines
+- [ ] Review the tests and fixtures against `docs/CODE_STYLE.md`, `docs/TYPE_HINT_AND_DOCSTRING_STYLE.md`, and `docs/WRITING_STYLE.md`
 - [ ] Update `tests/unit/__init__.py` and `tests/unit/fixtures/__init__.py` with any new files or edited docstrings
 
 ## Omissions
 
 Please do NOT:
 - Run or debug any tests you create
-- Reformat any files with black
+- Reformat any files; formatting is handled later through pre-commit by the debug command
 
 These steps are both handled by other slash commands.
 
@@ -34,7 +35,8 @@ These steps are both handled by other slash commands.
 2. **Understand the structure** of each class and function.
 3. **Search the codebase** for other relevant files.
 4. **If you find any relevant files**, read and understand those as well.
-5. **Study existing test and fixture patterns**:
+5. **Study the project's conventions and existing patterns**:
+    - Read the style docs before writing anything: `docs/CODE_STYLE.md` for code, `docs/TYPE_HINT_AND_DOCSTRING_STYLE.md` for type hints and docstrings, and `docs/WRITING_STYLE.md` for prose in docstrings and comments
     - Read `tests/unit/test_wing_cross_section_movement.py`
     - Read `tests/unit/fixtures/wing_cross_section_movement_fixtures.py`
     - Understand the patterns for creating fixtures and unit tests
@@ -57,8 +59,8 @@ These steps are both handled by other slash commands.
    d. **Create the tests** (but don't run them - we will check redundancy and debug later):
    e. **Review for style compliance**:
       - Re-read the fixtures and tests you just wrote
-      - Check if they match the guidance in your docs on code and writing styles
-      - Verify they match the unit testing patterns
+      - Check them against `docs/CODE_STYLE.md`, `docs/TYPE_HINT_AND_DOCSTRING_STYLE.md`, and `docs/WRITING_STYLE.md`
+      - Verify they match the existing unit testing patterns
       - Polish any style issues found
    f. **Repeat these sub-steps** for all remaining classes and functions within `$ARGUMENTS`
 8. **Read through `tests/unit/__init__.py` and `tests/unit/fixtures/__init__.py`** and update them with any new files or any changes to the docstrings of existing modules. Also add to or update the import list. Make sure both the import lists and the docstrings list modules in alphabetical order!

--- a/.claude/commands/open-issue.md
+++ b/.claude/commands/open-issue.md
@@ -1,0 +1,76 @@
+---
+description: Draft a GitHub issue from the conversation following this repository's streamlined issue conventions, then open it with the GitHub CLI
+---
+
+# Open an Issue
+
+Draft a GitHub issue for this repository from the current conversation and the command's argument, then open it with `gh issue create`. The issue follows this repository's lived, streamlined issue conventions, which are a maintainer-oriented adaptation of the templates in `.github/ISSUE_TEMPLATE/`, not the verbose template forms.
+
+Arguments: $ARGUMENTS
+
+The argument is a short description of what the issue is about. If its first token is the keyword `gfi`, mark the issue as a good first issue (add the `good_first_issue` label and a "Hints for New Contributors" section), and treat the rest of the argument as the description. The command also draws on the current conversation for context.
+
+## Environment constraints
+
+- `gh api` is denied. Use only the `gh issue` porcelain (`gh issue list`, `gh issue view`, `gh issue create`).
+- The title and body must contain only printable ASCII characters. Do not add a footer or any "Generated with" or "Co-Authored-By" line.
+- No git state is needed: an issue is not tied to a branch or commit, so do not run push or diff commands and do not require a pushed branch.
+
+## Steps
+
+1. **Determine the issue type and gather its substance** from the conversation and the argument:
+    - Decide whether this is a bug or a non-bug issue (feature, maintenance, performance, or a question). A bug reports incorrect behavior; everything else is a problem statement or proposal.
+    - Gather the concrete substance: what the problem is, where it lives (specific files, functions, or classes), and the proposed fix or next step. Draw this from the conversation and the argument, supplementing only with light, read-only lookups (for example, confirming a file path or function name) when needed to make the issue precise.
+    - If the available context is too thin to write a specific, accurate issue, stop and ask the user for the missing details (for a bug, the symptom and where it occurs; for a feature or task, the problem and the proposed approach). Never fabricate an issue.
+2. **Check for duplicates** with the pre-allowed read-only commands (no permission prompts):
+    - `gh issue list --search "<keywords>" --state all --limit 20 --json number,title,state,url` to find open or closed issues on the same topic.
+    - If any look like plausible duplicates, list them (number, state, title, and URL) in your draft and ask the user whether to proceed before creating anything.
+3. **Choose the title** following the repository's issue conventions:
+    - Sentence case, no trailing period. The title may contain backticked identifiers, and there is no length limit for issue titles.
+    - Set the prefix from the issue type and label: if it warrants the `bug` label, prefix with `[BUG] `; if it warrants the `feature` label, prefix with `[FEATURE] `; otherwise use no prefix. Issues have no branch, so the prefix is label-driven, unlike pull request titles.
+4. **Draft the body** following the lived, streamlined convention. Do not copy the verbose `.github/ISSUE_TEMPLATE/` placeholder prose, the end-user-reporter sections (`Reproduction`, `Screenshots`, `Desktop`), or `Alternative Solutions`. Keep each section to a few concise sentences.
+
+   Apply these writing conventions throughout the body:
+    - Do not hard-wrap. Write each paragraph and bullet as a single continuous line; GitHub reflows Markdown for display.
+    - Follow `docs/WRITING_STYLE.md` for tone, terminology, and mechanics.
+    - Backtick every file, path, module, class, function, method, and inline code span.
+
+   Use this structure:
+    - For a **bug**:
+        - `# Bug Description`: a concise description of the incorrect behavior, followed by a `**Location(s):**` line naming the affected files in backticks.
+        - `## Expected Behavior`: what should happen instead.
+        - `## Additional Context` (optional): extra notes, including any `TODO`, `TEST`, or `TEMP` comment that references the issue.
+    - For a **non-bug** (feature, maintenance, performance, or question):
+        - `# Problem Statement`: a concise description of the problem or opportunity, followed by a `**Location(s):**` line naming the affected files in backticks.
+        - `## Proposed Solution`: the fix or next step, as a short paragraph or a numbered list.
+        - `## Additional Context` (optional): extra notes, including any referencing `TODO`, `TEST`, or `TEMP` comment.
+    - If the `gfi` keyword was given, append a `## Hints for New Contributors` section: remind the contributor to read `CONTRIBUTING.md` and set up the development environment, point to the specific files and any relevant docs (for example, `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md` for running tests, or the convention docs when relevant), give a short numbered plan, and remind them to run the tests afterward.
+5. **Choose labels and assignment**:
+    - Read `.github/labels.yml`, the canonical label set, and pick the applicable labels from it. Include `bug` for a bug or `feature` for a feature so the label matches any title prefix, and add `maintenance`, `question`, `performance`, and so on as the topic warrants, matching the combinations seen in existing issues (for example, `maintenance` with `question` for an open-ended investigation).
+    - If the `gfi` keyword was given, include the `good_first_issue` label.
+    - Never assign the issue to anyone; do not pass `--assignee`. Leave it unassigned so it can be picked up, which matters especially for good first issues.
+    - Do not attach a milestone or project. Never pass `--milestone` or `--project`.
+6. **Present the draft** in your reply: the title, the full body, the selected labels, any possible duplicates found, and the fact that the issue will be unassigned. This is the user's review opportunity.
+7. **Open the issue** with a single command, providing the body on stdin via a quoted heredoc so the permission prompt shows the exact body as the final review gate:
+   ```bash
+   gh issue create \
+     --title "Your title here" \
+     --label "label-one" --label "label-two" \
+     --body-file - <<'EOF'
+   # Problem Statement
+
+   ...full body following the convention...
+   EOF
+   ```
+    - Repeat `--label` once per label. Do not pass `--assignee`, `--milestone`, or `--project`.
+    - The `gh issue create` permission prompt is the final gate. If the user denies it, treat any feedback as revision input, update the draft, and repeat from step 6. If they deny without feedback, stop and report that no issue was opened.
+8. **Confirm** by reporting the new issue's URL, which `gh issue create` prints on success.
+
+## Important Reminders
+
+- Draw the issue's substance from the conversation and the argument; never fabricate. If context is too thin, stop and ask for specifics.
+- Follow the lived, streamlined convention, not the verbose `.github/ISSUE_TEMPLATE/` forms: include the `**Location(s):**` line, and omit `Reproduction`, `Screenshots`, `Desktop`, and `Alternative Solutions`.
+- Keep the title and body ASCII-only and unwrapped, with backticked identifiers and no footer.
+- Never use `gh api`; use only the `gh issue` porcelain.
+- Never assign the issue, and never attach a milestone or project.
+- Add the `good_first_issue` label and a `## Hints for New Contributors` section only when the `gfi` keyword is given.

--- a/.claude/commands/update-pr.md
+++ b/.claude/commands/update-pr.md
@@ -1,0 +1,62 @@
+---
+description: Refresh an existing pull request's title, body, and labels to reflect new commits, following the same template and conventions as create-pr
+---
+
+# Update a Pull Request
+
+Refresh the open pull request for the current branch so its title, body, and labels reflect the commits added (or undone) since it was last written, then apply the changes with `gh pr edit`. This is an incremental refresh: it preserves human-authored content and changes only what the new or removed work requires.
+
+This command takes no arguments. It operates on the single open PR whose head is the current branch, and it leaves that PR's base branch and draft status unchanged.
+
+## Shared conventions
+
+Read `.claude/commands/create-pr.md` and apply every convention it defines: the `.github/pull_request_template.md` section structure and per-section detail level, the body writing conventions (no hard-wrapping, `docs/WRITING_STYLE.md`, backticking every identifier, path, and inline code span), the title rules (branch-derived `[FEATURE]`/`[BUG]` prefix and the 42-character limit with its awk check), label selection from `.github/labels.yml`, the checklist rule (never check an item that asserts a GitHub action or the ReadTheDocs build passes), and the environment constraints (an already-pushed branch; only the `gh pr` porcelain and never `gh api`; an ASCII-only title and body with no footer; and never attaching a milestone or project or requesting reviewers). Only the differences specific to updating an existing PR are spelled out below.
+
+## Environment constraints
+
+- `git push` is denied, so this command cannot push. The new commits must already be on the remote; if the branch has unpushed commits, stop and ask the user to push, then re-run.
+- `gh api` is denied. Use only the `gh pr` porcelain (`gh pr view`, `gh pr edit`).
+
+## Steps
+
+1. **Locate the PR and gather context** with these read-only commands (all run without permission prompts):
+    - `git status -sb` to confirm the branch is pushed and current, using the same first-line interpretation as create-pr. If the branch has no upstream, a `[gone]` upstream, or any `[ahead N]` marker, stop and tell the user to push first so the PR reflects the new commits.
+    - `gh pr list --head <branch> --state open` to find the open PR. If there is none, stop and tell the user to run `/create-pr` first. If there is more than one, stop and report them rather than guessing.
+    - `gh pr view <number> --json number,url,title,body,labels,baseRefName,isDraft` to read the PR's current state. Use `baseRefName` as the base for all diffs; do not assume `main`.
+    - `git log --oneline <base>..HEAD`, `git diff --stat <base>...HEAD`, and `git diff <base>...HEAD` to see the full, current change set the PR should describe.
+    - Read `.github/pull_request_template.md` and `.github/labels.yml` so the refreshed body matches the current template and the labels come from the canonical set.
+2. **Diff the PR against reality.** Compare the existing body's `Description` and `Changes` against the current diff to identify (a) new changes not yet described, (b) described changes that have since been undone or reverted and no longer appear in the diff, and (c) prose that is now inaccurate or has formatting or template defects.
+3. **Refresh the body incrementally**, preserving human-authored content and changing only what is required:
+    - Keep the author's `Motivation`, `Relevant Issues`, manually written `Description` prose, and the current checklist marks, except where the edits below require a change.
+    - Add `Changes` bullets for new work, and remove bullets describing work that has been undone. Extend the `Description` to cover genuinely new scope, and trim it where scope was removed.
+    - Update `Dependency Updates` if dependencies were added, changed, or removed, and re-evaluate `Change Magnitude` against the new total change set, changing the selected line only if the magnitude genuinely changed.
+    - Re-evaluate the checklist against the new state: preserve existing marks, add any template items that are missing, uncheck any item the new work makes no longer satisfied, reconsider items that were not applicable but now are (for example, package type hints once package code is touched), and uncheck any item asserting a GitHub action or the ReadTheDocs build passes.
+    - Correct typos and formatting defects anywhere in the body, including removing hard wraps, fixing backticking, and repairing any drift from the template's structure, even in otherwise-preserved sections.
+4. **Re-evaluate the title and labels** against the new change set:
+    - Recompute the title prefix from the branch name and confirm the title still fits and still describes the change set. Change it only if the new work makes it inaccurate or it breaks the rules, and re-run the 42-character and ASCII awk check from create-pr on any new title.
+    - Recompute the applicable labels from `.github/labels.yml`. Plan to add newly applicable labels and remove labels that no longer apply, keeping them consistent with any `[FEATURE]`/`[BUG]` title prefix.
+5. **Present the planned update** in your reply: the PR number and URL, the old and new title (or "unchanged"), the labels to add and remove (or "unchanged"), and the full new body. This is the user's review opportunity. If nothing needs to change, say so and stop without editing.
+6. **Apply the update** with `gh pr edit`. Provide the body on stdin via a quoted heredoc so the permission prompt shows the exact new body as the final review gate:
+   ```bash
+   gh pr edit <number> \
+     --title "Updated title here" \
+     --add-label "new-label" \
+     --remove-label "stale-label" \
+     --body-file - <<'EOF'
+   # Description
+
+   ...full refreshed body...
+   EOF
+   ```
+    - Include `--title` only if the title changed. Repeat `--add-label` and `--remove-label` once per label, and omit them when labels are unchanged. Do not pass `--milestone`, `--project`, `--reviewer`, `--base`, or any draft flag; this command leaves the base branch and draft status as they are.
+    - The `gh pr edit` permission prompt is the final gate. If the user denies it, treat any feedback as revision input, update the plan, and repeat from step 5. If they deny without feedback, stop and report that the PR was not changed.
+7. **Confirm** by reporting the PR's URL.
+
+## Important Reminders
+
+- This command edits an existing PR; if none exists for the branch, stop and direct the user to `/create-pr`.
+- Preserve human-authored content by default; change prose only to add new scope, remove undone scope, or fix typos, formatting (including hard wraps), and template drift.
+- Never push; if the new commits are not on the remote, stop and ask the user to push.
+- Never use `gh api`; use only the `gh pr` porcelain.
+- Apply all create-pr conventions to the refreshed title, body, and labels: ASCII-only with no hard-wrapping, branch-based prefix and the 42-character title limit, backticked identifiers, no checked action or ReadTheDocs checklist items, and no milestone, project, or reviewer changes.
+- Leave the PR's base branch and draft status unchanged.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,31 +11,9 @@ assignees: ''
 
 Please provide a clear and concise description of what the bug is.
 
-## Reproduction
-
-Please provide the steps to reproduce the behavior.
-
-For example:
-
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
-
 ## Expected Behavior
 
 Please provide a clear and concise description of what you expected to happen.
-
-## Screenshots
-
-If applicable, add screenshots to help explain your problem.
-
-## Desktop
-
-Please complete the following information.
-
-- OS: ''
-- Version: ''
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea for this project.
 title: "[FEATURE]"
-labels: enhancement
+labels: feature
 assignees: ''
 
 ---
@@ -14,10 +14,6 @@ Please describe what problem you want to be fixed with a new feature.
 ## Proposed Solution
 
 Please describe the solution you'd like implemented.
-
-## Alternative Solutions
-
-Please provide a clear and concise description of any alternative solutions or features you've considered.
 
 ## Additional Context
 

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,59 @@
+# Single source of truth for this repository's issue and pull request labels.
+#
+# The label-sync workflow (.github/workflows/label-sync.yml) reconciles the
+# repository to match this file on every push to main that touches it. Because
+# that workflow runs with delete-other-labels enabled, any label not listed
+# here is deleted. Add or edit entries here rather than in the GitHub UI.
+#
+# To rename a label without losing the issues already tagged with it, keep the
+# new name under "name" and list the previous name under "aliases".
+
+- name: bug
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: duplicate
+  color: "cfd3d7"
+  description: "This already exists"
+
+- name: feature
+  color: "a2eeef"
+  description: "New feature or request"
+  aliases: ["enhancement"]
+
+- name: good_first_issue
+  color: "7057ff"
+  description: "Good for newcomers"
+
+- name: maintenance
+  color: "0075ca"
+  description: "Improvements or additions to documentation, testing, robustness, or tooling"
+
+- name: question
+  color: "d876e3"
+  description: "Further information is needed"
+
+- name: invalid
+  color: "e4e669"
+  description: "This doesn't seem right"
+
+- name: wont_fix
+  color: "ffffff"
+  description: "This will not be worked on"
+  aliases: ["wontfix"]
+
+- name: dependencies
+  color: "0366d6"
+  description: "Updates to dependencies"
+
+- name: performance
+  color: "1e350e"
+  description: "An opportunity to improve performance"
+
+- name: pre_commit
+  color: "ba9f5b"
+  description: "Updates to pre-commit code"
+
+- name: github_actions
+  color: "c76012"
+  description: "Updates to GitHub Actions code"

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,32 @@
+name: label-sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/label-sync.yml
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Preview changes without applying them"
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  label-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: true
+          dry-run: ${{ inputs.dry-run || false }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,15 @@ Requires Python 3.11, but active development is done in 3.13
         - `codespell.yml`
         - `docformatter.yml`
         - `isort.yml`
+        - `label-sync.yml`
         - `mypy.yml`
         - `pre-commit-hooks.yml`
+        - `publish.yml`
         - `tests.yml`
+    - `CODEOWNERS`
+    - `dependabot.yml`
+    - `FUNDING.yml`
+    - `labels.yml`
     - `pull_request_template.md`
 - `.venv/`: Directory for the Python virtual environment, configured for the host machine's OS (not included in version control)
 - `.venv-wsl/`: Directory for the Python virtual environment configured for a WSL OS (not included in version control, may be missing if host machine doesn't use WSL for development)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,9 @@ Requires Python 3.11, but active development is done in 3.13
     - `trim.py`: Trim analysis functionality
     - `unsteady_ring_vortex_lattice_method.py`: Unsteady ring UVLM solver
 - `scripts/`: Directory with maintenance and tooling scripts
+    - `analyze_webp.py`: Renders WebP frames to PNG files for inspection (backs the `analyze-webp` slash command)
     - `check_ascii_only.py`: Pre-commit hook script that flags non-ASCII characters in text files
+    - `find_unused_fixtures.py`: Finds and optionally deletes unused fixtures and dead `setUp` attributes across the test suite (backs the `delete-unused-fixtures` slash command)
 - `tests/`: Directory with unit and integration tests
     - `integration/`: Integration tests for combined functionality
         - `fixtures/`: Fixtures for integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ There are three main ways you can contribute:
 3. [**Contribute code**](#contributing-code)
     - Submit changes that add new features, fix bugs, improve performance, or enhance documentation.
     - Code contributions can address your own ideas or work on existing open issues.
-    - If you find an issue labeled `good first issue` that you want to work on, **comment on the issue to claim it** before starting work. This prevents duplicate efforts.
+    - If you find an issue labeled `good_first_issue` that you want to work on, **comment on the issue to claim it** before starting work. This prevents duplicate efforts.
 
 ---
 
@@ -61,7 +61,7 @@ For feature requests:
 Ptera Software now uses GitHub Flow to manage code contributions. If this is new to you, it's a good idea to read through [this guide](https://docs.github.com/en/get-started/using-github/github-flow) first. Once you understand the process, here's how to implement it:
 
 1. **Choose what to work on**
-    - Look for issues labeled `good first issue`.
+    - Look for issues labeled `good_first_issue`.
         - If you want to work on one, check that no one else has already commented claiming it. If unclaimed, comment on the issue to claim it and a maintainer will then "assign" the issue to you.
         - If you want to work on a claimed issue that hasn't been updated in a while, write a comment asking if the user who originally claimed it is still actively working on it.
     - If you have your own idea, search the issues to ensure it hasn't already been proposed.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@ black
 build
 codecov
 codespell
+coverage
 docformatter
 isort
 mypy

--- a/scripts/analyze_webp.py
+++ b/scripts/analyze_webp.py
@@ -1,0 +1,368 @@
+"""Analyze a static or animated WebP file by rendering its frames to PNG.
+
+This helper backs the analyze-webp slash command, but it can also be run by
+hand. It decodes a WebP file with the webp package's animation decoder (which
+treats a static image as a one-frame animation), reports metadata including
+transparency statistics, and renders frames to PNG files for inspection.
+
+Rendered PNGs composite an opaque light red backdrop everywhere outside the
+frames themselves, so light red strictly means "not part of any frame." By
+default, pixels inside each frame keep their original alpha values, which means
+transparent regions inside a frame display as whatever background the PNG
+viewer uses. Check the info subcommand's alpha statistics to determine whether
+a file has transparency. The sheet and frames subcommands also accept a
+background color over which to composite the pixels inside each frame, which
+shows how the frames would look against that background.
+"""
+
+import argparse
+import io
+import math
+import sys
+import tempfile
+from pathlib import Path
+
+import matplotlib.image as mpimg
+import numpy as np
+import webp
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.colors import to_rgb
+from matplotlib.figure import Figure
+
+# The backdrop marks every pixel that is not part of a frame. Light red is used
+# because it is unlikely to appear in real rendered output, so it is visually
+# unambiguous.
+BACKDROP_RGB = np.array([1.0, 0.815, 0.815], dtype=float)
+
+DPI = 110.0
+
+# At this module's DPI constant, this width makes a default 9-tile sheet of 4:3
+# frames render at about 2000 x 1600 pixels, which fits within the resolution
+# at which current Claude models view images natively (2576 pixels on the long
+# edge and roughly 3.6 megapixels) with no downscaling.
+SHEET_TILE_WIDTH_INCHES = 6.0
+
+
+def _decode_frames(webp_bytes: bytes) -> list[tuple[np.ndarray, float]]:
+    """Decodes a WebP file's bytes into a list of RGBA frames with timestamps.
+
+    :param webp_bytes: The raw bytes of the WebP file.
+    :return: A list of tuples, one per frame in order. Each tuple holds a
+        (height, width, 4) ndarray of uint8s representing the frame's RGBA pixel
+        values and a float representing the frame's timestamp. The units of the
+        timestamps are seconds. A static WebP file decodes to a single frame
+        with a timestamp of 0.0.
+    """
+    decoder = webp.WebPAnimDecoder.new(webp.WebPData.from_buffer(webp_bytes))
+    return [(frame, timestamp_ms / 1000.0) for frame, timestamp_ms in decoder.frames()]
+
+
+def _sample_indices(first: int, last: int, count: int) -> list[int]:
+    """Returns evenly spaced frame indices spanning a range, without duplicates.
+
+    The first and last indices of the range are always included.
+
+    :param first: The first frame index in the range, inclusive.
+    :param last: The last frame index in the range, inclusive. It must be
+        greater than or equal to first.
+    :param count: The requested number of indices. It is clamped to the size of
+        the range.
+    :return: A sorted list of unique ints representing the sampled frame
+        indices.
+    """
+    span = last - first
+    count = min(count, span + 1)
+    if count <= 1:
+        return [first]
+    positions = [first + round(index * span / (count - 1)) for index in range(count)]
+    return sorted(set(positions))
+
+
+def _render_tiles(
+    tiles: list[tuple[int, np.ndarray, float]],
+    n_frames: int,
+    columns: int,
+    tile_width_inches: float,
+    out_path: Path,
+    background_rgb: np.ndarray | None = None,
+) -> None:
+    """Renders frames as a labeled grid of tiles and saves the grid as a PNG.
+
+    Every pixel outside the frames themselves (margins, labels, and unused grid
+    cells) is composited over an opaque light red backdrop. Pixels inside each
+    frame keep their original alpha values unless a background color is given,
+    in which case they are composited over that color.
+
+    :param tiles: A list of tuples, one per tile to render, in order. Each tuple
+        holds an int representing the frame's index, a (height, width, 4)
+        ndarray of uint8s representing the frame's RGBA pixel values, and a
+        float representing the frame's timestamp. The units of the timestamps
+        are seconds.
+    :param n_frames: The total number of frames in the source file, used for the
+        tile labels.
+    :param columns: The number of tiles per row of the grid.
+    :param tile_width_inches: The rendered width of each tile. The units are
+        inches at this module's DPI constant.
+    :param out_path: The path at which to save the rendered PNG.
+    :param background_rgb: A (3,) ndarray of floats representing the RGB
+        components of the color over which to composite the pixels inside each
+        frame. The values are normalized from 0.0 to 1.0 and are unitless. If
+        None, which is the default, the pixels inside each frame keep their
+        original alpha values.
+    :return: None
+    """
+    columns = min(columns, len(tiles))
+    rows = math.ceil(len(tiles) / columns)
+    frame_height, frame_width = tiles[0][1].shape[:2]
+    aspect_ratio = frame_height / frame_width
+    fig_width = columns * tile_width_inches
+    fig_height = rows * (tile_width_inches * aspect_ratio + 0.45)
+    fig = Figure(figsize=(fig_width, fig_height), dpi=DPI)
+    canvas = FigureCanvasAgg(fig)
+    axs = fig.subplots(rows, columns, squeeze=False)
+    artists = []
+    for ax in axs.flat:
+        ax.set_visible(False)
+    for ax, (index, frame, timestamp) in zip(axs.flat, tiles):
+        ax.set_visible(True)
+        artists.append(ax.imshow(frame))
+        if n_frames > 1:
+            label = f"frame {index}/{n_frames - 1} (t = {timestamp:.2f} s)"
+        else:
+            label = "static image"
+        ax.set_title(label, fontsize=10)
+        ax.axis("off")
+    fig.tight_layout()
+
+    # Render the figure with a fully transparent background so the pixels
+    # inside each frame keep their original alpha values.
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=DPI, transparent=True)
+    buffer.seek(0)
+    rendered = mpimg.imread(buffer)
+    height, width = rendered.shape[:2]
+
+    # Composite the whole render over the opaque backdrop, then refill each
+    # frame's exact extent: with the raw pixels (keeping their original alpha
+    # values) by default, or composited over the given background color. Labels
+    # land in the margins, so they survive the backdrop compositing.
+    alpha = rendered[:, :, 3:4]
+    out = np.empty((height, width, 4), dtype=float)
+    out[:, :, :3] = rendered[:, :, :3] * alpha + BACKDROP_RGB * (1.0 - alpha)
+    out[:, :, 3] = 1.0
+    if background_rgb is None:
+        refill = rendered
+    else:
+        refill = np.empty((height, width, 4), dtype=float)
+        refill[:, :, :3] = rendered[:, :, :3] * alpha + background_rgb * (1.0 - alpha)
+        refill[:, :, 3] = 1.0
+    renderer = canvas.get_renderer()
+    for artist in artists:
+        bbox = artist.get_window_extent(renderer)
+        col_0 = int(np.floor(bbox.x0))
+        col_1 = int(np.ceil(bbox.x1))
+        row_0 = height - int(np.ceil(bbox.y1))
+        row_1 = height - int(np.floor(bbox.y0))
+        out[row_0:row_1, col_0:col_1] = refill[row_0:row_1, col_0:col_1]
+    mpimg.imsave(out_path, np.clip(out, 0.0, 1.0))
+
+
+def _run_info(frames: list[tuple[np.ndarray, float]], file_path: Path) -> None:
+    """Prints metadata about a decoded WebP file.
+
+    :param frames: The decoded frames, as returned by _decode_frames.
+    :param file_path: The path of the source WebP file, used for display only.
+    :return: None
+    """
+    n_frames = len(frames)
+    frame_height, frame_width = frames[0][0].shape[:2]
+    print(f"file: {file_path}")
+    if n_frames > 1:
+        print(f"type: animated ({n_frames} frames)")
+    else:
+        print("type: static (1 frame)")
+    print(f"size: {frame_width} x {frame_height} pixels")
+    if n_frames > 1:
+        duration = frames[-1][1]
+        if duration > 0.0:
+            print(f"duration: {duration:.2f} s ({n_frames / duration:.1f} fps)")
+        else:
+            print("duration: unavailable (no timestamps)")
+    min_alpha = min(int(frame[:, :, 3].min()) for frame, _ in frames)
+    non_opaque = float(np.mean([np.mean(frame[:, :, 3] < 255) for frame, _ in frames]))
+    if non_opaque > 0.0:
+        print(
+            f"alpha: has transparency (min alpha is {min_alpha}; "
+            f"{100.0 * non_opaque:.1f} percent of pixels are non-opaque)"
+        )
+    else:
+        print("alpha: fully opaque")
+
+
+def main(argv: list[str]) -> int:
+    """Parses the command-line arguments and runs the requested subcommand.
+
+    :param argv: The command-line arguments, excluding the program name.
+    :return: An int representing the exit code, which is 0 on success and 1 on
+        a usage error.
+    """
+    parser = argparse.ArgumentParser(
+        description="Analyze a static or animated WebP file."
+    )
+    parser.add_argument("file", type=Path, help="The path to the WebP file.")
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    subparsers.add_parser("info", help="Print metadata about the file.")
+    sheet_parser = subparsers.add_parser(
+        "sheet", help="Render sampled frames as a labeled contact sheet PNG."
+    )
+    sheet_parser.add_argument(
+        "--count",
+        type=int,
+        default=9,
+        help="The number of frames to sample. The default is 9.",
+    )
+    sheet_parser.add_argument(
+        "--columns",
+        type=int,
+        default=3,
+        help="The number of tiles per row. The default is 3.",
+    )
+    sheet_parser.add_argument(
+        "--first",
+        type=int,
+        default=0,
+        help="The first frame index of the range to sample. The default is 0.",
+    )
+    sheet_parser.add_argument(
+        "--last",
+        type=int,
+        default=None,
+        help="The last frame index of the range to sample. The default is the "
+        "last frame.",
+    )
+    sheet_parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="The path at which to save the PNG. The default is a file named "
+        "after the input in the system's temporary directory.",
+    )
+    sheet_parser.add_argument(
+        "--background",
+        type=str,
+        default=None,
+        help="A color over which to composite the pixels inside each frame, "
+        "given as any matplotlib color specification (for example, 'black' or "
+        "'#1a2b3c'). The default is to keep the frames' original alpha values.",
+    )
+    frames_parser = subparsers.add_parser(
+        "frames", help="Render specific frames as full-resolution PNGs."
+    )
+    frames_parser.add_argument(
+        "indices",
+        type=int,
+        nargs="+",
+        help="The frame indices to render.",
+    )
+    frames_parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="The directory in which to save the PNGs. The default is a "
+        "directory named after the input in the system's temporary directory.",
+    )
+    frames_parser.add_argument(
+        "--background",
+        type=str,
+        default=None,
+        help="A color over which to composite the pixels inside each frame, "
+        "given as any matplotlib color specification (for example, 'black' or "
+        "'#1a2b3c'). The default is to keep the frames' original alpha values.",
+    )
+    args = parser.parse_args(argv)
+
+    background_rgb = None
+    if getattr(args, "background", None) is not None:
+        try:
+            background_rgb = np.array(to_rgb(args.background), dtype=float)
+        except ValueError:
+            print(
+                f"error: {args.background!r} is not a valid matplotlib color "
+                "specification",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        webp_bytes = args.file.read_bytes()
+    except OSError as exc:
+        print(f"error: could not read {args.file} ({exc})", file=sys.stderr)
+        return 1
+    frames = _decode_frames(webp_bytes)
+    n_frames = len(frames)
+
+    if args.mode == "info":
+        _run_info(frames, args.file)
+        return 0
+
+    if args.mode == "sheet":
+        first = args.first
+        last = args.last if args.last is not None else n_frames - 1
+        if not 0 <= first <= last <= n_frames - 1:
+            print(
+                f"error: the frame range [{first}, {last}] is invalid for a "
+                f"file with {n_frames} frame(s)",
+                file=sys.stderr,
+            )
+            return 1
+        if args.count < 1 or args.columns < 1:
+            print("error: --count and --columns must be positive", file=sys.stderr)
+            return 1
+        indices = _sample_indices(first, last, args.count)
+        out_path = args.out
+        if out_path is None:
+            out_path = Path(tempfile.gettempdir()) / f"{args.file.stem}_sheet.png"
+        tiles = [(index, frames[index][0], frames[index][1]) for index in indices]
+        _render_tiles(
+            tiles,
+            n_frames,
+            args.columns,
+            SHEET_TILE_WIDTH_INCHES,
+            out_path,
+            background_rgb,
+        )
+        print(f"sampled frame indices: {indices}")
+        print(f"saved sheet to: {out_path}")
+        return 0
+
+    # The mode is "frames".
+    invalid = [index for index in args.indices if not 0 <= index <= n_frames - 1]
+    if invalid:
+        print(
+            f"error: the frame indices {invalid} are invalid for a file with "
+            f"{n_frames} frame(s)",
+            file=sys.stderr,
+        )
+        return 1
+    out_dir = args.out_dir
+    if out_dir is None:
+        out_dir = Path(tempfile.gettempdir()) / f"{args.file.stem}_frames"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for index in args.indices:
+        frame, timestamp = frames[index]
+        frame_width = frame.shape[1]
+        out_path = out_dir / f"frame_{index:04d}.png"
+        _render_tiles(
+            [(index, frame, timestamp)],
+            n_frames,
+            1,
+            frame_width / DPI,
+            out_path,
+            background_rgb,
+        )
+        print(f"saved frame {index} to: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/find_unused_fixtures.py
+++ b/scripts/find_unused_fixtures.py
@@ -1,0 +1,872 @@
+"""Finds unused fixture functions and dead setUp attributes in the test suite."""
+
+import argparse
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = PROJECT_ROOT / "tests"
+
+FIXTURE_DIRS = [
+    TESTS_DIR / "unit" / "fixtures",
+    TESTS_DIR / "integration" / "fixtures",
+]
+
+TEST_DIRS = [
+    TESTS_DIR / "unit",
+    TESTS_DIR / "integration",
+]
+
+
+def find_fixture_functions() -> dict[tuple[str, str], tuple[int, int]]:
+    """Find all fixture function definitions across all fixture modules.
+
+    :return: A dictionary mapping (module_path, function_name) to a (lineno, end_lineno)
+        tuple.
+    """
+    fixtures = {}
+    for fixture_dir in FIXTURE_DIRS:
+        for filepath in sorted(fixture_dir.glob("*.py")):
+            if filepath.name == "__init__.py":
+                continue
+            tree = ast.parse(filepath.read_text(), filename=str(filepath))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name.startswith("make_"):
+                    end_lineno = node.end_lineno or node.lineno
+                    fixtures[(str(filepath), node.name)] = (node.lineno, end_lineno)
+    return fixtures
+
+
+def find_all_python_files() -> list[Path]:
+    """Find all Python files in the test directories.
+
+    :return: A list of Path objects for all .py files.
+    """
+    files = []
+    for test_dir in TEST_DIRS:
+        files.extend(sorted(test_dir.rglob("*.py")))
+    return files
+
+
+def _resolve_import_to_filepath(
+    module_str: str, level: int, caller_filepath: str
+) -> str | None:
+    """Resolve a Python import to a filesystem path.
+
+    Handles both absolute and relative imports by converting the dotted module string to
+    a path and checking if the corresponding .py file exists.
+
+    :param module_str: The dotted module string (e.g., "tests.unit.fixtures.foo").
+    :param level: The number of leading dots for relative imports (0 for absolute).
+    :param caller_filepath: The path of the file containing the import.
+    :return: The resolved file path as a string, or None if the file does not exist.
+    """
+    if level > 0:
+        base = Path(caller_filepath).parent
+        for _ in range(level - 1):
+            base = base.parent
+        if module_str:
+            resolved = base / Path(*module_str.split("."))
+        else:
+            resolved = base
+    else:
+        resolved = PROJECT_ROOT / Path(*module_str.split("."))
+
+    py_file = resolved.with_suffix(".py")
+    if py_file.exists():
+        return str(py_file)
+
+    return None
+
+
+def _parse_fixture_imports(
+    tree: ast.Module, caller_filepath: str, fixture_file_set: set[str]
+) -> dict[str, str]:
+    """Parse a file's imports to map local names to their source fixture files.
+
+    Handles qualified calls through imported fixture modules and unqualified calls
+    within fixture files that reference functions defined in the same file.
+
+    :param tree: The parsed AST of the file.
+    :param caller_filepath: The path of the file being parsed.
+    :param fixture_file_set: The set of all known fixture file paths (as strings).
+    :return: A dictionary mapping local module alias names (e.g., "foo_fixtures") to
+        their resolved fixture file paths.
+    """
+    module_aliases = {}
+
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.module is None and node.level == 0:
+            continue
+
+        for alias in node.names:
+            combined = f"{node.module}.{alias.name}" if node.module else alias.name
+            source = _resolve_import_to_filepath(combined, node.level, caller_filepath)
+            if source and source in fixture_file_set:
+                local_alias = alias.asname or alias.name
+                module_aliases[local_alias] = source
+
+    return module_aliases
+
+
+def find_fixture_call_sites(
+    all_files: list[Path], fixture_functions: dict[tuple[str, str], tuple[int, int]]
+) -> dict[tuple[str, str], set[tuple[str, str, str]]]:
+    """Find where each fixture function is called.
+
+    Uses import resolution to attribute calls to specific fixture definitions. When a
+    call cannot be resolved to a specific fixture, it is conservatively attributed to
+    all fixtures with that name to avoid false positives.
+
+    :param all_files: The list of all Python files to search.
+    :param fixture_functions: The dictionary of all fixture function definitions, keyed
+        by (filepath, function_name).
+    :return: A dictionary mapping (filepath, function_name) to a set of
+        (caller_filepath, caller_context, caller_name) tuples.
+    """
+    fixture_file_set = {fp for fp, _ in fixture_functions}
+
+    name_to_keys: dict[str, list[tuple[str, str]]] = {}
+    for fp, name in fixture_functions:
+        name_to_keys.setdefault(name, []).append((fp, name))
+
+    call_sites: dict[tuple[str, str], set[tuple[str, str, str]]] = {
+        key: set() for key in fixture_functions
+    }
+
+    for filepath in all_files:
+        try:
+            source = filepath.read_text()
+            tree = ast.parse(source, filename=str(filepath))
+        except SyntaxError:
+            continue
+
+        filepath_str = str(filepath)
+        module_aliases = _parse_fixture_imports(tree, filepath_str, fixture_file_set)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            caller_context = "fixture" if node.name.startswith("make_") else "test"
+
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Call):
+                    continue
+
+                func = child.func
+                resolved_source = None
+                func_name = None
+
+                if isinstance(func, ast.Attribute) and func.attr.startswith("make_"):
+                    # Qualified call: module.make_foo()
+                    func_name = func.attr
+                    if isinstance(func.value, ast.Name):
+                        resolved_source = module_aliases.get(func.value.id)
+                        # Same file call within a fixture module.
+                        if resolved_source is None and filepath_str in fixture_file_set:
+                            resolved_source = filepath_str
+
+                elif isinstance(func, ast.Name) and func.id.startswith("make_"):
+                    # Unqualified call: make_foo() (same file).
+                    func_name = func.id
+                    if filepath_str in fixture_file_set:
+                        resolved_source = filepath_str
+
+                if func_name is None:
+                    continue
+
+                caller_info = (filepath_str, caller_context, node.name)
+
+                if resolved_source:
+                    key = (resolved_source, func_name)
+                    if key in call_sites:
+                        call_sites[key].add(caller_info)
+                else:
+                    # Fallback: attribute to all definitions with this name.
+                    for key in name_to_keys.get(func_name, []):
+                        call_sites[key].add(caller_info)
+
+    return call_sites
+
+
+def find_directly_unused(
+    fixture_functions: dict[tuple[str, str], tuple[int, int]],
+    call_sites: dict[tuple[str, str], set[tuple[str, str, str]]],
+) -> set[tuple[str, str]]:
+    """Find fixture functions that are never called anywhere.
+
+    :param fixture_functions: The dictionary of all fixture function definitions.
+    :param call_sites: The dictionary of call sites keyed by (filepath, name).
+    :return: A set of (filepath, function_name) keys that are never called.
+    """
+    return {key for key in fixture_functions if not call_sites.get(key)}
+
+
+def find_transitively_unused(
+    fixture_functions: dict[tuple[str, str], tuple[int, int]],
+    call_sites: dict[tuple[str, str], set[tuple[str, str, str]]],
+) -> set[tuple[str, str]]:
+    """Find fixture functions that are only called by other unused fixtures.
+
+    This iteratively marks fixtures as unused if all their callers are themselves
+    unused, until no more changes occur. Caller identity is resolved using the caller's
+    filepath and function name.
+
+    :param fixture_functions: The dictionary of all fixture function definitions.
+    :param call_sites: The dictionary of call sites keyed by (filepath, name).
+    :return: A set of (filepath, function_name) keys that are transitively unused.
+    """
+    all_keys = set(fixture_functions.keys())
+    unused: set[tuple[str, str]] = set()
+
+    changed = True
+    while changed:
+        changed = False
+        for key in all_keys - unused:
+            sites = call_sites.get(key, set())
+            if not sites:
+                unused.add(key)
+                changed = True
+                continue
+
+            all_callers_unused = all(
+                context == "fixture"
+                and (caller_filepath, caller_name) in all_keys
+                and (caller_filepath, caller_name) in unused
+                for caller_filepath, context, caller_name in sites
+            )
+            if all_callers_unused:
+                unused.add(key)
+                changed = True
+
+    return unused
+
+
+def find_dead_setup_attributes(
+    all_files: list[Path],
+) -> list[tuple[str, str, str, int, int]]:
+    """Find setUp/setUpClass attributes that are never used in the class.
+
+    Parses each test file for classes that have a setUp or setUpClass method. For each
+    attribute assigned in setUp/setUpClass (e.g., self.foo = ...), checks whether that
+    attribute name is ever referenced in any other method of the same class or read (in
+    a Load context) within setUp/setUpClass itself. This catches attributes that are
+    only used to construct other setUp attributes.
+
+    :param all_files: The list of all Python files to search.
+    :return: A list of (filepath, class_name, attr_name, lineno, end_lineno) tuples.
+    """
+    dead_attrs = []
+
+    for filepath in all_files:
+        if not filepath.name.startswith("test_"):
+            continue
+
+        try:
+            source = filepath.read_text()
+            tree = ast.parse(source, filename=str(filepath))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+
+            setup_attrs = {}
+            setup_methods = []
+            other_methods = []
+
+            for item in node.body:
+                if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+
+                if item.name in ("setUp", "setUpClass"):
+                    setup_methods.append(item)
+                    for stmt in ast.walk(item):
+                        if not isinstance(stmt, ast.Assign):
+                            continue
+                        for target in stmt.targets:
+                            if (
+                                isinstance(target, ast.Attribute)
+                                and isinstance(target.value, ast.Name)
+                                and target.value.id in ("self", "cls")
+                            ):
+                                end_lineno = stmt.end_lineno or stmt.lineno
+                                setup_attrs[target.attr] = (stmt.lineno, end_lineno)
+
+                else:
+                    other_methods.append(item)
+
+            has_test_methods = any(m.name.startswith("test_") for m in other_methods)
+            if not setup_attrs or not has_test_methods:
+                continue
+
+            # Collect attribute references from non-setUp methods.
+            used_attrs = set()
+            for method in other_methods:
+                for child in ast.walk(method):
+                    if (
+                        isinstance(child, ast.Attribute)
+                        and isinstance(child.value, ast.Name)
+                        and child.value.id in ("self", "cls")
+                    ):
+                        used_attrs.add(child.attr)
+
+            # Also collect attribute READS within setUp/setUpClass itself. This catches
+            # attributes only used to construct other setUp attributes (e.g.,
+            # self.derived = make_derived(self.base)). Only Load context counts; Store
+            # context is the assignment itself.
+            for method in setup_methods:
+                for child in ast.walk(method):
+                    if (
+                        isinstance(child, ast.Attribute)
+                        and isinstance(child.value, ast.Name)
+                        and child.value.id in ("self", "cls")
+                        and isinstance(child.ctx, ast.Load)
+                    ):
+                        used_attrs.add(child.attr)
+
+            for attr_name, (lineno, end_lineno) in sorted(setup_attrs.items()):
+                if attr_name not in used_attrs:
+                    dead_attrs.append(
+                        (str(filepath), node.name, attr_name, lineno, end_lineno)
+                    )
+
+    return dead_attrs
+
+
+def _batch_delete(deletions: list[tuple[str, int, int]]) -> dict[str, str]:
+    """Delete multiple line ranges across multiple files.
+
+    Within each file, deletions are applied from bottom to top so that line numbers
+    remain valid.
+
+    :param deletions: A list of (filepath, start_line, end_line) tuples.
+    :return: A dictionary mapping filepath to original content for restoration.
+    """
+    by_file: dict[str, list[tuple[int, int]]] = {}
+    for filepath, start_line, end_line in deletions:
+        by_file.setdefault(filepath, []).append((start_line, end_line))
+
+    originals = {}
+    for filepath, ranges in by_file.items():
+        content = Path(filepath).read_text()
+        originals[filepath] = content
+        lines = content.splitlines(keepends=True)
+        for start_line, end_line in sorted(ranges, reverse=True):
+            lines = lines[: start_line - 1] + lines[end_line:]
+        Path(filepath).write_text("".join(lines))
+
+    return originals
+
+
+def _restore_files(originals: dict[str, str]) -> None:
+    """Restore files to their original content.
+
+    :param originals: A dictionary mapping filepath to original content.
+    """
+    for filepath, content in originals.items():
+        Path(filepath).write_text(content)
+
+
+def _discover_test_ids() -> list[str]:
+    """Discover all test IDs without running them.
+
+    Uses unittest's test loader to walk the test suite and collect fully qualified test
+    IDs (e.g., ``tests.unit.test_foo.TestBar.test_baz``). This is fast, deterministic,
+    and not affected by output interleaving from warnings or multi-line docstrings.
+
+    :return: A sorted list of test ID strings.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import unittest, sys\n"
+                "loader = unittest.TestLoader()\n"
+                f"suite = loader.discover({str(TESTS_DIR)!r})\n"
+                "def collect(s):\n"
+                "    ids = []\n"
+                "    for t in s:\n"
+                "        if isinstance(t, unittest.TestSuite):\n"
+                "            ids.extend(collect(t))\n"
+                "        else:\n"
+                "            ids.append(t.id())\n"
+                "    return ids\n"
+                "for tid in sorted(collect(suite)):\n"
+                "    print(tid)\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=60,
+    )
+    if result.returncode != 0:
+        print("  [ERROR] Test discovery failed:")
+        print(result.stderr)
+        return []
+    return sorted(result.stdout.strip().splitlines())
+
+
+def _run_full_test_suite() -> tuple[bool, str, str, float | None]:
+    """Run the full test suite under coverage in a subprocess.
+
+    :return: A (success, summary, stderr, coverage_pct) tuple where success is a bool,
+        summary is a short string, stderr is the full stderr output, and coverage_pct is
+        the overall coverage percentage (or None if coverage reporting failed).
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "coverage",
+            "run",
+            "--source=pterasoftware",
+            "-m",
+            "unittest",
+            "discover",
+            "-s",
+            str(TESTS_DIR),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=600,
+    )
+    stderr = result.stderr
+
+    # Extract coverage percentage.
+    coverage_pct = None
+    cov_result = subprocess.run(
+        [sys.executable, "-m", "coverage", "report"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+        timeout=30,
+    )
+    if cov_result.returncode == 0:
+        for line in cov_result.stdout.splitlines():
+            if line.startswith("TOTAL"):
+                parts = line.split()
+                for part in parts:
+                    if part.endswith("%"):
+                        try:
+                            coverage_pct = float(part.rstrip("%"))
+                        except ValueError:
+                            pass
+                        break
+                break
+
+    if result.returncode == 0:
+        for line in stderr.splitlines():
+            if line.startswith("Ran "):
+                return True, line.strip().lower(), stderr, coverage_pct
+        return True, "all tests passed", stderr, coverage_pct
+    stderr_lines = stderr.strip().splitlines()
+    last_line = stderr_lines[-1] if stderr_lines else "unknown error"
+    return False, last_line, stderr, coverage_pct
+
+
+def _find_false_positives_from_traceback(
+    stderr: str, all_deletions: list[tuple[str, int, int, str]]
+) -> set[str]:
+    """Analyze test suite stderr to identify which deletions caused failures.
+
+    Scans the traceback for references to deleted fixture function names and deleted
+    setUp attribute names to determine which candidates are false positives.
+
+    :param stderr: The full stderr output from the test suite run.
+    :param all_deletions: The list of (filepath, start_line, end_line, label) tuples for
+        all candidates.
+    :return: A set of labels that appear to be false positives based on the traceback.
+    """
+    false_positives = set()
+    for _, _, _, label in all_deletions:
+        # The label is like "path:line  name" or "path:line  Class.attr". Extract the
+        # name or attr from the end.
+        candidate_name = label.split()[-1]
+
+        # For "Class.attr" form, extract just the attr.
+        if "." in candidate_name:
+            candidate_name = candidate_name.split(".")[-1]
+
+        if candidate_name in stderr:
+            false_positives.add(label)
+
+    return false_positives
+
+
+def _format_key(key: tuple[str, str]) -> tuple[Path, str]:
+    """Format a (filepath, name) fixture key for display.
+
+    :param key: A (filepath, function_name) tuple.
+    :return: A string like "relative/path.py  function_name".
+    """
+    filepath, name = key
+    rel = Path(filepath).relative_to(PROJECT_ROOT)
+    return rel, name
+
+
+def main() -> int:
+    """Run the unused fixture analysis and optionally verify each candidate."""
+    parser = argparse.ArgumentParser(
+        description="Find unused fixture functions in the test suite."
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "Verify candidates by deleting them and running the full test "
+            "suite with coverage. Reports results but does not modify files."
+        ),
+    )
+    group.add_argument(
+        "--delete-verified",
+        action="store_true",
+        help=(
+            "Verify candidates (same as --verify), then permanently delete "
+            "all confirmed candidates if verification passes."
+        ),
+    )
+    args = parser.parse_args()
+
+    print("Scanning fixture definitions...", flush=True)
+    fixture_functions = find_fixture_functions()
+    print(f"  Found {len(fixture_functions)} fixture functions.\n")
+
+    print("Scanning for call sites...", flush=True)
+    all_files = find_all_python_files()
+    call_sites = find_fixture_call_sites(all_files, fixture_functions)
+
+    directly_unused = find_directly_unused(fixture_functions, call_sites)
+    transitively_unused = find_transitively_unused(fixture_functions, call_sites)
+    only_transitively_unused = transitively_unused - directly_unused
+
+    all_unused_fixtures = sorted(transitively_unused)
+
+    print("=" * 80)
+    print("DIRECTLY UNUSED FIXTURES (never called anywhere)")
+    print("=" * 80)
+    if directly_unused:
+        for key in sorted(directly_unused):
+            rel, name = _format_key(key)
+            filepath, _ = key
+            lineno, _ = fixture_functions[key]
+            print(f"  {rel}:{lineno}  {name}")
+    else:
+        print("  None found.")
+
+    print()
+    print("=" * 80)
+    print("TRANSITIVELY UNUSED FIXTURES (only called by other unused fixtures)")
+    print("=" * 80)
+    if only_transitively_unused:
+        for key in sorted(only_transitively_unused):
+            rel, name = _format_key(key)
+            lineno, _ = fixture_functions[key]
+            callers = call_sites[key]
+            caller_names = sorted({c for _, _, c in callers})
+            print(f"  {rel}:{lineno}  {name}")
+            print(f"    Called only by: {', '.join(caller_names)}")
+    else:
+        print("  None found.")
+
+    print()
+    print("=" * 80)
+    print("DEAD setUp/setUpClass ATTRIBUTES (assigned but never used in tests)")
+    print("=" * 80)
+    dead_attrs = find_dead_setup_attributes(all_files)
+    if dead_attrs:
+        for filepath, class_name, attr_name, lineno, end_lineno in dead_attrs:
+            rel = Path(filepath).relative_to(PROJECT_ROOT)
+            print(f"  {rel}:{lineno}  {class_name}.{attr_name}")
+    else:
+        print("  None found.")
+
+    total_issues = len(transitively_unused) + len(dead_attrs)
+    print()
+    print(
+        f"Total: {len(directly_unused)} directly unused, "
+        f"{len(only_transitively_unused)} transitively unused, "
+        f"{len(dead_attrs)} dead setUp attributes."
+    )
+
+    if not args.verify and not args.delete_verified:
+        if total_issues > 0:
+            print(
+                "\nRe-run with --verify to confirm, or --delete-verified to "
+                "confirm and delete."
+            )
+        return 1 if total_issues > 0 else 0
+
+    # Build the list of all deletions: (filepath, start_line, end_line, label).
+    all_deletions = []
+    for key in all_unused_fixtures:
+        filepath, name = key
+        lineno, end_lineno = fixture_functions[key]
+        rel = Path(filepath).relative_to(PROJECT_ROOT)
+        all_deletions.append((filepath, lineno, end_lineno, f"{rel}:{lineno}  {name}"))
+
+    for filepath, class_name, attr_name, lineno, end_lineno in dead_attrs:
+        rel = Path(filepath).relative_to(PROJECT_ROOT)
+        all_deletions.append(
+            (filepath, lineno, end_lineno, f"{rel}:{lineno}  {class_name}.{attr_name}")
+        )
+
+    if not all_deletions:
+        return 0
+
+    print()
+    print("=" * 80)
+    print("VERIFICATION (full test suite + coverage)")
+    print("=" * 80)
+
+    # Baseline: discover test IDs (fast, no execution) and run the full suite under
+    # coverage. Post-deletion runs must match on three dimensions:
+    # 1. All tests pass.
+    # 2. Same test IDs are discoverable (no test methods lost or broken).
+    # 3. Coverage does not drop (no subtests or code paths silently lost).
+    print()
+    print(
+        "Baseline: Discovering test IDs and running test suite with coverage...",
+        flush=True,
+    )
+    baseline_ids = _discover_test_ids()
+    if not baseline_ids:
+        print("  [FAIL] Baseline discovery found no tests.")
+        return 1
+
+    baseline_ok, baseline_summary, _, baseline_cov = _run_full_test_suite()
+    if not baseline_ok:
+        print(f"  [FAIL] Baseline test suite failed ({baseline_summary})")
+        print("Cannot verify candidates against a failing baseline.")
+        return 1
+    cov_str = f", {baseline_cov:.2f}% coverage" if baseline_cov is not None else ""
+    print(f"  Baseline: {len(baseline_ids)} test IDs, " f"{baseline_summary}{cov_str}.")
+
+    # Phase 1: batch-delete ALL candidates, then verify all three dimensions.
+    print()
+    print(
+        f"Phase 1: Batch-deleting all {len(all_deletions)} candidates and "
+        f"running the full test suite with coverage...",
+        flush=True,
+    )
+
+    batch = [(fp, sl, el) for fp, sl, el, _ in all_deletions]
+    originals = _batch_delete(batch)
+    try:
+        ok, summary, stderr, post_cov = _run_full_test_suite()
+        post_ids = _discover_test_ids() if ok else []
+    finally:
+        _restore_files(originals)
+
+    if ok:
+        # Check test ID match.
+        missing = sorted(set(baseline_ids) - set(post_ids))
+        extra = sorted(set(post_ids) - set(baseline_ids))
+        if missing or extra:
+            print(f"  [FAIL] Tests passed but test ID mismatch ({summary})")
+            if missing:
+                print(f"  Missing {len(missing)} test(s) after deletion:")
+                for tid in missing:
+                    print(f"    - {tid}")
+            if extra:
+                print(f"  Unexpected {len(extra)} new test(s) after deletion:")
+                for tid in extra:
+                    print(f"    + {tid}")
+            return 1
+
+        # Check coverage match.
+        if baseline_cov is not None and post_cov is not None:
+            if post_cov < baseline_cov:
+                print(
+                    f"  [FAIL] Coverage dropped: {baseline_cov:.2f}% -> "
+                    f"{post_cov:.2f}% ({summary})"
+                )
+                return 1
+            cov_str = f", coverage {post_cov:.2f}%"
+        else:
+            cov_str = ""
+
+        print(
+            f"  [PASS] All {len(all_deletions)} candidates confirmed "
+            f"({summary}, {len(post_ids)} test IDs match baseline{cov_str})"
+        )
+        confirmed_deletions = all_deletions
+    else:
+        # Some candidates are false positives. Identify them.
+        print(f"  [FAIL] Batch test failed ({summary})")
+        print()
+        false_positives = _find_false_positives_from_traceback(stderr, all_deletions)
+        if not false_positives:
+            print("Could not identify specific false positives from the " "traceback.")
+            print("Full stderr from the test run:")
+            print()
+            print(stderr)
+            return 1
+
+        n_confirmed = len(all_deletions) - len(false_positives)
+        print(
+            f"Traceback analysis identified {len(false_positives)} false "
+            f"positive(s):"
+        )
+        print()
+        for _, _, _, label in all_deletions:
+            status = "FAIL" if label in false_positives else "PASS"
+            print(f"  [{status}] {label}")
+
+        confirmed_deletions = [d for d in all_deletions if d[3] not in false_positives]
+
+        # Phase 2: re-batch with only confirmed candidates, verify.
+        print()
+        print(
+            f"Phase 2: Batch-deleting {n_confirmed} confirmed candidates and "
+            f"re-running the full test suite with coverage...",
+            flush=True,
+        )
+        batch = [(fp, sl, el) for fp, sl, el, _ in confirmed_deletions]
+        originals = _batch_delete(batch)
+        try:
+            ok, summary, stderr, post_cov = _run_full_test_suite()
+            post_ids = _discover_test_ids() if ok else []
+        finally:
+            _restore_files(originals)
+
+        if ok:
+            missing = sorted(set(baseline_ids) - set(post_ids))
+            extra = sorted(set(post_ids) - set(baseline_ids))
+            if missing or extra:
+                print(f"  [FAIL] Tests passed but test ID mismatch ({summary})")
+                if missing:
+                    print(f"  Missing {len(missing)} test(s) after deletion:")
+                    for tid in missing:
+                        print(f"    - {tid}")
+                if extra:
+                    print(f"  Unexpected {len(extra)} new test(s) after deletion:")
+                    for tid in extra:
+                        print(f"    + {tid}")
+                return 1
+
+            if baseline_cov is not None and post_cov is not None:
+                if post_cov < baseline_cov:
+                    print(
+                        f"  [FAIL] Coverage dropped: {baseline_cov:.2f}% -> "
+                        f"{post_cov:.2f}% ({summary})"
+                    )
+                    return 1
+                cov_str = f", coverage {post_cov:.2f}%"
+            else:
+                cov_str = ""
+
+            print(
+                f"  [PASS] All {n_confirmed} confirmed candidates pass "
+                f"({summary}, {len(post_ids)} test IDs match baseline"
+                f"{cov_str})"
+            )
+        else:
+            print(f"  [FAIL] Confirmed-only batch also failed ({summary})")
+            print("There may be interaction effects. Manual investigation " "required.")
+            return 1
+
+    # Phase 3: with confirmed deletions applied, re-run static analysis to find newly
+    # exposed candidates.
+    print()
+    print("=" * 80)
+    print("RE-SCAN FOR NEWLY EXPOSED CANDIDATES")
+    print("=" * 80)
+    print(flush=True)
+
+    batch = [(fp, sl, el) for fp, sl, el, _ in confirmed_deletions]
+    originals = _batch_delete(batch)
+    try:
+        new_fixture_functions = find_fixture_functions()
+        new_all_files = find_all_python_files()
+        new_call_sites = find_fixture_call_sites(new_all_files, new_fixture_functions)
+        new_transitively_unused = find_transitively_unused(
+            new_fixture_functions, new_call_sites
+        )
+        new_dead_attrs = find_dead_setup_attributes(new_all_files)
+    finally:
+        _restore_files(originals)
+
+    # Filter to only genuinely new candidates (not already in confirmed list).
+    confirmed_keys = set()
+    confirmed_attr_keys = set()
+    for fp, sl, el, label in confirmed_deletions:
+        parts = label.split()[-1]
+        if "." in parts:
+            confirmed_attr_keys.add(parts)
+        else:
+            confirmed_keys.add((fp, parts))
+
+    newly_exposed_fixtures = sorted(new_transitively_unused - confirmed_keys)
+    newly_exposed_attrs = [
+        (fp, cls, attr, ln, eln)
+        for fp, cls, attr, ln, eln in new_dead_attrs
+        if f"{cls}.{attr}" not in confirmed_attr_keys
+    ]
+
+    has_newly_exposed = bool(newly_exposed_fixtures or newly_exposed_attrs)
+
+    if has_newly_exposed:
+        print("Removing confirmed candidates exposed new unused items:")
+        print()
+        if newly_exposed_fixtures:
+            print("  New unused fixture functions:")
+            for key in newly_exposed_fixtures:
+                rel, name = _format_key(key)
+                lineno, _ = new_fixture_functions[key]
+                print(f"    {rel}:{lineno}  {name}")
+        if newly_exposed_attrs:
+            print("  New dead setUp/setUpClass attributes:")
+            for filepath, class_name, attr_name, lineno, _ in newly_exposed_attrs:
+                rel = Path(filepath).relative_to(PROJECT_ROOT)
+                print(f"    {rel}:{lineno}  {class_name}.{attr_name}")
+    else:
+        print("No newly exposed candidates found. The confirmed list is complete.")
+
+    # If --delete-verified, permanently apply the confirmed deletions.
+    if args.delete_verified:
+        print()
+        print("=" * 80)
+        print("DELETING CONFIRMED CANDIDATES")
+        print("=" * 80)
+        print()
+
+        batch = [(fp, sl, el) for fp, sl, el, _ in confirmed_deletions]
+        _batch_delete(batch)
+
+        print(f"Deleted {len(confirmed_deletions)} confirmed candidate(s):")
+        for _, _, _, label in confirmed_deletions:
+            print(f"  {label}")
+
+        if has_newly_exposed:
+            n_newly = len(newly_exposed_fixtures) + len(newly_exposed_attrs)
+            print()
+            print(
+                f"Re-run this script to verify and delete the {n_newly} "
+                f"newly exposed candidate(s)."
+            )
+
+    print()
+    total_confirmed = len(confirmed_deletions)
+    total_failed = len(all_deletions) - total_confirmed
+    n_newly = len(newly_exposed_fixtures) + len(newly_exposed_attrs)
+    print(
+        f"Final summary: {total_confirmed} confirmed, {total_failed} false "
+        f"positive(s), {n_newly} newly exposed."
+    )
+
+    return 1 if total_issues > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Description

This pull request expands the contributor tooling layer without touching the `pterasoftware` package or any simulation behavior. It adds a suite of Claude Code slash commands under `.claude/commands/` for drafting pull requests, refreshing them, opening issues, analyzing WebP renders, and pruning unused test fixtures, together with two backing scripts in `scripts/`. It also establishes a single source of truth for the repository's labels in `.github/labels.yml`, reconciled automatically by a new `label-sync` workflow, and streamlines the issue templates to match how issues are written in practice.

All changes are confined to developer tooling, continuous integration configuration, and documentation. No runtime module, public API, or numerical result is affected, and the existing commands keep working with their conventions clarified rather than changed.

## Motivation

The repository's contributor workflows were partly manual and partly captured by older slash commands that assumed a bare `black` invocation and a single-module fixture scan. Codifying the pull request, issue, and commit conventions as slash commands makes them reproducible and keeps drafts aligned with `.github/pull_request_template.md` and `docs/WRITING_STYLE.md` rather than relying on memory. The labels were previously managed by hand in the GitHub user interface, which let them drift; moving them into `.github/labels.yml` with an automated sync makes the label set reviewable in version control and consistent with the `feature` and `good_first_issue` names that the commands and the contributing guide now reference. The trimmed issue templates drop the end-user-reporter sections that maintainers do not fill in.

## Relevant Issues

None.

## Changes

* Add `.claude/commands/create-pr.md`, a slash command that drafts a body strictly following `.github/pull_request_template.md`, derives the title prefix from the branch, enforces the 42-character ASCII title limit with an `awk` check, selects labels from `.github/labels.yml`, and opens the pull request through `gh pr create` using only the porcelain, never `gh api`.
* Add `.claude/commands/update-pr.md`, a companion command that refreshes an existing pull request's title, body, and labels to reflect new or undone commits, reusing every convention from `create-pr.md` and applying the edit through `gh pr edit`.
* Add `.claude/commands/open-issue.md`, a command that drafts an issue from the conversation following a streamlined, maintainer-oriented adaptation of the `.github/ISSUE_TEMPLATE/` forms, with a `gfi` keyword that adds the `good_first_issue` label and a "Hints for New Contributors" section, opening through `gh issue create`.
* Add `.claude/commands/analyze-webp.md` and `scripts/analyze_webp.py`, which decode a static or animated WebP with the `webp` package, report metadata and alpha statistics, and render frames or an evenly sampled contact sheet to PNG for inspection, with an optional `--background` composite.
* Rewrite `.claude/commands/delete-unused-fixtures.md` and add `scripts/find_unused_fixtures.py`, a whole-suite `ast`-based analyzer that detects directly unused fixtures, transitively unused fixtures iterated to a fixed point, and dead `setUp`/`setUpClass` attributes, verifies each candidate by running the suite under `coverage`, and deletes only verified candidates under `--delete-verified`.
* Rework `.claude/commands/commit.md` to add a sequencer-state check that halts on an in-progress merge, cherry-pick, revert, or rebase so a prepared message is not discarded, to combine subject validation and body wrapping into one `fold` and `awk` step, to enforce ASCII-only messages, and to make the `git commit` permission prompt the review gate.
* Update `.claude/commands/debug-unit-tests-and-fixtures.md`, `.claude/commands/make-unit-tests-and-fixtures.md`, and `.claude/commands/check-unit-tests-redundancy.md` to route test runs through `unittest` per `docs/RUNNING_TESTS_AND_TYPE_CHECKS.md`, reformat through `pre-commit` instead of a bare `black`, point at the style documents, and require user confirmation before removing redundant tests.
* Add `.github/labels.yml` as the canonical label set and `.github/workflows/label-sync.yml`, a pinned `EndBug/label-sync` workflow that reconciles repository labels on every push to `main` that touches the configuration, with `delete-other-labels` enabled and a `workflow_dispatch` dry-run input.
* Trim `.github/ISSUE_TEMPLATE/bug_report.md` by removing its `Reproduction`, `Screenshots`, and `Desktop` sections, and `.github/ISSUE_TEMPLATE/feature_request.md` by removing `Alternative Solutions` and changing its label from `enhancement` to `feature`.
* Update `CONTRIBUTING.md` to reference the `good_first_issue` label name in place of `good first issue`, matching the canonical labels.
* Document the new files in `CLAUDE.md`: the `analyze_webp.py` and `find_unused_fixtures.py` scripts, plus the previously undocumented `label-sync.yml`, `publish.yml`, `CODEOWNERS`, `dependabot.yml`, `FUNDING.yml`, and `labels.yml`.
* Add `coverage` to `requirements_dev.txt` to back the verification passes in `scripts/find_unused_fixtures.py`.

## Dependency Updates

Add `coverage` (unpinned) to `requirements_dev.txt`, used by `scripts/find_unused_fixtures.py` to run the test suite under coverage when verifying that a fixture is safe to delete. No runtime dependencies changed.

## Change Magnitude

**Moderate**: A medium-sized addition of developer tooling and continuous integration configuration that adds and modifies features without large-scale impact, leaving the `pterasoftware` package and all simulation behavior untouched.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
