### PR TITLE
Harden the free-flight MuJoCo interface

### DIFF
--- a/.idea/inspectionProfiles/Ptera_Software_Default.xml
+++ b/.idea/inspectionProfiles/Ptera_Software_Default.xml
@@ -23,6 +23,47 @@
     <inspection_tool class="PyNewStyleGenericSyntaxInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyNewTypeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyStringConversionWithoutDunderMethodInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredTypes">
+        <list>
+          <option value="types.NoneType" />
+          <option value="_io.TextIOWrapper" />
+          <option value="str" />
+          <option value="int" />
+          <option value="float" />
+          <option value="complex" />
+          <option value="set" />
+          <option value="frozenset" />
+          <option value="bytes" />
+          <option value="bytearray" />
+          <option value="memoryview" />
+          <option value="slice" />
+          <option value="list" />
+          <option value="dict" />
+          <option value="bool" />
+          <option value="range" />
+          <option value="tuple" />
+          <option value="pathlib.PurePath" />
+          <option value="uuid.UUID" />
+          <option value="decimal.Decimal" />
+          <option value="fractions.Fraction" />
+          <option value="numpy.floating" />
+          <option value="numpy.ndarray" />
+          <option value="numpy.dtype" />
+          <option value="_collections_abc.Buffer" />
+          <option value="numpy.number" />
+          <option value="numpy.object_" />
+          <option value="object" />
+          <option value="numpy.object_" />
+        </list>
+      </option>
+      <option name="reportedTypes">
+        <list>
+          <option value="types.FunctionType" />
+          <option value="type" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyTypeCheckerInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyTypeHintsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/Ptera_Software_Default.xml
+++ b/.idea/inspectionProfiles/Ptera_Software_Default.xml
@@ -54,7 +54,6 @@
           <option value="numpy.number" />
           <option value="numpy.object_" />
           <option value="object" />
-          <option value="numpy.object_" />
         </list>
       </option>
       <option name="reportedTypes">

--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -230,7 +230,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Construction-only parameters
 
-`extra_xml` and `mujoco_assets` are constructor parameters, not attributes: both are validated here for structural shape (each a dict or None; `extra_xml` keys restricted to the permitted injection points and values to strings; `mujoco_assets` mapping string filenames to bytes), then forwarded to the `MuJoCoModel` constructed in `__init__` and not stored on the problem, so neither has a slot or an attribute-category entry above. They are the only raw user input reaching the `MuJoCoModel`, which performs no validation of its own; deeper XML and asset-reference correctness is left to MuJoCo. See Construction-Only Parameters under Design Principles.
+`integrator`, `extra_xml`, and `mujoco_assets` are constructor parameters, not attributes: all three are validated here (`integrator` a str naming a supported MuJoCo integrator; `extra_xml` a dict or None with keys restricted to the permitted injection points and str values; `mujoco_assets` a dict or None mapping str filenames to bytes), then forwarded to the `MuJoCoModel` constructed in `__init__` and not stored on the problem, so none has a slot or an attribute-category entry above. They are the only raw user input reaching the `MuJoCoModel`, which performs no validation of its own; deeper XML and asset-reference correctness is left to MuJoCo. See Construction-Only Parameters under Design Principles.
 
 ## CoreMovement / Movement Class (`_core.py`, `movements/movement.py`)
 
@@ -710,7 +710,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Construction-only parameters
 
-`extra_xml` and `mujoco_assets` are constructor parameters, not attributes: both shape the generated model during initialization and are then discarded, so neither has a slot or an attribute-category entry above. `extra_xml` is folded into `xml_str`, so its content survives indirectly through the stored XML, while `mujoco_assets` is passed to MuJoCo's `from_xml_string` and not retained at all, which is why an asset-based model cannot be rebuilt from `xml_str` alone. `MuJoCoModel` does not validate them: it is private and validates nothing, so they arrive already validated for structural shape from `FreeFlightUnsteadyProblem` (the only constructor), with deeper XML and asset-reference correctness left to MuJoCo. See Construction-Only Parameters under Design Principles.
+`integrator`, `extra_xml`, and `mujoco_assets` are constructor parameters, not attributes: all three shape the generated model during initialization and are then discarded, so none has a slot or an attribute-category entry above. `integrator` and `extra_xml` are folded into `xml_str`, so their content survives indirectly through the stored XML, while `mujoco_assets` is passed to MuJoCo's `from_xml_string` and not retained at all, which is why an asset-based model cannot be rebuilt from `xml_str` alone. `MuJoCoModel` does not validate them: it is private and validates nothing, so they arrive already validated from `FreeFlightUnsteadyProblem` (the only constructor), with deeper XML and asset-reference correctness left to MuJoCo. See Construction-Only Parameters under Design Principles.
 
 ---
 

--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -159,38 +159,38 @@ All `CoreUnsteadyProblem` attributes (documented in the section above) are inher
 
 Each is stored in a `_`-prefixed backing slot and exposed through a read-only property of the unprefixed name.
 
-| Attribute               | Type    | Backing Slot             | Notes                                                  |
-|-------------------------|---------|--------------------------|--------------------------------------------------------|
-| `wing_density`          | `float` | `_wing_density`          | Mass per unit span area (kg/m^2)                       |
-| `spring_constant`       | `float` | `_spring_constant`       | Torsional spring stiffness (N*m/rad)                   |
-| `damping_constant`      | `float` | `_damping_constant`      | Torsional damping coefficient (N*m*s/rad)              |
-| `aero_scaling`          | `float` | `_aero_scaling`          | Scaling factor applied to aerodynamic moments          |
-| `moment_scaling_factor` | `float` | `_moment_scaling_factor` | Scaling factor applied to deformation angles           |
-| `step_discards`         | `int`   | `_step_discards`         | Number of initial steps discarded for stability        |
-| `plot_flap_cycle`       | `bool`  | `_plot_flap_cycle`       | Whether to plot time histories at the end of the solve |
+| Attribute               | Type    | Notes                                                  |
+|-------------------------|---------|--------------------------------------------------------|
+| `wing_density`          | `float` | Mass per unit span area (kg/m^2)                       |
+| `spring_constant`       | `float` | Torsional spring stiffness (N*m/rad)                   |
+| `damping_constant`      | `float` | Torsional damping coefficient (N*m*s/rad)              |
+| `aero_scaling`          | `float` | Scaling factor applied to aerodynamic moments          |
+| `moment_scaling_factor` | `float` | Scaling factor applied to deformation angles           |
+| `step_discards`         | `int`   | Number of initial steps discarded for stability        |
+| `plot_flap_cycle`       | `bool`  | Whether to plot time histories at the end of the solve |
 
 #### Derived from Immutable (read-only property, no backing slot)
 
-| Property                | Depends On              | Notes                                                                                         |
-|-------------------------|-------------------------|-----------------------------------------------------------------------------------------------|
+| Property                | Depends On              | Notes                                                                                               |
+|-------------------------|-------------------------|-----------------------------------------------------------------------------------------------------|
 | `_aeroelastic_movement` | `_movement`             | Typed-narrow cast of the inherited `_movement` slot to `AeroelasticMovement` (recomputed, uncached) |
-| `wing_movement`         | `_aeroelastic_movement` | The first airplane movement's first wing movement, cast to `AeroelasticWingMovement`          |
+| `wing_movement`         | `_aeroelastic_movement` | The first airplane movement's first wing movement, cast to `AeroelasticWingMovement`                |
 
 #### Mutable (populated by solver)
 
 These lists are allocated in `__init__` with one entry per wing in the initial airplane, then appended to or reassigned element-wise by the solver during the run. They are plain slots rather than read-only properties because the solver must update them after construction, mirroring the mutable-result-list treatment on `CoreUnsteadyProblem`.
 
-| Attribute                        | Type                     | Notes                                                  |
-|----------------------------------|--------------------------|--------------------------------------------------------|
-| `net_deformation_per_wing`       | `list[np.ndarray]`       | Current cumulative deformation angles, per wing        |
-| `angular_velocities_per_wing`    | `list[np.ndarray]`       | Current angular velocity state, per wing               |
-| `positions_per_wing`             | `list[list[np.ndarray]]` | Panel center position history, indexed `[wing][step]`  |
-| `per_step_inertial_per_wing`     | `list[list[np.ndarray]]` | Inertial moment history, indexed `[wing][step]`        |
-| `per_step_aero_per_wing`         | `list[list[np.ndarray]]` | Aerodynamic moment history, indexed `[wing][step]`     |
+| Attribute                        | Type                     | Notes                                                    |
+|----------------------------------|--------------------------|----------------------------------------------------------|
+| `net_deformation_per_wing`       | `list[np.ndarray]`       | Current cumulative deformation angles, per wing          |
+| `angular_velocities_per_wing`    | `list[np.ndarray]`       | Current angular velocity state, per wing                 |
+| `positions_per_wing`             | `list[list[np.ndarray]]` | Panel center position history, indexed `[wing][step]`    |
+| `per_step_inertial_per_wing`     | `list[list[np.ndarray]]` | Inertial moment history, indexed `[wing][step]`          |
+| `per_step_aero_per_wing`         | `list[list[np.ndarray]]` | Aerodynamic moment history, indexed `[wing][step]`       |
 | `net_data_per_wing`              | `list[list[np.ndarray]]` | Cumulative deformation snapshots, indexed `[wing][step]` |
