### PR TITLE
Clean up the unreleased API surface

### DIFF
--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -219,15 +219,11 @@ The rigid body dynamics engine lives in the private `_mujoco_model` slot (a `MuJ
 
 #### Mutable (populated by solver)
 
-These are allocated in `__init__` (the four load-history lists as empty lists, the validation guard as `False`) and updated by the problem's `initialize_next_problem` as the solver advances. They are plain slots rather than read-only properties because they must change after construction, mirroring the mutable-result-list treatment on `CoreUnsteadyProblem`.
+This is allocated in `__init__` (the validation guard as `False`) and updated by the problem's `initialize_next_problem` on the `external_loads_fn`'s first invocation. It is a plain slot rather than a read-only property because it must change after construction.
 
-| Attribute                   | Type               | Notes                                                                                                      |
-|-----------------------------|--------------------|------------------------------------------------------------------------------------------------------------|
-| `forces_W`                  | `list[np.ndarray]` | Per-step aerodynamic force history, in wind axes                                                           |
-| `forceCoefficients_W`       | `list[np.ndarray]` | Per-step aerodynamic force coefficient history                                                             |
-| `moments_W_Cg`              | `list[np.ndarray]` | Per-step aerodynamic moment history, in wind axes about the CG                                             |
-| `momentCoefficients_W_Cg`   | `list[np.ndarray]` | Per-step aerodynamic moment coefficient history                                                            |
-| `_external_loads_validated` | `bool`             | Once-only guard; flips to `True` after the `external_loads_fn` return is validated on its first invocation |
+| Attribute                   | Type   | Notes                                                                                                      |
+|-----------------------------|--------|------------------------------------------------------------------------------------------------------------|
+| `_external_loads_validated` | `bool` | Once-only guard; flips to `True` after the `external_loads_fn` return is validated on its first invocation |
 
 #### Construction-only parameters
 

--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -40,7 +40,7 @@ Most attribute falls into one of these categories:
 
 A constructor parameter is not always retained as an attribute. Some parameters shape how an object is built but are deliberately discarded once construction finishes: they have no `__slots__` entry, appear in no attribute-category table, and are not serialized or deep copied, because nothing reads them after `__init__`. They are still validated exactly like their stored counterparts.
 
-`Wing`'s `explode_into_strips` is one example. When True, it triggers `Wing.explode_wing` to replace the supplied wing cross sections with single-strip cross sections, then plays no further role. Storing it would only create a stale provenance flag, since an exploded Wing is indistinguishable from one defined with single-strip cross sections directly. So the validated value lives in a local variable inside `__init__` and is never assigned to `self`, while still passing through `boolLike_return_bool`, the same check applied to the stored bool-likes `symmetric` and `mirror_only`.
+`Wing`'s `explode_into_strips` is one example. When True, it triggers `Wing._explode_wing` to replace the supplied wing cross sections with single-strip cross sections, then plays no further role. Storing it would only create a stale provenance flag, since an exploded Wing is indistinguishable from one defined with single-strip cross sections directly. So the validated value lives in a local variable inside `__init__` and is never assigned to `self`, while still passing through `boolLike_return_bool`, the same check applied to the stored bool-likes `symmetric` and `mirror_only`.
 
 ### Key Decisions
 
@@ -558,7 +558,7 @@ This is allocated in `__init__` (the validation guard as `False`) and updated by
 
 #### Construction-only parameters
 
-`explode_into_strips` is a constructor parameter, not an attribute: when True it triggers `explode_wing` during initialization and is then discarded, so it has no slot and no attribute-category entry above. See Construction-Only Parameters under Design Principles.
+`explode_into_strips` is a constructor parameter, not an attribute: when True it triggers `_explode_wing` during initialization and is then discarded, so it has no slot and no attribute-category entry above. See Construction-Only Parameters under Design Principles.
 
 ## WingCrossSection Class (`geometry/wing_cross_section.py`)
 

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -87,7 +87,7 @@ _CALLABLE_FUNC_TO_NAME = {func: name for name, func in _CALLABLE_NAME_TO_FUNC.it
 
 # Increments only when the serialization structure changes (slots added/removed/
 # renamed, class registry changed, encoding strategy changed).
-_FORMAT_VERSION = 10
+_FORMAT_VERSION = 11
 
 
 def _all_slots(cls: type) -> list[str]:

--- a/pterasoftware/geometry/wing.py
+++ b/pterasoftware/geometry/wing.py
@@ -250,14 +250,14 @@ class Wing:
             either are True. For more details on how this parameter interacts with
             symmetryNormal_G, symmetric, and mirror_only, see the class docstring. The
             units are meters. The default is None.
-        :param explode_into_strips: Set this to True to have the explode_wing method
-            called on this Wing during initialization, replacing wing_cross_sections
-            with a new list in which every panel is broken into single spanwise strips
-            for deformation. When True, every non tip WingCrossSection in
-            wing_cross_sections must have spanwise_spacing="uniform"; the explosion
-            assumes uniformly spaced intermediates and rejects other spacings rather
-            than silently overriding them. This parameter is consumed during
-            initialization and is not stored as an attribute.
+        :param explode_into_strips: Set this to True to replace wing_cross_sections
+            during initialization with a new list in which every panel is broken into
+            single spanwise strips for deformation. When True, every non tip
+            WingCrossSection in wing_cross_sections must have
+            spanwise_spacing="uniform"; the explosion assumes uniformly spaced
+            intermediates and rejects other spacings rather than silently overriding
+            them. This parameter is consumed during initialization and is not stored as
+            an attribute.
         :param num_chordwise_panels: The number of chordwise panels to be used on this
             Wing, which must be set to a positive integer. The default is 8.
         :param chordwise_spacing: The type of spacing between the Wing's chordwise
@@ -274,7 +274,7 @@ class Wing:
             explode_into_strips, "explode_into_strips"
         )
         if explode_into_strips:
-            wing_cross_sections = self.explode_wing(wing_cross_sections)
+            wing_cross_sections = self._explode_wing(wing_cross_sections)
         num_wing_cross_sections = len(wing_cross_sections)
         if num_wing_cross_sections < 2:
             raise ValueError("wing_cross_sections must contain at least two elements.")
@@ -1506,43 +1506,25 @@ class Wing:
 
         return None
 
-    def interpolate_between_wing_cross_sections(
-        self,
+    @staticmethod
+    def _interpolate_between_wing_cross_sections(
         wcs1: wing_cross_section_mod.WingCrossSection,
         wcs2: wing_cross_section_mod.WingCrossSection,
-        first_wcs: bool,
     ) -> list[wing_cross_section_mod.WingCrossSection]:
-        """Wing cross section panels are between the line of wcs1 and wcs2.
+        """Build the single-panel WingCrossSections spanning from just past wcs1 through
+        wcs2.
 
         When exploding a wing to 1 spanwise panel per cross section, we need to
-        interpolate the intermediate cross sections.
+        interpolate the intermediate cross sections. This returns the N sections
+        downstream of wcs1, where N is wcs1's spanwise panel count. The section at wcs1
+        itself is seeded once by _explode_wing, so it is not repeated here.
 
         :param wcs1: The first WingCrossSection.
         :param wcs2: The second WingCrossSection.
-        :param first_wcs: Whether wcs1 is the first WingCrossSection of the wing. If
-            True, the method will include a WingCrossSection with the same parameters as
-            wcs1 in the output list. If False, it will not, since it will have already
-            been included as the last interpolated WingCrossSection between the previous
-            pair of WingCrossSections.
         :return: A list of WingCrossSections representing the interpolated cross
             sections
         """
         interpolated = []
-
-        if first_wcs:
-            interpolated.append(
-                wing_cross_section_mod.WingCrossSection(
-                    num_spanwise_panels=1,
-                    chord=wcs1.chord,
-                    Lp_Wcsp_Lpp=wcs1.Lp_Wcsp_Lpp,
-                    angles_Wcsp_to_Wcs_ixyz=wcs1.angles_Wcsp_to_Wcs_ixyz,
-                    control_surface_symmetry_type=wcs1.control_surface_symmetry_type,
-                    control_surface_hinge_point=wcs1.control_surface_hinge_point,
-                    control_surface_deflection=wcs1.control_surface_deflection,
-                    spanwise_spacing="uniform",
-                    airfoil=wcs1.airfoil,
-                )
-            )
 
         N = wcs1.num_spanwise_panels
         assert N is not None, "wcs1.num_spanwise_panels must not be None"
@@ -1555,7 +1537,7 @@ class Wing:
             # WingCrossSection's constructor docstring), so each of the N intermediates
             # carries 1/N of wcs2's delta and the chain composes back to wcs2's offset
             # and twist. This is exact only when the intermediates are uniformly
-            # spaced, which explode_wing enforces by validating the input.
+            # spaced, which _explode_wing enforces by validating the input.
             Lp_Wcsp_Lpp = tuple(np.array(wcs2.Lp_Wcsp_Lpp) / N)
             angles_Wcsp_to_Wcs_ixyz = wcs2.angles_Wcsp_to_Wcs_ixyz / N
             is_final_section = wcs2.num_spanwise_panels is None and i == N - 1
@@ -1575,7 +1557,7 @@ class Wing:
             )
         return interpolated
 
-    def explode_wing(
+    def _explode_wing(
         self, wing_cross_sections: list[wing_cross_section_mod.WingCrossSection]
     ) -> list[wing_cross_section_mod.WingCrossSection]:
         """Takes a list of WingCrossSections and returns a new list where all cross
@@ -1602,12 +1584,29 @@ class Wing:
                     f"WingCrossSection."
                 )
 
-        new_cross_sections = []
+        # Seed the result with the root strip, then fill in the single-panel sections
+        # spanning each adjacent pair. Seeding the root here, rather than inside the
+        # per-pair interpolation, keeps that helper independent of its position in the
+        # wing.
+        root = wing_cross_sections[0]
+        new_cross_sections = [
+            wing_cross_section_mod.WingCrossSection(
+                num_spanwise_panels=1,
+                chord=root.chord,
+                Lp_Wcsp_Lpp=root.Lp_Wcsp_Lpp,
+                angles_Wcsp_to_Wcs_ixyz=root.angles_Wcsp_to_Wcs_ixyz,
+                control_surface_symmetry_type=root.control_surface_symmetry_type,
+                control_surface_hinge_point=root.control_surface_hinge_point,
+                control_surface_deflection=root.control_surface_deflection,
+                spanwise_spacing="uniform",
+                airfoil=root.airfoil,
+            )
+        ]
 
         for i in range(len(wing_cross_sections) - 1):
             new_cross_sections.extend(
-                self.interpolate_between_wing_cross_sections(
-                    wing_cross_sections[i], wing_cross_sections[i + 1], i == 0
+                self._interpolate_between_wing_cross_sections(
+                    wing_cross_sections[i], wing_cross_sections[i + 1]
                 )
             )
 

--- a/pterasoftware/movements/__init__.py
+++ b/pterasoftware/movements/__init__.py
@@ -24,6 +24,18 @@ aeroelastic_wing_movement.py: Contains the AeroelasticWingMovement class.
 
 airplane_movement.py: Contains the AirplaneMovement class.
 
+free_flight_airplane_movement.py: Contains the FreeFlightAirplaneMovement class.
+
+free_flight_movement.py: Contains the FreeFlightMovement class.
+
+free_flight_operating_point_movement.py: Contains the FreeFlightOperatingPointMovement
+class.
+
+free_flight_wing_cross_section_movement.py: Contains the
+FreeFlightWingCrossSectionMovement class.
+
+free_flight_wing_movement.py: Contains the FreeFlightWingMovement class.
+
 movement.py: Contains the Movement class.
 
 operating_point_movement.py: Contains the OperatingPointMovement class.
@@ -39,6 +51,11 @@ import pterasoftware.movements.aeroelastic_operating_point_movement
 import pterasoftware.movements.aeroelastic_wing_cross_section_movement
 import pterasoftware.movements.aeroelastic_wing_movement
 import pterasoftware.movements.airplane_movement
+import pterasoftware.movements.free_flight_airplane_movement
+import pterasoftware.movements.free_flight_movement
+import pterasoftware.movements.free_flight_operating_point_movement
+import pterasoftware.movements.free_flight_wing_cross_section_movement
+import pterasoftware.movements.free_flight_wing_movement
 import pterasoftware.movements.movement
 import pterasoftware.movements.operating_point_movement
 import pterasoftware.movements.wing_cross_section_movement

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -450,10 +450,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         "_external_loads_validated",
         "_k_max",
         "_mujoco_model",
-        "forces_W",
-        "forceCoefficients_W",
-        "moments_W_Cg",
-        "momentCoefficients_W_Cg",
     )
 
     def __init__(
@@ -626,13 +622,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             min_val=0,
             min_inclusive=False,
         )
-
-        # Initialize empty lists to hold the loads and load coefficients experienced by
-        # each time step's Airplane.
-        self.forces_W: list[np.ndarray] = []
-        self.forceCoefficients_W: list[np.ndarray] = []
-        self.moments_W_Cg: list[np.ndarray] = []
-        self.momentCoefficients_W_Cg: list[np.ndarray] = []
 
         # Validate the integrator name against the supported MuJoCo integrators. The
         # MuJoCoModel sets the validated name in the generated model XML's option
@@ -1279,8 +1268,7 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         the body advances once. During the free flight phase (once the step index
         reaches the movement's prescribed_num_steps), the aerodynamic loads and the
         rigid body state are driven to mutual consistency by the strongly coupled sub-
-        iteration before the next step is committed. On every step (including the last
-        one), records the current step's loads in the load history lists.
+        iteration before the next step is committed.
 
         :param solver: The CoupledUnsteadyRingVortexLatticeMethodSolver instance
             providing aerodynamic data from the current time step.
@@ -1289,16 +1277,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         """
         current_airplane = solver.current_airplanes[0]
         current_operating_point = solver.current_operating_point
-
-        # The solver populates these load attributes via _calculate_loads before
-        # invoking this method.
-        assert current_airplane.forces_W is not None
-        assert current_airplane.forceCoefficients_W is not None
-        assert current_airplane.moments_W_CgP1 is not None
-        assert current_airplane.momentCoefficients_W_CgP1 is not None
-
-        aeroForces_W = current_airplane.forces_W
-        aeroMoments_W_CgP1 = current_airplane.moments_W_CgP1
 
         if step < self.num_steps - 1:
             if step >= self._free_flight_movement.prescribed_num_steps:
@@ -1325,14 +1303,6 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                     new_state, current_operating_point
                 )
                 self._commit_next_problem(next_operating_point, step)
-
-        # Store the current step's loads in the load history.
-        self.forces_W.append(np.copy(aeroForces_W))
-        self.forceCoefficients_W.append(np.copy(current_airplane.forceCoefficients_W))
-        self.moments_W_Cg.append(np.copy(aeroMoments_W_CgP1))
-        self.momentCoefficients_W_Cg.append(
-            np.copy(current_airplane.momentCoefficients_W_CgP1)
-        )
 
 
 class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,24 +1,5 @@
-"""This package contains the tests for Ptera Software.
-
-This package contains the following subpackages:
-    integration: This package contains integration tests.
-    unit: This package contains the unit tests.
-
-This package contains the following directories:
-    benchmarks: This directory contains benchmark scripts and results.
-    references: This directory contains reference files for tests.
-
-This package contains the following modules:
-    __init__.py: This module is this package's initialization script.
-
-    _test_environment.py: This module quiets known sources of test run noise
-    (serialization dirty tree warnings, tqdm progress bars, and the VTK
-    headless display warning). It is imported first so its side effects take
-    effect before any pterasoftware, pyvista, or tqdm module loads.
-"""
+"""Contains the tests for Ptera Software."""
 
 # Must be the first import so environment variables are set before any other
 # module reads them.
 import tests._test_environment  # noqa: F401
-import tests.integration
-import tests.unit

--- a/tests/integration/test_free_flight_unsteady_ring_vortex_lattice_method.py
+++ b/tests/integration/test_free_flight_unsteady_ring_vortex_lattice_method.py
@@ -45,7 +45,7 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethod(unittest.TestCase):
         operating_points = problem.movement.operating_point_movement.operating_points
 
         # Extract per-time-step time histories from the dynamically populated
-        # OperatingPoints and the problem's recorded aerodynamic load history.
+        # OperatingPoints and each time step's solved Airplane.
         cls.speeds = np.array(
             [operating_point.vCg__E for operating_point in operating_points]
         )
@@ -64,7 +64,12 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethod(unittest.TestCase):
 
         # In Ptera Software's wind axes, lift is the negative z-component of the wind-axes
         # force.
-        forces_W = np.array(problem.forces_W)
+        forces_W = np.array(
+            [
+                steady_problem.airplanes[0].forces_W
+                for steady_problem in problem.steady_problems
+            ]
+        )
         cls.lifts = -forces_W[:, 2]
         cls.side_forces = forces_W[:, 1]
 
@@ -219,7 +224,7 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethodFlapping(unittest.TestCase):
         operating_points = problem.movement.operating_point_movement.operating_points
 
         # Extract per-time-step time histories from the dynamically populated
-        # OperatingPoints and the problem's recorded aerodynamic load history.
+        # OperatingPoints and each time step's solved Airplane.
         cls.betas = np.array(
             [operating_point.beta for operating_point in operating_points]
         )
@@ -229,7 +234,12 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethodFlapping(unittest.TestCase):
 
         # In Ptera Software's wind axes, lift is the negative z-component of the wind-axes
         # force and the lateral side force is the y-component.
-        forces_W = np.array(problem.forces_W)
+        forces_W = np.array(
+            [
+                steady_problem.airplanes[0].forces_W
+                for steady_problem in problem.steady_problems
+            ]
+        )
         cls.forces_W = forces_W
         cls.lifts = -forces_W[:, 2]
         cls.side_forces = forces_W[:, 1]

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -284,20 +284,6 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
             ps.problems.SteadyProblem,
         )
 
-    def test_initialization_of_load_lists(self):
-        """Test that load lists are initialized as empty."""
-        self.assertIsInstance(self.problem.forces_W, list)
-        self.assertEqual(len(self.problem.forces_W), 0)
-
-        self.assertIsInstance(self.problem.forceCoefficients_W, list)
-        self.assertEqual(len(self.problem.forceCoefficients_W), 0)
-
-        self.assertIsInstance(self.problem.moments_W_Cg, list)
-        self.assertEqual(len(self.problem.moments_W_Cg), 0)
-
-        self.assertIsInstance(self.problem.momentCoefficients_W_Cg, list)
-        self.assertEqual(len(self.problem.momentCoefficients_W_Cg), 0)
-
     def test_I_BP1_CgP1_attribute(self):
         """Test that I_BP1_CgP1 is stored correctly."""
         self.assertIsInstance(self.problem.I_BP1_CgP1, np.ndarray)
@@ -503,28 +489,6 @@ class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
         mock_model.apply_loads.assert_not_called()
         mock_model.step.assert_called_once()
 
-    def test_records_loads_on_non_final_step(self):
-        """Test that the current Airplane's loads are recorded on a non final step."""
-        self._mock_mujoco_model()
-
-        self.problem.initialize_next_problem(self.solver, step=0)
-
-        self.assertEqual(len(self.problem.forces_W), 1)
-        np.testing.assert_array_equal(
-            self.problem.forces_W[0], self.current_airplane.forces_W
-        )
-        np.testing.assert_array_equal(
-            self.problem.forceCoefficients_W[0],
-            self.current_airplane.forceCoefficients_W,
-        )
-        np.testing.assert_array_equal(
-            self.problem.moments_W_Cg[0], self.current_airplane.moments_W_CgP1
-        )
-        np.testing.assert_array_equal(
-            self.problem.momentCoefficients_W_Cg[0],
-            self.current_airplane.momentCoefficients_W_CgP1,
-        )
-
     def test_no_steady_problem_appended_on_final_step(self):
         """Test that no SteadyProblem is appended on the final step."""
         before = len(self.problem.steady_problems)
@@ -532,17 +496,6 @@ class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
         self.problem.initialize_next_problem(self.solver, step=self.final_step)
 
         self.assertEqual(len(self.problem.steady_problems), before)
-
-    def test_records_loads_on_final_step(self):
-        """Test that the current Airplane's loads are still recorded on the final
-        step.
-        """
-        self.problem.initialize_next_problem(self.solver, step=self.final_step)
-
-        self.assertEqual(len(self.problem.forces_W), 1)
-        np.testing.assert_array_equal(
-            self.problem.forces_W[0], self.current_airplane.forces_W
-        )
 
     def test_does_not_step_dynamics_on_final_step(self):
         """Test that the MuJoCo model is not stepped on the final step."""
@@ -552,17 +505,6 @@ class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
 
         mock_model.apply_loads.assert_not_called()
         mock_model.step.assert_not_called()
-
-    def test_recorded_loads_are_copies(self):
-        """Test that the recorded loads are copies, so later mutation of the Airplane's
-        loads does not change the recorded history.
-        """
-        # Use the final step so no rigid body dynamics integration is required.
-        self.problem.initialize_next_problem(self.solver, step=self.final_step)
-
-        self.current_airplane.forces_W[0] = 999.0
-
-        self.assertNotEqual(self.problem.forces_W[0][0], 999.0)
 
     def test_external_loads_fn_invoked_on_non_final_step(self):
         """Test that a set external_loads_fn is invoked with the current OperatingPoint
@@ -686,11 +628,6 @@ class TestFreeFlightUnsteadyProblemImmutability(unittest.TestCase):
         """Test that the delta_time property is read only."""
         with self.assertRaises(AttributeError):
             self.problem.delta_time = 0.5
-
-    def test_mutable_load_lists(self):
-        """Test that load lists remain mutable for solver population."""
-        self.problem.forces_W.append(np.array([1.0, 2.0, 3.0]))
-        self.assertEqual(len(self.problem.forces_W), 1)
 
 
 class TestFreeFlightUnsteadyProblemStateConversions(unittest.TestCase):

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -2162,21 +2162,6 @@ class TestFreeFlightUnsteadyProblemRoundTrip(unittest.TestCase):
         assert isinstance(result, FreeFlightUnsteadyProblem)
         self.assertEqual(result.k_max, 5)
 
-    def test_load_history_round_trip(self):
-        """Tests that recorded load-history arrays survive a round trip.
-
-        :return: None
-        """
-        problem = problem_fixtures.make_basic_free_flight_unsteady_problem_fixture()
-        problem.forces_W.append(np.array([1.0, 2.0, 3.0], dtype=float))
-        problem.forceCoefficients_W.append(np.array([0.1, 0.2, 0.3], dtype=float))
-        problem.moments_W_Cg.append(np.array([4.0, 5.0, 6.0], dtype=float))
-        problem.momentCoefficients_W_Cg.append(np.array([0.4, 0.5, 0.6], dtype=float))
-        result = _deserialize_value(_serialize_value(problem))
-        assert isinstance(result, FreeFlightUnsteadyProblem)
-        npt.assert_array_equal(result.forces_W[0], problem.forces_W[0])
-        npt.assert_array_equal(result.moments_W_Cg[0], problem.moments_W_Cg[0])
-
     def test_custom_external_loads_fn_is_not_serializable(self):
         """Tests that a FreeFlightUnsteadyProblem with a custom external_loads_fn raises
         on serialization, matching the custom-callable disposition used elsewhere.

--- a/tests/unit/test_slots.py
+++ b/tests/unit/test_slots.py
@@ -817,10 +817,6 @@ class TestFreeFlightUnsteadyProblemSlots(unittest.TestCase):
         self.assertIsInstance(self.problem.mass, float)
         self.assertIsInstance(self.problem.k_max, int)
         self.assertIsNone(self.problem.external_loads_fn)
-        self.assertIsInstance(self.problem.forces_W, list)
-        self.assertIsInstance(self.problem.forceCoefficients_W, list)
-        self.assertIsInstance(self.problem.moments_W_Cg, list)
-        self.assertIsInstance(self.problem.momentCoefficients_W_Cg, list)
 
 
 class TestCoreOperatingPointMovementSlots(unittest.TestCase):

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -1639,7 +1639,7 @@ class TestWingTransformationMatrixCaching(unittest.TestCase):
                 T[0, 0] = 999.0
 
 
-class TestSingleStepWingMethods(unittest.TestCase):
+class TestExplodeIntoStripsMethods(unittest.TestCase):
     """This class contains unit tests for Wing._explode_wing,
     Wing._interpolate_between_wing_cross_sections, and the explode_into_strips
     parameter."""

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -1640,8 +1640,8 @@ class TestWingTransformationMatrixCaching(unittest.TestCase):
 
 
 class TestSingleStepWingMethods(unittest.TestCase):
-    """This class contains unit tests for Wing.explode_wing,
-    Wing.interpolate_between_wing_cross_sections, and the explode_into_strips
+    """This class contains unit tests for Wing._explode_wing,
+    Wing._interpolate_between_wing_cross_sections, and the explode_into_strips
     parameter."""
 
     @staticmethod
@@ -1705,61 +1705,43 @@ class TestSingleStepWingMethods(unittest.TestCase):
         wing = self._make_plain_wing(explode_into_strips=True)
         self.assertIsNone(wing.wing_cross_sections[-1].num_spanwise_panels)
 
-    def test_interpolate_returns_correct_count_with_first_wcs(self):
-        """Test that interpolate_between_wing_cross_sections with first_wcs=True
-        returns N+1 WCS (root copy plus N interpolated)."""
+    def test_interpolate_returns_n_sections(self):
+        """Test that _interpolate_between_wing_cross_sections returns N WCS (the
+        sections downstream of wcs1, with no root copy), where N is wcs1's spanwise
+        panel count."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=True
+        result = wing._interpolate_between_wing_cross_sections(
+            self._make_wcs_3span(), self._make_tip_wcs()
         )
-        # N=3: root copy + 3 interpolated = 4 total
-        self.assertEqual(len(result), 4)
-
-    def test_interpolate_returns_correct_count_without_first_wcs(self):
-        """Test that interpolate_between_wing_cross_sections with first_wcs=False
-        returns N WCS (no root copy)."""
-        wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=False
-        )
-        # N=3: no root copy => 3 WCS total
+        # N=3 => 3 interpolated sections
         self.assertEqual(len(result), 3)
 
-    def test_interpolate_root_copy_chord(self):
-        """Test that the first WCS in the result has the root chord when
-        first_wcs=True."""
-        wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=True
-        )
-        self.assertAlmostEqual(result[0].chord, 1.0)
-
-    def test_interpolate_tip_chord(self):
+    def test_interpolate_last_section_has_tip_chord(self):
         """Test that the last WCS in the result has the tip chord."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=True
+        result = wing._interpolate_between_wing_cross_sections(
+            self._make_wcs_3span(), self._make_tip_wcs()
         )
         self.assertAlmostEqual(result[-1].chord, 0.5)
 
-    def test_interpolate_intermediate_chord_linearly_interpolated(self):
-        """Test that intermediate WCS chords are linearly interpolated between
-        root (1.0) and tip (0.5)."""
+    def test_interpolate_first_section_chord_linearly_interpolated(self):
+        """Test that the first interpolated WCS chord is linearly interpolated
+        between root (1.0) and tip (0.5)."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=True
+        result = wing._interpolate_between_wing_cross_sections(
+            self._make_wcs_3span(), self._make_tip_wcs()
         )
-        # N=3: t=1/3, 2/3, 3/3
+        # N=3: the first section is at t=1/3
         # chord at t=1/3: (1 - 1/3)*1.0 + (1/3)*0.5 = 5/6
         expected_first_interp = (1.0 - 1.0 / 3.0) * 1.0 + (1.0 / 3.0) * 0.5
-        self.assertAlmostEqual(result[1].chord, expected_first_interp, places=10)
+        self.assertAlmostEqual(result[0].chord, expected_first_interp, places=10)
 
     def test_interpolate_lp_y_divided_by_n(self):
         """Test that the Lp_Wcsp_Lpp y-component of each interpolated WCS is
         tip_Lp_y / N."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.interpolate_between_wing_cross_sections(
-            self._make_wcs_3span(), self._make_tip_wcs(), first_wcs=False
+        result = wing._interpolate_between_wing_cross_sections(
+            self._make_wcs_3span(), self._make_tip_wcs()
         )
         # tip has Lp_y = 0.5; N=3 => each section Lp_y = 0.5/3
         expected_lp_y = 0.5 / 3.0
@@ -1770,29 +1752,37 @@ class TestSingleStepWingMethods(unittest.TestCase):
                 )
 
     def test_explode_wing_with_two_wcs_returns_correct_count(self):
-        """Test that explode_wing with a 2-WCS input (root: num=3, tip) returns 4
+        """Test that _explode_wing with a 2-WCS input (root: num=3, tip) returns 4
         WCS."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
+        result = wing._explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
         self.assertEqual(len(result), 4)
 
+    def test_explode_wing_first_wcs_is_root(self):
+        """Test that _explode_wing seeds the result with the root WCS (root chord, a
+        single spanwise panel)."""
+        wing = self._make_plain_wing(explode_into_strips=False)
+        result = wing._explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
+        self.assertAlmostEqual(result[0].chord, 1.0)
+        self.assertEqual(result[0].num_spanwise_panels, 1)
+
     def test_explode_wing_all_non_tip_have_num_spanwise_one(self):
-        """Test that explode_wing produces WCS where every non-tip entry has
+        """Test that _explode_wing produces WCS where every non-tip entry has
         num_spanwise_panels=1."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
+        result = wing._explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
         for wcs in result[:-1]:
             with self.subTest(wcs=wcs):
                 self.assertEqual(wcs.num_spanwise_panels, 1)
 
     def test_explode_wing_last_wcs_is_tip(self):
-        """Test that explode_wing produces a final WCS with num_spanwise_panels=None."""
+        """Test that _explode_wing produces a final WCS with num_spanwise_panels=None."""
         wing = self._make_plain_wing(explode_into_strips=False)
-        result = wing.explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
+        result = wing._explode_wing([self._make_wcs_3span(), self._make_tip_wcs()])
         self.assertIsNone(result[-1].num_spanwise_panels)
 
     def test_explode_wing_rejects_non_uniform_spanwise_spacing(self):
-        """Test that explode_wing raises ValueError when a non tip WCS uses cosine
+        """Test that _explode_wing raises ValueError when a non tip WCS uses cosine
         spanwise spacing, since the explosion assumes uniformly distributed
         intermediates."""
         wing = self._make_plain_wing(explode_into_strips=False)
@@ -1805,4 +1795,4 @@ class TestSingleStepWingMethods(unittest.TestCase):
             spanwise_spacing="cosine",
         )
         with self.assertRaises(ValueError):
-            wing.explode_wing([cosine_root, self._make_tip_wcs()])
+            wing._explode_wing([cosine_root, self._make_tip_wcs()])


### PR DESCRIPTION
# Description

This pull request performs API hygiene on the currently unreleased public surface for free flight and geometry, privatizing and removing items that are non-breaking to change only before the next tag. It also trims `tests/__init__.py` to match the format PR #205 established for the subpackage `__init__.py` files, completing a cleanup that was missed in that pass.

## Motivation

The free-flight and geometry classes added since the last release shipped several public attributes and methods that were never intended as user-facing API. Four load-history lists on `FreeFlightUnsteadyProblem` duplicated data already available on each time step's solved Airplane and were not read by any production code. Two `Wing` methods (`explode_wing` and `interpolate_between_wing_cross_sections`) existed only to support the internal strip-explosion pipeline and were called only from `Wing.__init__` and each other. The five free-flight movement modules were importable only via `problems.py`'s transitive imports, unlike their aeroelastic counterparts which were registered in `movements/__init__.py`. All of these are non-breaking to fix only before the next tag; after the tag they become locked-in public API. Separately, `tests/__init__.py` still carried the old multi-line module-listing docstring and eager subpackage imports that PR #205 removed from `tests/unit/__init__.py` and `tests/integration/__init__.py`.

## Relevant Issues

None.

## Changes

* Deleted the four free-flight load-history lists (`forces_W`, `forceCoefficients_W`, `moments_W_Cg`, `momentCoefficients_W_Cg`) from `FreeFlightUnsteadyProblem`: removed their `__slots__` entries, empty-list initialization in `__init__`, the recording block in `initialize_next_problem`, and the assertion and aliasing preamble that fed them. Updated `CLASSES_AND_IMMUTABILITY.md` to reflect the reduced mutable-slot table. Bumped `_FORMAT_VERSION` from 10 to 11 for the slot removal.
* Repointed the two free-flight integration test classes (`TestFreeFlightUnsteadyRingVortexLatticeMethod` and `TestFreeFlightUnsteadyRingVortexLatticeMethodFlapping`) to read per-step forces from `problem.steady_problems[step].airplanes[0].forces_W` instead of the deleted `problem.forces_W`.
* Removed the unit tests that covered the deleted load-history lists: the initialization test, two recording tests (non-final and final step), the copy-independence test, and the mutable-list immutability test in `test_free_flight_unsteady_problem.py`, the load-history round-trip test in `test_serialization.py`, and the four slot-type assertions in `test_slots.py`.
* Registered the five free-flight movement modules (`free_flight_airplane_movement`, `free_flight_movement`, `free_flight_operating_point_movement`, `free_flight_wing_cross_section_movement`, `free_flight_wing_movement`) in `movements/__init__.py`'s imports and docstring, matching the existing aeroelastic registrations.
* Privatized `Wing.explode_wing` and `Wing.interpolate_between_wing_cross_sections` to `Wing._explode_wing` and `Wing._interpolate_between_wing_cross_sections`. Moved the root-strip seeding from a `first_wcs` flag in the interpolation helper into `_explode_wing` itself, which made the helper independent of its caller-loop position and allowed it to become a `staticmethod`. Updated the two internal call sites, `CLASSES_AND_IMMUTABILITY.md` references, the `explode_into_strips` parameter docstring, and all unit-test call sites and docstrings.
* Renamed `TestSingleStepWingMethods` to `TestExplodeIntoStripsMethods` so the test class name agrees with its docstring and the `explode_into_strips`/`_explode_wing` surface it covers.
* Added `test_explode_wing_first_wcs_is_root`, which asserts that `_explode_wing` seeds the result with the root WCS (root chord, a single spanwise panel), replacing the coverage that was previously embedded in the `first_wcs=True` interpolation tests.
* Trimmed `tests/__init__.py` to a one-line docstring plus the functional `_test_environment` import, removing the multi-line module-listing docstring and the eager `import tests.integration`/`import tests.unit` lines that PR #205's subpackage trim missed.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
