### PR TITLE
Clarify save-file format-version contract

### DIFF
--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -217,6 +217,13 @@ def save(path: str | Path, obj: object) -> None:
     Gzip compression typically reduces file sizes by 10x or more, and plain ".json"
     files use indented formatting that further increases their size.
 
+    The file records an internal serialization format version. load() accepts a file
+    only when that format version matches the running code's exactly, and there is no
+    migration of files written under a different format version. The format version is
+    independent of the package version and bumps whenever the serialized structure
+    changes. To read a saved file later, run a build of Ptera Software whose format
+    version matches the file's.
+
     :param path: The file path to save to. Should end with ".json" or ".json.gz".
     :param obj: The Ptera Software object to save. Must be a public Ptera Software class
         (e.g., Airplane, SteadyProblem, or a solver). Internal classes such as Panel
@@ -266,6 +273,12 @@ def load(path: str | Path, max_size: int | None = None) -> object:
 
     If the path ends with ".json.gz", the input is gzip decompressed automatically.
 
+    The file records an internal serialization format version. A file is accepted only
+    when that format version matches the running code's exactly, and there is no
+    migration of files written under a different format version. A mismatch raises a
+    ValueError reporting the file's format version and the running code's. To read the
+    file, run a build of Ptera Software whose format version matches the file's.
+
     :param path: The file path to load from.
     :param max_size: The maximum decompressed size in bytes for gzip files. If None, the
         default of 4 GB is used. Set this to a larger value if loading very large
@@ -296,12 +309,18 @@ def load(path: str | Path, max_size: int | None = None) -> object:
 
     data = json.loads(raw)
 
-    # Check format version compatibility.
+    # Check format version compatibility. A file loads only when its stored format
+    # version matches the running code's, and there is no migration path, so a mismatch
+    # is unrecoverable under the running code. The error reports both format versions
+    # only. It names no package version to install: the gate keys on the format integer,
+    # not the package version, and the stored _pterasoftware_version is provenance that
+    # does not reliably identify a build at the file's format version.
     file_version = data.get("_format_version")
     if file_version != _FORMAT_VERSION:
         raise ValueError(
-            f"Format version mismatch: file has version {file_version}, but the "
-            f"current code expects version {_FORMAT_VERSION}."
+            f"Format version mismatch: file has format version {file_version}, but the "
+            f"current code uses format version {_FORMAT_VERSION}. A file loads only "
+            f"under a build of Ptera Software whose format version matches the file's."
         )
 
     # Validate that the top level type is a public saveable class.

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -833,7 +833,8 @@ class TestSaveLoad(unittest.TestCase):
         self.assertIn("_dirty", data)
 
     def test_format_version_mismatch_raises(self):
-        """Tests that loading a file with a mismatched format version raises.
+        """Tests that loading a file with a mismatched format version raises, reporting
+        both format versions and naming no package version.
 
         :return: None
         """
@@ -843,11 +844,16 @@ class TestSaveLoad(unittest.TestCase):
             save(path, operating_point)
             with open(path) as f:
                 data = json.load(f)
+            writing_version = data["_pterasoftware_version"]
             data["_format_version"] = 9999
             with open(path, "w") as f:
                 json.dump(data, f)
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError) as context:
                 load(path)
+        message = str(context.exception)
+        self.assertIn("9999", message)
+        self.assertIn(str(_FORMAT_VERSION), message)
+        self.assertNotIn(writing_version, message)
 
     def test_save_accepts_string_path(self):
         """Tests that save accepts a string path in addition to a Path object.

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -844,8 +844,8 @@ class TestSaveLoad(unittest.TestCase):
             save(path, operating_point)
             with open(path) as f:
                 data = json.load(f)
-            writing_version = data["_pterasoftware_version"]
             data["_format_version"] = 9999
+            data["_pterasoftware_version"] = "4.0.0"
             with open(path, "w") as f:
                 json.dump(data, f)
             with self.assertRaises(ValueError) as context:
@@ -853,7 +853,7 @@ class TestSaveLoad(unittest.TestCase):
         message = str(context.exception)
         self.assertIn("9999", message)
         self.assertIn(str(_FORMAT_VERSION), message)
-        self.assertNotIn(writing_version, message)
+        self.assertNotIn("4.0.0", message)
 
     def test_save_accepts_string_path(self):
         """Tests that save accepts a string path in addition to a Path object.


### PR DESCRIPTION
# Description

Documents the save-file compatibility contract in the `save()` and `load()` docstrings and clarifies the format-version mismatch error in `_serialization.py`. The serialization format version is an internal integer, decoupled from the package version, and `load()` accepts a file only when that integer matches the running code's. This is a documentation and messaging change with no behavior change to the gate itself.

## Motivation

The version-locking policy was invisible to users: neither public docstring mentioned the gate, and the mismatch error reported two bare integers with no context. The error must not point users at a package version to install, because the gate keys on the format integer, not the package version, and the stored `_pterasoftware_version` is provenance that does not reliably identify a build at the file's format version. The fix makes the contract explicit and keeps the error honest about what it can and cannot tell the user.

## Relevant Issues

None.

## Changes

* Added a paragraph to the `save()` and `load()` docstrings in `_serialization.py` stating that a file loads only under a build whose format version matches the file's, with no migration, and framing recovery as running such a build.
* Rewrote the format-version mismatch `ValueError` in `load()` to report both format versions and name no package version to install, and removed the now-unused `_pterasoftware_version` read from the gate.
* Added a code comment explaining why the error names no package version, leaving `_pterasoftware_version` as informational provenance.
* Strengthened `test_format_version_mismatch_raises` in `test_serialization.py` to assert the message reports both format versions and does not contain the writing package version.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