-| `angular_velocity_data_per_wing` | `list[list[np.ndarray]]` | Angular velocity snapshots, indexed `[wing][step]`     |
-| `flap_points_per_wing`           | `list[list[np.ndarray]]` | Wing deflection offsets, indexed `[wing][step]`        |
-| `base_wing_positions_per_wing`   | `list[np.ndarray]`       | Undeformed baseline panel positions, per wing          |
+| `angular_velocity_data_per_wing` | `list[list[np.ndarray]]` | Angular velocity snapshots, indexed `[wing][step]`       |
+| `flap_points_per_wing`           | `list[list[np.ndarray]]` | Wing deflection offsets, indexed `[wing][step]`          |
+| `base_wing_positions_per_wing`   | `list[np.ndarray]`       | Undeformed baseline panel positions, per wing            |
 
 ## FreeFlightUnsteadyProblem Class (`problems.py`)
 
@@ -202,12 +202,13 @@ These lists are allocated in `__init__` with one entry per wing in the initial a
 
 Each is stored in a `_`-prefixed backing slot and exposed through a read-only property of the unprefixed name.
 
-| Attribute           | Type               | Backing Slot         | Notes                                                                                                                                   |
-|---------------------|--------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `I_BP1_CgP1`        | `np.ndarray`       | `_I_BP1_CgP1`        | Inertia matrix in the first Airplane's body axes about its CG (kg*m^2); the array itself is set read-only                               |
-| `mass`              | `float`            | `_mass`              | Mass of the first Airplane (kg)                                                                                                          |
-| `external_loads_fn` | `Callable \| None` | `_external_loads_fn` | Optional callback returning additional (force, moment) loads to apply each step, or None                                                |
-| `mujoco_model`      | `MuJoCoModel`      | `_mujoco_model`      | Rigid body dynamics engine; the reference is fixed while the engine's own state advances during the solve (see the MuJoCoModel section) |
+| Attribute           | Type               | Notes                                                                                                     |
+|---------------------|--------------------|-----------------------------------------------------------------------------------------------------------|
+| `I_BP1_CgP1`        | `np.ndarray`       | Inertia matrix in the first Airplane's body axes about its CG (kg*m^2); the array itself is set read-only |
+| `mass`              | `float`            | Mass of the first Airplane (kg)                                                                           |
+| `external_loads_fn` | `Callable \| None` | Optional callback returning additional (force, moment) loads to apply each step, or None                  |
+
+The rigid body dynamics engine lives in the private `_mujoco_model` slot (a `MuJoCoModel`). Like the attributes above, it is set in `__init__` and never reassigned, and the reference stays fixed while the engine's own state advances during the solve. It has no public property: users never interact with the engine directly (see the MuJoCoModel section).
 
 #### Derived from Immutable (read-only property, no backing slot)
 
@@ -332,7 +333,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 `AeroelasticWingMovement` extends `CoreWingMovement` directly, as a feature-specific sibling of `WingMovement`. It inherits every attribute above unchanged and adds the one immutable slot below, stored in a `_`-prefixed backing slot and exposed through a read-only property of the unprefixed name.
 
-| Attribute                                     | Type                           | Notes                                                                                                                                                                                                          |
+| Attribute                                     | Type                           | Notes                                                                                                                                                                                                           |
 |-----------------------------------------------|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `spacingAnglesSecondDerivative_Gs_to_Wn_ixyz` | `tuple[Callable \| None, ...]` | Per-basis-direction (x, y, z) analytical second time derivative of the matching custom angular spacing; an entry is a callable when its `spacingAngles_Gs_to_Wn_ixyz` component is a custom callable, else None |
 
@@ -389,8 +390,8 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 `FreeFlightOperatingPointMovement` extends `CoreOperatingPointMovement` directly, as a feature-specific sibling of `OperatingPointMovement`. It inherits every attribute above unchanged and adds the one mutable slot below, since its `OperatingPoint`s are produced by the solver's rigid body dynamics integration rather than prescribed.
 
-| Attribute          | Type                   | Notes                                                                                                                                                                                                                                          |
-|--------------------|------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Attribute          | Type                   | Notes                                                                                                                                                                                                                                            |
+|--------------------|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `operating_points` | `list[OperatingPoint]` | Mutable OperatingPoint history; seeded with the base OperatingPoint at step 0, then the solver appends one per step. A plain mutable slot rather than a read-only property, mirroring the mutable-result-list treatment on `CoreUnsteadyProblem` |
 
 ## SteadyProblem Class (`problems.py`)
@@ -695,7 +696,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 | Attribute              | Type             | Notes                                                 |
 |------------------------|------------------|-------------------------------------------------------|
 | `xml_str`              | `str`            | Generated MuJoCo XML                                  |
-| `model`                | `mujoco.MjModel` | Compiled MuJoCo model                                 |
+| `_model`               | `mujoco.MjModel` | Compiled MuJoCo model; private slot with no property  |
 | `body_id`              | `int`            | MuJoCo body ID for the Airplane                       |
 | `initial_key_frame_id` | `int`            | MuJoCo key frame ID for initial conditions            |
 | `initial_qpos`         | `np.ndarray`     | Initial generalized positions (computed during init)  |
@@ -703,9 +704,9 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Mutable
 
-| Attribute | Type            | Notes                                                   |
-|-----------|-----------------|---------------------------------------------------------|
-| `data`    | `mujoco.MjData` | Mutated by `apply_loads`, `step`, `reset`, `mj_forward` |
+| Attribute | Type            | Notes                                                                                  |
+|-----------|-----------------|----------------------------------------------------------------------------------------|
+| `_data`   | `mujoco.MjData` | Mutated by `apply_loads`, `step`, `reset`, `mj_forward`; private slot with no property |
 
 #### Construction-only parameters
 

--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -230,7 +230,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Construction-only parameters
 
-`integrator`, `extra_xml`, and `mujoco_assets` are constructor parameters, not attributes: all three are validated here (`integrator` a str naming a supported MuJoCo integrator; `extra_xml` a dict or None with keys restricted to the permitted injection points and str values; `mujoco_assets` a dict or None mapping str filenames to bytes), then forwarded to the `MuJoCoModel` constructed in `__init__` and not stored on the problem, so none has a slot or an attribute-category entry above. They are the only raw user input reaching the `MuJoCoModel`, which performs no validation of its own; deeper XML and asset-reference correctness is left to MuJoCo. See Construction-Only Parameters under Design Principles.
+`integrator`, `extra_xml`, and `mujoco_assets` are constructor parameters, not attributes: all three are validated here (`integrator` a str naming a supported MuJoCo integrator; `extra_xml` a dict or None with keys restricted to the permitted injection points and str values; `mujoco_assets` a dict or None mapping str filenames to bytes), then forwarded to the `MuJoCoModel` constructed in `__init__` and not stored on the problem, so none has a slot or an attribute-category entry above. They are the only raw user input reaching the `MuJoCoModel`, which performs no validation of its own; deeper XML and asset-reference correctness is left to MuJoCo. A problem built with `mujoco_assets` cannot be saved: the `MuJoCoModel` retains the assets dict, and the serialization layer raises rather than write a file whose rebuilt engine could not resolve the asset references. See Construction-Only Parameters under Design Principles.
 
 ## CoreMovement / Movement Class (`_core.py`, `movements/movement.py`)
 
@@ -693,14 +693,15 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Immutable (set in `__init__`, never modified)
 
-| Attribute              | Type             | Notes                                                 |
-|------------------------|------------------|-------------------------------------------------------|
-| `xml_str`              | `str`            | Generated MuJoCo XML                                  |
-| `_model`               | `mujoco.MjModel` | Compiled MuJoCo model; private slot with no property  |
-| `body_id`              | `int`            | MuJoCo body ID for the Airplane                       |
-| `initial_key_frame_id` | `int`            | MuJoCo key frame ID for initial conditions            |
-| `initial_qpos`         | `np.ndarray`     | Initial generalized positions (computed during init)  |
-| `initial_qvel`         | `np.ndarray`     | Initial generalized velocities (computed during init) |
+| Attribute              | Type                       | Notes                                                                                                    |
+|------------------------|----------------------------|----------------------------------------------------------------------------------------------------------|
+| `xml_str`              | `str`                      | Generated MuJoCo XML                                                                                     |
+| `_model`               | `mujoco.MjModel`           | Compiled MuJoCo model; private slot with no property                                                     |
+| `body_id`              | `int`                      | MuJoCo body ID for the Airplane                                                                          |
+| `initial_key_frame_id` | `int`                      | MuJoCo key frame ID for initial conditions                                                               |
+| `initial_qpos`         | `np.ndarray`               | Initial generalized positions (computed during init)                                                     |
+| `initial_qvel`         | `np.ndarray`               | Initial generalized velocities (computed during init)                                                    |
+| `_mujoco_assets`       | `dict[str, bytes] \| None` | Retained assets dict (or None); private slot with no property; a truthy value makes the model unsaveable |
 
 #### Mutable
 
@@ -710,7 +711,7 @@ These are allocated in `__init__` (the four load-history lists as empty lists, t
 
 #### Construction-only parameters
 
-`integrator`, `extra_xml`, and `mujoco_assets` are constructor parameters, not attributes: all three shape the generated model during initialization and are then discarded, so none has a slot or an attribute-category entry above. `integrator` and `extra_xml` are folded into `xml_str`, so their content survives indirectly through the stored XML, while `mujoco_assets` is passed to MuJoCo's `from_xml_string` and not retained at all, which is why an asset-based model cannot be rebuilt from `xml_str` alone. `MuJoCoModel` does not validate them: it is private and validates nothing, so they arrive already validated from `FreeFlightUnsteadyProblem` (the only constructor), with deeper XML and asset-reference correctness left to MuJoCo. See Construction-Only Parameters under Design Principles.
+`integrator` and `extra_xml` are constructor parameters, not attributes: both shape the generated model during initialization, are folded into `xml_str` (so their content survives indirectly through the stored XML), and are then discarded, so neither has a slot or an attribute-category entry above. `mujoco_assets`, by contrast, is retained in the `_mujoco_assets` slot after being passed to MuJoCo's `from_xml_string`: an asset-based model cannot be rebuilt from `xml_str` alone, so the serialization layer reads the slot and raises on save rather than write a file that fails on load (the slot itself is serialized as null, since it can only ever be falsy when saving succeeds). `MuJoCoModel` does not validate any of the three: it is private and validates nothing, so they arrive already validated from `FreeFlightUnsteadyProblem` (the only constructor), with deeper XML and asset-reference correctness left to MuJoCo. See Construction-Only Parameters under Design Principles.
 
 ---
 

--- a/docs/MUJOCO_CONVENTIONS.md
+++ b/docs/MUJOCO_CONVENTIONS.md
@@ -8,7 +8,7 @@ Free flight support is single-airplane for now, so this document describes the s
 
 A body with a freejoint is a six degree of freedom floating body. MuJoCo describes its configuration with a seven element generalized position array (`qpos`: three position components followed by a four component orientation quaternion) and its motion with a six element generalized velocity array (`qvel`: three linear components followed by three angular components). External loads are applied through the body's six element `xfrc_applied` entry (three force components followed by three torque components). The sections below interpret each block.
 
-### Position (qpos[0:3])
+### Position (qpos\[0:3])
 
 `qpos[0:3]` is the position of the first Airplane's CG (in Earth axes, relative to the Earth origin), in meters. No transformation is needed.
 
@@ -16,7 +16,7 @@ A body with a freejoint is a six degree of freedom floating body. MuJoCo describ
 position_E_Eo = qpos[0:3]
 ```
 
-### Orientation Quaternion (qpos[3:7])
+### Orientation Quaternion (qpos\[3:7])
 
 `qpos[3:7]` is the body's orientation quaternion in scalar-first format, [w, x, y, z]. It encodes the active rotation from Earth axes to the first Airplane's body axes (the active rotation that carries a frame from the Earth orientation to the body orientation). MuJoCoModel sets it from the initial passive orientation matrix R_pas_BP1_to_E (the rotation block of T_pas_BP1_CgP1_to_E_CgP1):
 
@@ -39,7 +39,7 @@ R_pas_E_to_BP1 = R_pas_BP1_to_E.T
 
 Verification: with the body rotated 90 degrees about the Earth y axis, the body's +x direction points along Earth -z. The test showed `xmat[:, 0] = [0, 0, -1]`, confirming that the columns of `xmat` are the body axes expressed in Earth axes.
 
-### Linear Velocity (qvel[0:3])
+### Linear Velocity (qvel\[0:3])
 
 `qvel[0:3]` is the linear velocity of the first Airplane's CG (in Earth axes, observed from the Earth frame), in meters per second. No transformation is needed.
 
@@ -49,7 +49,7 @@ velocity_E__E = qvel[0:3]
 
 Verification: when a force along Earth +x is applied to a rotated body, the velocity grows along Earth +x regardless of the body's orientation.
 
-### Angular Velocity (qvel[3:6])
+### Angular Velocity (qvel\[3:6])
 
 This is the most error-prone block. `qvel[3:6]` is in body axes, not Earth axes. It is the angular velocity of the first Airplane's body axes (in the first Airplane's body axes, observed from the Earth frame), in radians per second. Ptera Software works in degrees per second, so MuJoCoModel converts:
 
@@ -65,7 +65,7 @@ omegas_E__E = np.rad2deg(xmat @ qvel[3:6])
 
 Verification: with the body rotated 90 degrees about the y axis (so the body's +x direction equals Earth -z), setting `qvel[3:6] = [1, 0, 0]` produced rotation about Earth -z, not Earth +x, proving that `qvel[3:6]` is expressed in body axes.
 
-### Applied Forces (xfrc_applied[body_id][0:3])
+### Applied Forces (xfrc_applied\[body_id]\[0:3])
 
 `xfrc_applied[body_id][0:3]` is the external force applied to the body at its CG (in Earth axes), in Newtons. No transformation is needed when the force is already in Earth axes.
 
@@ -73,7 +73,7 @@ Verification: with the body rotated 90 degrees about the y axis (so the body's +
 xfrc_applied[body_id][0:3] = forces_E
 ```
 
-### Applied Torques (xfrc_applied[body_id][3:6])
+### Applied Torques (xfrc_applied\[body_id]\[3:6])
 
 `xfrc_applied[body_id][3:6]` is the external torque applied to the body about its CG (in Earth axes, relative to the first Airplane's CG), in Newton meters. No transformation is needed when the moment is already in Earth axes.
 

--- a/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.py
+++ b/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.py
@@ -216,10 +216,11 @@ del wing_movements
 # angle of attack are the trimmed glide found for this airframe. The initial body
 # orientation (angles_E_to_BP1_izyx) pitches the airplane nose up by the angle of attack
 # with zero sideslip, which places the trim velocity along the horizontal Earth x axis at
-# the start of free flight. No external thrust is applied (externalFX_W=0.0), so the
-# glider flies an unpowered glide. Standard gravity is set explicitly via g_E (the
-# default is no gravitational field), while the zero initial body rates (omegas_BP1__E)
-# are left at their default.
+# the start of free flight. The glider flies an unpowered glide: externalFX_W must be
+# zero in free flight (the dynamics never apply it), and thrust would instead be modeled
+# with FreeFlightUnsteadyProblem's external_loads_fn. Standard gravity is set explicitly
+# via g_E (the default is no gravitational field), while the zero initial body rates
+# (omegas_BP1__E) are left at their default.
 example_operating_point = ps.operating_point.OperatingPoint(
     rho=1.225,
     vCg__E=12.9,

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -71,6 +71,7 @@ class MuJoCoModel:
         vCg_E__E: np.ndarray,
         I_BP1_CgP1: np.ndarray,
         delta_time: float | int,
+        integrator: str = "RK4",
         extra_xml: dict[str, str] | None = None,
         mujoco_assets: dict[str, bytes] | None = None,
     ) -> None:
@@ -98,6 +99,9 @@ class MuJoCoModel:
             FreeFlightUnsteadyProblem, which validates that it is symmetric.
         :param delta_time: The time, in seconds, between each time step. Supplied by
             FreeFlightUnsteadyProblem from the Movement.
+        :param integrator: A str naming the MuJoCo integrator to set in the generated
+            model XML's option element. Validated by FreeFlightUnsteadyProblem before
+            being passed here. The default is "RK4".
         :param extra_xml: A dict (or None) mapping injection point names to XML fragment
             strings to inject into the generated MuJoCo XML. Supported keys are
             "default", "asset", and "visual" (inserted as top level elements),
@@ -171,7 +175,7 @@ class MuJoCoModel:
         # Initialize the immutable attributes.
         self._xml_str: str = f"""
         <mujoco model="{name}">
-          <option timestep="{delta_time}" integrator="RK4" gravity="{gravity_str}"/>
+          <option timestep="{delta_time}" integrator="{integrator}" gravity="{gravity_str}"/>
 
           {extra_default}
           {extra_asset}

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -238,10 +238,6 @@ class MuJoCoModel:
         return self._xml_str
 
     @property
-    def model(self) -> mujoco.MjModel:
-        return self._model
-
-    @property
     def body_id(self) -> int:
         return self._body_id
 
@@ -256,11 +252,6 @@ class MuJoCoModel:
     @property
     def initial_qvel(self) -> np.ndarray:
         return self._initial_qvel
-
-    # --- Mutable: read only properties ---
-    @property
-    def data(self) -> mujoco.MjData:
-        return self._data
 
     # --- Other methods ---
     def apply_loads(

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -60,6 +60,7 @@ class MuJoCoModel:
         "_initial_key_frame_id",
         "_initial_qpos",
         "_initial_qvel",
+        "_mujoco_assets",
     )
 
     def __init__(
@@ -112,8 +113,10 @@ class MuJoCoModel:
         :param mujoco_assets: A dict (or None) mapping virtual filenames to their binary
             contents. These are passed to MuJoCo's from_xml_string as the assets
             parameter, allowing meshes and other binary files to be loaded without
-            writing to disk. Validated by FreeFlightUnsteadyProblem before being passed
-            here. The default is None, which provides no extra assets.
+            writing to disk. The dict is retained, which lets the serialization layer
+            refuse to save an asset-based model. Validated by FreeFlightUnsteadyProblem
+            before being passed here. The default is None, which provides no extra
+            assets.
         :return: None
         """
         start_key_frame_name: str = "start"
@@ -207,6 +210,11 @@ class MuJoCoModel:
         else:
             # noinspection PyArgumentList
             self._model = mujoco.MjModel.from_xml_string(self._xml_str)
+
+        # Retain the assets dict so the serialization layer can refuse to save an
+        # asset-based model: the engine is rebuilt on load from the stored XML alone,
+        # whose asset references would be unresolvable.
+        self._mujoco_assets: dict[str, bytes] | None = mujoco_assets
 
         # Set the internal model's time step to be the same as the simulation's.
         self._model.opt.timestep = delta_time
@@ -379,9 +387,9 @@ class MuJoCoModel:
         them from the XML string and resets the data to the initial keyframe, matching
         the state established at construction. The live, post-run data state is not
         restored: the canonical per-step state lives in the FreeFlightUnsteadyProblem's
-        steady problems. Models built with mujoco_assets (such as meshes) cannot be
-        rebuilt, since the assets are not retained, so the XML string's references to
-        them are unresolvable.
+        steady problems. Models built with mujoco_assets (such as meshes) never reach
+        this method: the serialization layer refuses to save them, since the rebuilt
+        engine could not resolve the XML string's asset references.
 
         :return: None
         """

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -87,7 +87,7 @@ _CALLABLE_FUNC_TO_NAME = {func: name for name, func in _CALLABLE_NAME_TO_FUNC.it
 
 # Increments only when the serialization structure changes (slots added/removed/
 # renamed, class registry changed, encoding strategy changed).
-_FORMAT_VERSION = 6
+_FORMAT_VERSION = 7
 
 
 def _all_slots(cls: type) -> list[str]:
@@ -200,9 +200,13 @@ _UNSTEADY_SOLVER_SKIP_SLOTS: frozenset[str] = frozenset(
 # on deserialization to preserve object identity.
 _MOVEMENT_SKIP_SLOTS: frozenset[str] = frozenset({"_airplanes", "_operating_points"})
 
-# Slots on MuJoCoModel that wrap native MuJoCo state and cannot be serialized. They are
-# rebuilt from the serialized XML string on deserialization via MuJoCoModel._rebuild_engine.
-_MUJOCO_MODEL_SKIP_SLOTS: frozenset[str] = frozenset({"_model", "_data"})
+# Slots on MuJoCoModel that are serialized as null. _model and _data wrap native MuJoCo
+# state and are rebuilt from the serialized XML string on deserialization via
+# MuJoCoModel._rebuild_engine. _mujoco_assets holds raw bytes and is only ever falsy
+# when serialization succeeds, because a model with assets raises on save.
+_MUJOCO_MODEL_SKIP_SLOTS: frozenset[str] = frozenset(
+    {"_model", "_data", "_mujoco_assets"}
+)
 
 
 def save(path: str | Path, obj: object) -> None:
@@ -434,6 +438,18 @@ def _object_to_dict(
     # The MuJoCoModel's native model and data objects cannot be serialized; they are
     # rebuilt from the XML string on deserialization.
     if isinstance(obj, MuJoCoModel):
+        # An asset-based model cannot survive that rebuild: the engine is recreated
+        # from the stored XML alone, whose asset references would be unresolvable.
+        # Refuse to save rather than produce a file that fails on load.
+        # This module is inherently coupled to class internals, so reading a private
+        # attribute directly is acceptable here.
+        # noinspection PyProtectedMember
+        if obj._mujoco_assets:
+            raise ValueError(
+                "A MuJoCoModel built with mujoco_assets cannot be saved: the engine "
+                "is rebuilt on load from the stored XML alone, so the asset "
+                "references would be unresolvable."
+            )
         _skip_slots = _skip_slots | _MUJOCO_MODEL_SKIP_SLOTS
 
     result: dict[str, Any] = {"_type": class_name}

--- a/pterasoftware/operating_point.py
+++ b/pterasoftware/operating_point.py
@@ -162,7 +162,10 @@ class OperatingPoint:
         :param externalFX_W: The additional thrust or drag on a problem's Airplane(s)
             (in wind axes) not due to the Airplanes' Wings. It is useful for trim
             analyses. It must be a number (int or float) and will be converted
-            internally to a float. The units are in Newtons. The default is 0.0.
+            internally to a float. The units are in Newtons. The default is 0.0. The
+            free-flight solver never applies externalFX_W and raises if it is non-zero;
+            model thrust there with FreeFlightUnsteadyProblem's external_loads_fn
+            instead.
         :param nu: The fluid's kinematic viscosity. The units are in meters squared per
             second. This parameter is only used in the unsteady ring vortex lattice
             method's vortex core growth model. It must be a positive number and will be

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -501,7 +501,10 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             for the MuJoCo model. Setting this to None provides no extra assets. The
             default is None. The argument is checked to be a dict (or None) mapping
             string filenames to bytes; whether a referenced asset is actually supplied
-            is left to MuJoCo, so this is an advanced-user parameter.
+            is left to MuJoCo, so this is an advanced-user parameter. A
+            FreeFlightUnsteadyProblem built with mujoco_assets cannot be saved: save()
+            raises, because the saved engine is rebuilt on load from the stored XML
+            alone, whose asset references would be unresolvable.
         :return: None
         """
         if not isinstance(movement, free_flight_movement.FreeFlightMovement):

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -380,6 +380,11 @@ _EXTRA_XML_INJECTION_POINTS = frozenset(
     {"default", "asset", "visual", "worldbody", "body"}
 )
 
+# The permitted values for FreeFlightUnsteadyProblem's integrator parameter. Each names
+# a MuJoCo numerical integrator that MuJoCoModel sets in the generated model XML's
+# option element.
+_MUJOCO_INTEGRATORS = frozenset({"Euler", "RK4", "implicit", "implicitfast"})
+
 
 class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
     """A class used to contain problems with coupled unsteady aerodynamics and rigid
@@ -447,6 +452,7 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             ]
             | None
         ) = None,
+        integrator: str = "RK4",
         extra_xml: dict[str, str] | None = None,
         mujoco_assets: dict[str, bytes] | None = None,
     ) -> None:
@@ -478,6 +484,12 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             is not a pair of (3,) finite numeric vectors raises a descriptive error. The
             physical correctness of the forces and moments themselves is not checked.
             Setting this to None applies no additional loads. The default is None.
+        :param integrator: A str naming the MuJoCo integrator used to advance the rigid
+            body dynamics. It must be one of "Euler", "RK4", "implicit", or
+            "implicitfast". The choice is baked into the generated MuJoCo model XML, so
+            it survives saving and loading. "RK4" is accurate for smooth dynamics but
+            handles contacts poorly, so runs with collision geometry (injected via
+            extra_xml) should prefer "implicit" or "implicitfast". The default is "RK4".
         :param extra_xml: A dict mapping injection point names to XML fragment strings
             to inject into the MuJoCo model's XML. Supported keys are "default",
             "asset", "visual", "worldbody", and "body". Setting this to None injects no
@@ -567,11 +579,22 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         self.moments_W_Cg: list[np.ndarray] = []
         self.momentCoefficients_W_Cg: list[np.ndarray] = []
 
+        # Validate the integrator name against the supported MuJoCo integrators. The
+        # MuJoCoModel sets the validated name in the generated model XML's option
+        # element, so the choice survives saving and loading.
+        integrator = _parameter_validation.str_return_str(integrator, "integrator")
+        if integrator not in _MUJOCO_INTEGRATORS:
+            raise ValueError(
+                f"integrator '{integrator}' is not a supported MuJoCo integrator; "
+                f"expected one of {sorted(_MUJOCO_INTEGRATORS)}."
+            )
+
         # Validate the extra_xml injection-point dict (it must be a dict, or None, whose
         # keys are permitted injection points and whose values are XML fragment strings)
         # and rebuild it from the validated values. Deeper XML correctness is left to
-        # MuJoCo's own parser. These two arguments are the only raw user input forwarded
-        # to the MuJoCoModel, which performs no validation of its own.
+        # MuJoCo's own parser. The integrator, extra_xml, and mujoco_assets arguments
+        # are the only raw user input forwarded to the MuJoCoModel, which performs no
+        # validation of its own.
         if extra_xml is not None:
             if not isinstance(extra_xml, dict):
                 raise TypeError("extra_xml must be a dict or None.")
@@ -618,6 +641,7 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             ),
             I_BP1_CgP1=self._I_BP1_CgP1,
             delta_time=movement.delta_time,
+            integrator=integrator,
             extra_xml=extra_xml,
             mujoco_assets=mujoco_assets,
         )

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -418,8 +418,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
 
     external_loads_fn: A callable that computes additional forces and moments to apply
     to the Airplane during the simulation, or None.
-
-    mujoco_model: The MuJoCoModel used for rigid body dynamics integration.
     """
 
     __slots__ = (
@@ -647,10 +645,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         | None
     ):
         return self._external_loads_fn
-
-    @property
-    def mujoco_model(self) -> _mujoco_model.MuJoCoModel:
-        return self._mujoco_model
 
     @property
     def _free_flight_movement(self) -> free_flight_movement.FreeFlightMovement:

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -483,7 +483,9 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             return value is validated on the callable's first invocation; a return that
             is not a pair of (3,) finite numeric vectors raises a descriptive error. The
             physical correctness of the forces and moments themselves is not checked.
-            Setting this to None applies no additional loads. The default is None.
+            Setting this to None applies no additional loads. The default is None. This
+            is the only mechanism for non-aerodynamic loads in free flight: the
+            OperatingPoint's externalFX_W is never applied and must be zero.
         :param integrator: A str naming the MuJoCo integrator used to advance the rigid
             body dynamics. It must be one of "Euler", "RK4", "implicit", or
             "implicitfast". The choice is baked into the generated MuJoCo model XML, so
@@ -564,6 +566,17 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                 f"mass * |g_E| is {expected_weight} N. Set the Airplane's weight, the "
                 "mass, and the OperatingPoint's g_E so they agree (for a zero-gravity "
                 "simulation, leave both g_E and the weight at zero)."
+            )
+
+        # The free-flight dynamics never apply externalFX_W: non-aerodynamic loads
+        # enter free flight only through external_loads_fn, which is strictly more
+        # capable (full force and moment, time varying). A nonzero value would be
+        # silently ignored, so raise instead.
+        if initial_operating_point.externalFX_W != 0.0:
+            raise ValueError(
+                "The OperatingPoint's externalFX_W must be zero for free flight. The "
+                "free-flight dynamics never apply externalFX_W; use external_loads_fn "
+                "to model thrust or other additional loads."
             )
 
         if external_loads_fn is not None and not callable(external_loads_fn):

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -204,7 +204,7 @@ def make_with_body_rates_unsteady_problem_fixture():
 
 
 def make_basic_free_flight_unsteady_problem_fixture(
-    base_operating_point=None, external_loads_fn=None
+    base_operating_point=None, external_loads_fn=None, mujoco_assets=None
 ):
     """This method makes a fixture that is a FreeFlightUnsteadyProblem for general
     testing.
@@ -216,6 +216,9 @@ def make_basic_free_flight_unsteady_problem_fixture(
         A callable that computes additional forces and moments to apply to the Airplane
         during the simulation. If None, no additional loads are applied. The default is
         None.
+    :param mujoco_assets: dict or None
+        A dict mapping virtual filenames to their binary contents for the MuJoCo model.
+        If None, no extra assets are provided. The default is None.
     :return basic_free_flight_unsteady_problem_fixture: FreeFlightUnsteadyProblem
         This is the FreeFlightUnsteadyProblem configured for general testing.
     """
@@ -290,6 +293,7 @@ def make_basic_free_flight_unsteady_problem_fixture(
         mass=mass,
         I_BP1_CgP1=np.diag([1.0, 1.0, 1.0]),
         external_loads_fn=external_loads_fn,
+        mujoco_assets=mujoco_assets,
     )
 
     return basic_free_flight_unsteady_problem_fixture

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -317,6 +317,7 @@ def make_basic_coupled_unsteady_problem_fixture():
     """
     # SteadyProblem sets GP1_CgP1 attributes on each Panel exactly once, so a fresh
     # Airplane is required for every _CoupledUnsteadyProblem instance.
+    # noinspection PyProtectedMember
     basic_coupled_unsteady_problem_fixture = ps.problems._CoupledUnsteadyProblem(
         movement=core_movement_fixtures.make_static_core_movement_fixture(),
         initial_airplanes=[geometry_fixtures.make_first_airplane_fixture()],

--- a/tests/unit/test_aeroelastic_wing_movement.py
+++ b/tests/unit/test_aeroelastic_wing_movement.py
@@ -415,6 +415,7 @@ class TestAeroelasticWingMovementSecondDerivativeValidation(unittest.TestCase):
         a tuple, and stored correctly.
         """
 
+        # noinspection PyUnusedLocal
         def custom_spacing(t):
             return 0.0
 
@@ -450,6 +451,7 @@ class TestAeroelasticWingMovementSecondDerivativeValidation(unittest.TestCase):
         matching second derivative raises ValueError.
         """
 
+        # noinspection PyUnusedLocal
         def custom_spacing(t):
             return 0.0
 
@@ -508,6 +510,7 @@ class TestAeroelasticWingMovementDeepCopy(unittest.TestCase):
             _make_base_wing_and_wing_cross_section_movements()
         )
 
+        # noinspection PyUnusedLocal
         def custom_spacing(t):
             return 0.0
 

--- a/tests/unit/test_airplane.py
+++ b/tests/unit/test_airplane.py
@@ -1,5 +1,6 @@
 """This module contains classes to test Airplanes."""
 
+import copy
 import unittest
 from unittest.mock import PropertyMock, patch
 
@@ -465,8 +466,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_new_instance(self):
         """Test that deepcopy creates a new Airplane instance."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -475,8 +474,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_airplane_parameters(self):
         """Test that deepcopy preserves Airplane parameters."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -489,8 +486,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_independent_cg_array(self):
         """Test that deepcopy creates an independent copy of Cg_GP1_CgP1."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -498,8 +493,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_independent_wings(self):
         """Test that deepcopy creates independent Wing copies."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -510,8 +503,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_multi_wing_airplane(self):
         """Test that deepcopy works correctly for multi wing Airplanes."""
-        import copy
-
         original = self.multi_wing_airplane
         copied = copy.deepcopy(original)
 
@@ -523,8 +514,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_resets_forces_and_moments(self):
         """Test that deepcopy resets forces and moments to None."""
-        import copy
-
         original = self.basic_airplane
         original.forces_W = np.array([1.0, 2.0, 3.0])
         original.moments_W_CgP1 = np.array([0.1, 0.2, 0.3])
@@ -540,8 +529,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_num_panels(self):
         """Test that deepcopy preserves the total number of Panels."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -549,8 +536,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_wing_panels(self):
         """Test that deepcopy preserves Wing Panels."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -567,8 +552,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_resets_wing_wake_state(self):
         """Test that deepcopy resets wake state in all Wings."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -577,8 +560,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_copied_airplane_is_functional(self):
         """Test that copied Airplanes are fully functional."""
-        import copy
-
         original = self.basic_airplane
         copied = copy.deepcopy(original)
 
@@ -594,8 +575,6 @@ class TestAirplaneDeepCopy(unittest.TestCase):
 
     def test_deepcopy_first_airplane(self):
         """Test that deepcopy works correctly for first Airplane (Cg at origin)."""
-        import copy
-
         original = self.first_airplane
         copied = copy.deepcopy(original)
 

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -166,6 +166,39 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
                 mujoco_assets={"dummy.stl": "not bytes"},
             )
 
+    def test_integrator_type_validation(self):
+        """Test that integrator must be a str."""
+        movement, mass = _movement_and_mass()
+        with self.assertRaises(TypeError):
+            ps.problems.FreeFlightUnsteadyProblem(
+                movement=movement,
+                mass=mass,
+                I_BP1_CgP1=np.eye(3, dtype=float),
+                integrator=4,
+            )
+
+    def test_integrator_value_validation(self):
+        """Test that integrator must be a supported MuJoCo integrator."""
+        movement, mass = _movement_and_mass()
+        with self.assertRaises(ValueError):
+            ps.problems.FreeFlightUnsteadyProblem(
+                movement=movement,
+                mass=mass,
+                I_BP1_CgP1=np.eye(3, dtype=float),
+                integrator="rk4",
+            )
+
+    def test_integrator_forwarded_to_mujoco_model(self):
+        """Test that the integrator choice reaches the generated MuJoCo XML."""
+        movement, mass = _movement_and_mass()
+        problem = ps.problems.FreeFlightUnsteadyProblem(
+            movement=movement,
+            mass=mass,
+            I_BP1_CgP1=np.eye(3, dtype=float),
+            integrator="implicitfast",
+        )
+        self.assertIn('integrator="implicitfast"', problem._mujoco_model.xml_str)
+
     def test_external_loads_fn_default_none(self):
         """Test that external_loads_fn defaults to None."""
         self.assertIsNone(self.problem.external_loads_fn)

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -188,6 +188,14 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
                 integrator="rk4",
             )
 
+    def test_externalFX_W_validation(self):
+        """Test that a nonzero externalFX_W on the initial OperatingPoint raises."""
+        base_operating_point = ps.operating_point.OperatingPoint(externalFX_W=10.0)
+        with self.assertRaises(ValueError):
+            problem_fixtures.make_basic_free_flight_unsteady_problem_fixture(
+                base_operating_point=base_operating_point
+            )
+
     def test_integrator_forwarded_to_mujoco_model(self):
         """Test that the integrator choice reaches the generated MuJoCo XML."""
         movement, mass = _movement_and_mass()

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -19,6 +19,7 @@ def _movement_and_mass():
     :return: A tuple of the FreeFlightMovement and the consistent mass in kilograms.
     """
     fixture_problem = problem_fixtures.make_basic_free_flight_unsteady_problem_fixture()
+    # noinspection PyProtectedMember
     return fixture_problem._free_flight_movement, fixture_problem.mass
 
 
@@ -172,6 +173,7 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
     def test_external_loads_fn_stored_when_callable(self):
         """Test that a callable external_loads_fn is stored and returned."""
 
+        # noinspection PyUnusedLocal
         def external_loads_fn(operating_point, airplane):
             return np.zeros(3, dtype=float), np.zeros(3, dtype=float)
 
@@ -265,7 +267,7 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
         # noinspection PyProtectedMember
         from pterasoftware import _mujoco_model
 
-        self.assertIsInstance(self.problem.mujoco_model, _mujoco_model.MuJoCoModel)
+        self.assertIsInstance(self.problem._mujoco_model, _mujoco_model.MuJoCoModel)
 
     def test_mass_attribute(self):
         """Test that mass is stored as a float."""
@@ -346,7 +348,8 @@ class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
         self.problem._mujoco_model = mock_model
         return mock_model
 
-    def _primed_problem_and_solver(self, external_loads_fn):
+    @staticmethod
+    def _primed_problem_and_solver(external_loads_fn):
         """Build a problem carrying the given external_loads_fn and a primed mock solver.
 
         Mirrors setUp's load priming and _mock_mujoco_model, but for a fresh problem that
@@ -629,11 +632,6 @@ class TestFreeFlightUnsteadyProblemImmutability(unittest.TestCase):
         """Test that the external_loads_fn property is read only."""
         with self.assertRaises(AttributeError):
             self.problem.external_loads_fn = None
-
-    def test_immutable_mujoco_model_property(self):
-        """Test that the mujoco_model property is read only."""
-        with self.assertRaises(AttributeError):
-            self.problem.mujoco_model = None
 
     def test_immutable_num_steps_property(self):
         """Test that the num_steps property is read only."""

--- a/tests/unit/test_movement.py
+++ b/tests/unit/test_movement.py
@@ -2237,7 +2237,7 @@ class TestOptimizeDeltaTimeNonStaticWarnings(unittest.TestCase):
         # with num_steps, so the best is at min_num_steps (lower bound = largest
         # delta_time). Mirrors the original 1.0 / delta_time shape via
         # delta_time = lcm_period / num_steps.
-        # noinspection PyUnusedLocal
+        # noinspection PyUnusedLocal,PyShadowingNames
         def mock_cached_mismatches(
             airplane_movements,
             operating_point_movement,
@@ -2298,7 +2298,7 @@ class TestOptimizeDeltaTimeNonStaticWarnings(unittest.TestCase):
         # with num_steps, so the best is at max_num_steps (upper bound =
         # smallest delta_time). Mirrors the original delta_time * 10.0 shape
         # via delta_time = lcm_period / num_steps.
-        # noinspection PyUnusedLocal
+        # noinspection PyUnusedLocal,PyShadowingNames
         def mock_cached_mismatches(
             airplane_movements,
             operating_point_movement,

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -156,6 +156,11 @@ class TestMuJoCoModelInit(unittest.TestCase):
             mujoco_assets=mujoco_assets,
         )
         self.assertIsInstance(model, _mujoco_model.MuJoCoModel)
+        self.assertIs(model._mujoco_assets, mujoco_assets)
+
+    def test_mujoco_assets_default_none(self):
+        """Test that the retained mujoco_assets defaults to None."""
+        self.assertIsNone(self.model._mujoco_assets)
 
     def test_rotated_initial_orientation(self):
         """Test that a rotated initial orientation produces correct initial state."""

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -33,6 +33,29 @@ class TestMuJoCoModelInit(unittest.TestCase):
         delta_time = mujoco_model_fixtures.make_basic_mujoco_model_delta_time_fixture()
         self.assertIn(str(delta_time), self.model.xml_str)
 
+    def test_xml_str_contains_default_integrator(self):
+        """Test that the generated XML defaults to the RK4 integrator."""
+        self.assertIn('integrator="RK4"', self.model.xml_str)
+
+    def test_accepts_integrator(self):
+        """Test that MuJoCoModel accepts an integrator, injects it into the XML, and
+        the compiled model uses it.
+        """
+        model = _mujoco_model.MuJoCoModel(
+            name="integrator_test",
+            mass=1.0,
+            omegas_BP1__E=(0.0, 0.0, 0.0),
+            T_pas_BP1_CgP1_to_E_CgP1=np.eye(4, dtype=float),
+            vCg_E__E=(10.0, 0.0, 0.0),
+            I_BP1_CgP1=np.eye(3, dtype=float),
+            delta_time=0.01,
+            integrator="implicitfast",
+        )
+        self.assertIn('integrator="implicitfast"', model.xml_str)
+        self.assertEqual(
+            model._model.opt.integrator, mujoco.mjtIntegrator.mjINT_IMPLICITFAST
+        )
+
     def test_model_is_mj_model(self):
         """Test that the internal model object is an MjModel."""
         self.assertIsInstance(self.model._model, mujoco.MjModel)

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -34,12 +34,12 @@ class TestMuJoCoModelInit(unittest.TestCase):
         self.assertIn(str(delta_time), self.model.xml_str)
 
     def test_model_is_mj_model(self):
-        """Test that the model property returns an MjModel."""
-        self.assertIsInstance(self.model.model, mujoco.MjModel)
+        """Test that the internal model object is an MjModel."""
+        self.assertIsInstance(self.model._model, mujoco.MjModel)
 
     def test_data_is_mj_data(self):
-        """Test that the data property returns an MjData."""
-        self.assertIsInstance(self.model.data, mujoco.MjData)
+        """Test that the internal data object is an MjData."""
+        self.assertIsInstance(self.model._data, mujoco.MjData)
 
     def test_body_id_is_int(self):
         """Test that body_id is an int."""
@@ -72,17 +72,17 @@ class TestMuJoCoModelInit(unittest.TestCase):
         expected_mass = mujoco_model_fixtures.make_basic_mujoco_model_mass_fixture()
 
         body_id = self.model.body_id
-        actual_mass = self.model.model.body_mass[body_id]
+        actual_mass = self.model._model.body_mass[body_id]
         self.assertAlmostEqual(actual_mass, expected_mass, places=10)
 
     def test_timestep_set_on_model(self):
         """Test that the MuJoCo model timestep matches delta_time."""
         delta_time = mujoco_model_fixtures.make_basic_mujoco_model_delta_time_fixture()
-        self.assertAlmostEqual(self.model.model.opt.timestep, delta_time, places=14)
+        self.assertAlmostEqual(self.model._model.opt.timestep, delta_time, places=14)
 
     def test_gravity_disabled_in_mujoco(self):
         """Test that gravity is set to zero in the MuJoCo model."""
-        npt.assert_array_equal(self.model.model.opt.gravity, [0.0, 0.0, 0.0])
+        npt.assert_array_equal(self.model._model.opt.gravity, [0.0, 0.0, 0.0])
 
     def test_accepts_extra_xml(self):
         """Test that MuJoCoModel accepts extra_xml and injects it into the XML."""
@@ -181,11 +181,6 @@ class TestMuJoCoModelImmutability(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.model.xml_str = "new xml"
 
-    def test_immutable_model_raises_attribute_error(self):
-        """Test that setting model raises AttributeError."""
-        with self.assertRaises(AttributeError):
-            self.model.model = None
-
     def test_immutable_body_id_raises_attribute_error(self):
         """Test that setting body_id raises AttributeError."""
         with self.assertRaises(AttributeError):
@@ -205,11 +200,6 @@ class TestMuJoCoModelImmutability(unittest.TestCase):
         """Test that setting initial_qvel raises AttributeError."""
         with self.assertRaises(AttributeError):
             self.model.initial_qvel = np.zeros(6)
-
-    def test_immutable_data_raises_attribute_error(self):
-        """Test that setting data raises AttributeError."""
-        with self.assertRaises(AttributeError):
-            self.model.data = None
 
     def test_initial_qpos_is_read_only_array(self):
         """Test that initial_qpos array is not writeable."""
@@ -235,7 +225,7 @@ class TestMuJoCoModelApplyLoads(unittest.TestCase):
         moments_E_CgP1 = np.array([0.0, 0.0, 0.0])
         self.model.apply_loads(forces_E, moments_E_CgP1)
 
-        applied = self.model.data.xfrc_applied[self.model.body_id]
+        applied = self.model._data.xfrc_applied[self.model.body_id]
         npt.assert_allclose(applied[0:3], forces_E, atol=1e-14)
 
     def test_apply_loads_sets_moments(self):
@@ -244,7 +234,7 @@ class TestMuJoCoModelApplyLoads(unittest.TestCase):
         moments_E_CgP1 = np.array([4.0, 5.0, 6.0])
         self.model.apply_loads(forces_E, moments_E_CgP1)
 
-        applied = self.model.data.xfrc_applied[self.model.body_id]
+        applied = self.model._data.xfrc_applied[self.model.body_id]
         npt.assert_allclose(applied[3:6], moments_E_CgP1, atol=1e-14)
 
     def test_apply_loads_overwrites_previous(self):
@@ -252,7 +242,7 @@ class TestMuJoCoModelApplyLoads(unittest.TestCase):
         self.model.apply_loads([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
         self.model.apply_loads([10.0, 0.0, 0.0], [0.0, 0.0, 0.0])
 
-        applied = self.model.data.xfrc_applied[self.model.body_id]
+        applied = self.model._data.xfrc_applied[self.model.body_id]
         npt.assert_allclose(applied[0:3], [10.0, 0.0, 0.0], atol=1e-14)
         npt.assert_allclose(applied[3:6], [0.0, 0.0, 0.0], atol=1e-14)
 
@@ -268,7 +258,7 @@ class TestMuJoCoModelStep(unittest.TestCase):
         """Test that step advances the simulation time by delta_time."""
         delta_time = mujoco_model_fixtures.make_basic_mujoco_model_delta_time_fixture()
         self.model.step()
-        self.assertAlmostEqual(self.model.data.time, delta_time, places=14)
+        self.assertAlmostEqual(self.model._data.time, delta_time, places=14)
 
     def test_multiple_steps_advance_time(self):
         """Test that multiple steps advance time correctly."""
@@ -276,7 +266,7 @@ class TestMuJoCoModelStep(unittest.TestCase):
         num_steps = 10
         for _ in range(num_steps):
             self.model.step()
-        self.assertAlmostEqual(self.model.data.time, num_steps * delta_time, places=10)
+        self.assertAlmostEqual(self.model._data.time, num_steps * delta_time, places=10)
 
     def test_step_with_force_changes_velocity(self):
         """Test that stepping with an applied force changes the velocity."""
@@ -381,7 +371,7 @@ class TestMuJoCoModelReset(unittest.TestCase):
         self.model.step()
         self.model.step()
         self.model.reset()
-        self.assertAlmostEqual(self.model.data.time, 0.0, places=14)
+        self.assertAlmostEqual(self.model._data.time, 0.0, places=14)
 
     def test_reset_restores_initial_qpos(self):
         """Test that reset restores initial generalized positions."""
@@ -390,7 +380,7 @@ class TestMuJoCoModelReset(unittest.TestCase):
         for _ in range(10):
             self.model.step()
         self.model.reset()
-        npt.assert_allclose(self.model.data.qpos, initial_qpos, atol=1e-14)
+        npt.assert_allclose(self.model._data.qpos, initial_qpos, atol=1e-14)
 
     def test_reset_restores_initial_qvel(self):
         """Test that reset restores initial generalized velocities."""
@@ -399,13 +389,13 @@ class TestMuJoCoModelReset(unittest.TestCase):
         for _ in range(10):
             self.model.step()
         self.model.reset()
-        npt.assert_allclose(self.model.data.qvel, initial_qvel, atol=1e-14)
+        npt.assert_allclose(self.model._data.qvel, initial_qvel, atol=1e-14)
 
     def test_reset_clears_applied_loads(self):
         """Test that reset clears any applied loads."""
         self.model.apply_loads([100.0, 200.0, 300.0], [10.0, 20.0, 30.0])
         self.model.reset()
-        applied = self.model.data.xfrc_applied[self.model.body_id]
+        applied = self.model._data.xfrc_applied[self.model.body_id]
         npt.assert_array_equal(applied, np.zeros(6))
 
     def test_reset_produces_same_state_as_init(self):
@@ -459,7 +449,7 @@ class TestMuJoCoModelConventions(unittest.TestCase):
         With a 90 degree pitch about the y axis, the body's +x direction points along
         Earth -z, its +y direction along Earth +y, and its +z direction along Earth +x.
         """
-        xmat = self.model.data.xmat[self.model.body_id].reshape(3, 3)
+        xmat = self.model._data.xmat[self.model.body_id].reshape(3, 3)
         npt.assert_allclose(xmat[:, 0], [0.0, 0.0, -1.0], atol=1e-10)
         npt.assert_allclose(xmat[:, 1], [0.0, 1.0, 0.0], atol=1e-10)
         npt.assert_allclose(xmat[:, 2], [1.0, 0.0, 0.0], atol=1e-10)

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import numpy as np
 import numpy.testing as npt
 
+# noinspection PyProtectedMember
 from pterasoftware._mujoco_model import MuJoCoModel
 
 # noinspection PyProtectedMember
@@ -1990,7 +1991,7 @@ class TestMuJoCoModelRoundTrip(unittest.TestCase):
 
         :return: None
         """
-        model = self.problem.mujoco_model
+        model = self.problem._mujoco_model
         result = _deserialize_value(_serialize_value(model))
         assert isinstance(result, MuJoCoModel)
         self.assertEqual(result.xml_str, model.xml_str)
@@ -2004,7 +2005,7 @@ class TestMuJoCoModelRoundTrip(unittest.TestCase):
 
         :return: None
         """
-        result = _deserialize_value(_serialize_value(self.problem.mujoco_model))
+        result = _deserialize_value(_serialize_value(self.problem._mujoco_model))
         assert isinstance(result, MuJoCoModel)
         state = result.get_state()
         self.assertEqual(
@@ -2115,9 +2116,9 @@ class TestFreeFlightUnsteadyProblemRoundTrip(unittest.TestCase):
         npt.assert_array_equal(result.I_BP1_CgP1, problem.I_BP1_CgP1)
         self.assertEqual(result.mass, problem.mass)
         self.assertIsNone(result.external_loads_fn)
-        self.assertIsInstance(result.mujoco_model, MuJoCoModel)
+        self.assertIsInstance(result._mujoco_model, MuJoCoModel)
         # The rebuilt MuJoCoModel is functional.
-        result.mujoco_model.step()
+        result._mujoco_model.step()
 
     def test_load_history_round_trip(self):
         """Tests that recorded load-history arrays survive a round trip.
@@ -2141,6 +2142,7 @@ class TestFreeFlightUnsteadyProblemRoundTrip(unittest.TestCase):
         :return: None
         """
 
+        # noinspection PyUnusedLocal
         def external_loads_fn(operating_point, airplane):
             return np.zeros(3, dtype=float), np.zeros(3, dtype=float)
 

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1999,6 +1999,25 @@ class TestMuJoCoModelRoundTrip(unittest.TestCase):
         npt.assert_array_equal(result.initial_qpos, model.initial_qpos)
         npt.assert_array_equal(result.initial_qvel, model.initial_qvel)
 
+    def test_mujoco_assets_model_is_not_serializable(self):
+        """Tests that a MuJoCoModel built with mujoco_assets raises on serialization,
+        since the engine rebuilt on load could not resolve the asset references.
+
+        :return: None
+        """
+        model = MuJoCoModel(
+            name="assets_test",
+            mass=1.0,
+            omegas_BP1__E=np.zeros(3, dtype=float),
+            T_pas_BP1_CgP1_to_E_CgP1=np.eye(4, dtype=float),
+            vCg_E__E=np.array([10.0, 0.0, 0.0]),
+            I_BP1_CgP1=np.eye(3, dtype=float),
+            delta_time=0.01,
+            mujoco_assets={"dummy.txt": b"placeholder"},
+        )
+        with self.assertRaises(ValueError):
+            _serialize_value(model)
+
     def test_rebuilt_engine_is_functional(self):
         """Tests that a round-tripped MuJoCoModel can be queried and stepped, confirming
         its native model and data objects were rebuilt from the XML string.
@@ -2148,6 +2167,19 @@ class TestFreeFlightUnsteadyProblemRoundTrip(unittest.TestCase):
 
         problem = problem_fixtures.make_basic_free_flight_unsteady_problem_fixture(
             external_loads_fn=external_loads_fn
+        )
+        with self.assertRaises(ValueError):
+            _serialize_value(problem)
+
+    def test_mujoco_assets_problem_is_not_serializable(self):
+        """Tests that a FreeFlightUnsteadyProblem whose MuJoCoModel was built with
+        mujoco_assets raises on serialization, matching the external_loads_fn
+        disposition.
+
+        :return: None
+        """
+        problem = problem_fixtures.make_basic_free_flight_unsteady_problem_fixture(
+            mujoco_assets={"dummy.txt": b"placeholder"}
         )
         with self.assertRaises(ValueError):
             _serialize_value(problem)

--- a/tests/unit/test_slots.py
+++ b/tests/unit/test_slots.py
@@ -816,7 +816,6 @@ class TestFreeFlightUnsteadyProblemSlots(unittest.TestCase):
         self.assertEqual(self.problem.I_BP1_CgP1.shape, (3, 3))
         self.assertIsInstance(self.problem.mass, float)
         self.assertIsNone(self.problem.external_loads_fn)
-        self.assertIsInstance(self.problem.mujoco_model, _mujoco_model.MuJoCoModel)
         self.assertIsInstance(self.problem.forces_W, list)
         self.assertIsInstance(self.problem.forceCoefficients_W, list)
         self.assertIsInstance(self.problem.moments_W_Cg, list)

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -1082,8 +1082,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_new_instance(self):
         """Test that deepcopy creates a new Wing instance."""
-        import copy
-
         original = self.type_1_wing
         copied = copy.deepcopy(original)
 
@@ -1092,8 +1090,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_wing_parameters(self):
         """Test that deepcopy preserves Wing parameters."""
-        import copy
-
         original = self.type_1_wing
         copied = copy.deepcopy(original)
 
@@ -1109,8 +1105,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_independent_arrays(self):
         """Test that deepcopy creates independent copies of numpy arrays."""
-        import copy
-
         original = self.type_1_wing
         copied = copy.deepcopy(original)
 
@@ -1119,8 +1113,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_creates_independent_wing_cross_sections(self):
         """Test that deepcopy creates independent WingCrossSection copies."""
-        import copy
-
         original = self.type_1_wing
         copied = copy.deepcopy(original)
 
@@ -1135,8 +1127,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_symmetry_attributes(self):
         """Test that deepcopy preserves symmetry attributes correctly."""
-        import copy
-
         original = self.type_4_wing
         copied = copy.deepcopy(original)
 
@@ -1149,8 +1139,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_none_symmetry_attributes(self):
         """Test that deepcopy handles None symmetry attributes correctly."""
-        import copy
-
         original = self.type_1_wing
         copied = copy.deepcopy(original)
 
@@ -1159,8 +1147,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_unmeshed_wing(self):
         """Test that deepcopy handles unmeshed Wings correctly."""
-        import copy
-
         original = self.type_1_wing
         self.assertIsNone(original.panels)
 
@@ -1174,8 +1160,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_meshed_wing_preserves_mesh_metadata(self):
         """Test that deepcopy preserves mesh metadata for meshed Wings."""
-        import copy
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1187,8 +1171,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_meshed_wing_preserves_panels(self):
         """Test that deepcopy preserves Panels for meshed Wings."""
-        import copy
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1206,8 +1188,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_resets_wake_state(self):
         """Test that deepcopy resets wake state to an empty array."""
-        import copy
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1222,8 +1202,6 @@ class TestWingDeepCopy(unittest.TestCase):
     def test_deepcopy_independence_modifying_copy_mutable_attrs(self):
         """Test that modifying mutable attributes on the copy does not affect the
         original."""
-        import copy
-
         original = self.type_4_wing
         original.generate_mesh(4)
         original_symmetric = original.symmetric
@@ -1242,8 +1220,6 @@ class TestWingDeepCopy(unittest.TestCase):
     def test_deepcopy_independence_modifying_original_mutable_attrs(self):
         """Test that modifying mutable attributes on the original does not affect the
         copy."""
-        import copy
-
         original = self.type_4_wing
         original.generate_mesh(4)
 
@@ -1313,8 +1289,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_preserves_geometric_properties(self):
         """Test that deepcopy preserves geometric property calculations."""
-        import copy
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1328,8 +1302,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_type_4_wing(self):
         """Test that deepcopy works correctly for type 4 symmetric Wings."""
-        import copy
-
         original = self.type_4_wing
         original.generate_mesh(4)
 
@@ -1342,8 +1314,6 @@ class TestWingDeepCopy(unittest.TestCase):
 
     def test_deepcopy_copied_wing_is_functional(self):
         """Test that copied Wings are fully functional."""
-        import copy
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1369,10 +1339,6 @@ class TestWingDeepCopy(unittest.TestCase):
         be cached as non-None, which exercises the not-None copy branches inside
         __deepcopy__ that are skipped when only calling generate_mesh.
         """
-        import copy
-
-        import numpy.testing as npt
-
         original = self.type_1_wing
         original.generate_mesh(1)
 
@@ -1678,7 +1644,8 @@ class TestSingleStepWingMethods(unittest.TestCase):
     Wing.interpolate_between_wing_cross_sections, and the explode_into_strips
     parameter."""
 
-    def _make_wcs_3span(self):
+    @staticmethod
+    def _make_wcs_3span():
         """Create a root WCS with num_spanwise_panels=3."""
         return ps.geometry.wing_cross_section.WingCrossSection(
             airfoil=ps.geometry.airfoil.Airfoil(name="naca2412"),
@@ -1689,7 +1656,8 @@ class TestSingleStepWingMethods(unittest.TestCase):
             spanwise_spacing="uniform",
         )
 
-    def _make_tip_wcs(self):
+    @staticmethod
+    def _make_tip_wcs():
         """Create a tip WCS with num_spanwise_panels=None."""
         return ps.geometry.wing_cross_section.WingCrossSection(
             airfoil=ps.geometry.airfoil.Airfoil(name="naca2412"),

--- a/tests/unit/test_wing_movement.py
+++ b/tests/unit/test_wing_movement.py
@@ -4,6 +4,7 @@ import unittest
 
 import pterasoftware as ps
 from tests.unit.fixtures import (
+    core_wing_cross_section_movement_fixtures,
     geometry_fixtures,
     wing_cross_section_movement_fixtures,
     wing_movement_fixtures,
@@ -40,8 +41,6 @@ class TestWingMovement(unittest.TestCase):
 
     def test_rejects_core_wing_cross_section_movement_children(self):
         """Test that WingMovement rejects CoreWingCrossSectionMovement instances."""
-        from tests.unit.fixtures import core_wing_cross_section_movement_fixtures
-
         base_wing = geometry_fixtures.make_origin_wing_fixture()
         wing_cross_section_movements = [
             core_wing_cross_section_movement_fixtures.make_static_core_wing_cross_section_movement_fixture(),


### PR DESCRIPTION
# Description

This PR cleans up the public surface of the free-flight rigid body dynamics interface and closes several footguns around it. The MuJoCo engine is now fully internal: `FreeFlightUnsteadyProblem`'s `mujoco_model` property and `MuJoCoModel`'s `model` and `data` properties are removed, so user code can no longer reach the engine mutators (`apply_loads`, `step`, and `reset`) that could desync the rigid body dynamics from the solver mid-run. In their place, the supported configuration surface grows one knob: a validated `integrator` parameter on `FreeFlightUnsteadyProblem`. Two new guards replace silent failure modes: saving an asset-based model now raises instead of producing an unloadable file, and a nonzero `externalFX_W` on a free-flight `OperatingPoint` now raises instead of being silently ignored. Free flight is new and unreleased, so the removals and new guards are non-breaking.

## Motivation

Free flight shipped with its engine internals reachable from user code: the `mujoco_model` property handed out instances of `MuJoCoModel`, a private, no-validation class that is not even importable from the public API, and whose mutating methods can corrupt a run in ways the solver cannot detect. Meanwhile, the genuinely useful engine choice, the integrator, was hardcoded to RK4, which handles contacts poorly, so collision runs driven through `extra_xml` geometry had no supported way to pick a contact-friendly integrator. Two failure modes were also silent: a `FreeFlightUnsteadyProblem` built with `mujoco_assets` saved successfully but produced a file that fails on load (discovered only after the expensive run is gone), and a nonzero `externalFX_W` was propagated onto every per-step `OperatingPoint` without ever being applied, while example prose implied it would act as thrust. This PR makes the internal surface private, the supported surface explicit, and the unsupported configurations loud.

## Relevant Issues

None.

## Changes

* Removed the public `mujoco_model` property from `FreeFlightUnsteadyProblem` and the `model` and `data` properties from `MuJoCoModel`; the engine is now reachable only through the private `_mujoco_model` slot, and the affected unit tests read the private attributes directly.
* Added an `integrator` parameter to `FreeFlightUnsteadyProblem` and `MuJoCoModel`, validated against the supported MuJoCo set (`Euler`, `RK4`, `implicit`, and `implicitfast`) via the new module-level `_MUJOCO_INTEGRATORS` frozenset and baked into the generated XML's `option` element so the choice survives saving and loading. The default, `"RK4"`, preserves the previous behavior; collision runs driven through `extra_xml` geometry should prefer `"implicit"` or `"implicitfast"`.
* `MuJoCoModel` now retains its `mujoco_assets` dict in a new `_mujoco_assets` slot, and `_serialization.py` raises a `ValueError` when saving an asset-based model, since the engine is rebuilt on load from the stored XML alone, whose asset references would be unresolvable. This mirrors the `external_loads_fn` raise-on-save disposition.
* Bumped `_FORMAT_VERSION` from 6 to 7 for the new slot, which is serialized as null because it can only ever be falsy when saving succeeds.
* `FreeFlightUnsteadyProblem.__init__` now raises when the initial `OperatingPoint` carries a nonzero `externalFX_W`, since the free-flight dynamics never apply it; `external_loads_fn` is the single mechanism for non-aerodynamic loads in free flight. The restriction is documented in the `externalFX_W` and `external_loads_fn` docstrings, and the glider example's comment now points at `external_loads_fn` for thrust.
* Added unit tests covering the integrator type and value validation, its forwarding into the generated XML and compiled model, the default RK4 XML, the retained assets dict, both asset raise-on-save paths (`MuJoCoModel` directly and through a `FreeFlightUnsteadyProblem`), and the `externalFX_W` guard; `make_basic_free_flight_unsteady_problem_fixture` gained a `mujoco_assets` passthrough.
* Updated `CLASSES_AND_IMMUTABILITY.md`: the private `_mujoco_model`, `_model`, `_data`, and `_mujoco_assets` slots are documented as having no public properties, the construction-only-parameter paragraphs reflect the new `integrator` parameter and the retained assets dict, and the two redundant Backing Slot table columns are dropped since every backing slot is just the underscore-prefixed attribute name, which the tables' preambles already state.
* Escaped the literal square brackets in `MUJOCO_CONVENTIONS.md`'s section headings so markdown renderers do not parse spans like `qpos[0:3]` as link syntax.
* Quieted PyCharm inspections in the test suite (targeted `noinspection` comments for intentional patterns, in-function imports hoisted to module level, and self-free helpers converted to static methods) and updated the shared inspection profile to ignore the false-positive string-conversion warnings on NumPy types, which define `__str__` and `__repr__` at runtime but not in their type stubs.

## Dependency Updates

None.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
