### PR TITLE
Improve the documentation website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,5 +167,10 @@ Draw.webp
 *.json
 *.json.gz
 
+# The benchmark archive publishes a redacted host snapshot here. It is a real
+# tracked artifact, not serialization output, so re-include it past the *.json
+# rule above.
+!/docs/_static/benchmarks/host.json
+
 # These are the Claude's documentation files to ignore.
 /docs/CLAUDE_*.md

--- a/docs/_static/benchmarks/host.json
+++ b/docs/_static/benchmarks/host.json
@@ -1,0 +1,24 @@
+{
+  "os": {
+    "name": "Ubuntu",
+    "version": "24.04.4 LTS (Noble Numbat)"
+  },
+  "cpu": {
+    "model": "AMD Ryzen 9 9950X 16-Core Processor",
+    "logical_cores": 32,
+    "governor": "performance"
+  },
+  "memory": {
+    "total_mb": 63842,
+    "swappiness": 0,
+    "transparent_hugepages": "madvise"
+  },
+  "gpu": {
+    "model": "NVIDIA GeForce RTX 5080",
+    "driver_version": "580.167.08",
+    "cuda_version": "13.0"
+  },
+  "storage": {
+    "model": "WD_BLACK SN850X 1000GB"
+  }
+}

--- a/docs/website/_static/custom.css
+++ b/docs/website/_static/custom.css
@@ -704,6 +704,18 @@ dl.py dd {
   overflow-wrap: break-word;
 }
 
+/* In a multi-line signature, align the closing parenthesis with the opening
+   keyword (class or def) line instead of with the parameter column. Furo's
+   .sig rule gives the block a 2.5em hanging indent that only pulls the first
+   line left, so the closing paren, which sits on its own line at the content
+   origin, lands one space to the right of the parameter names. Pulling it back
+   by the same 2.5em lines it up under the first character of the signature.
+   The selector matches only the closing paren (the one that follows the
+   parameter list's dl); the opening paren precedes the dl and is unaffected. */
+dl.py dt.sig dl + .sig-paren {
+  margin-left: -2.5em;
+}
+
 
 /* --------------------------------------------------------------------------
    Footer

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -2,19 +2,15 @@ import os
 import re
 import sys
 from datetime import datetime
-from importlib.machinery import ModuleSpec
 from pathlib import Path
-from unittest.mock import MagicMock
 
 # Add project root to sys.path so sphinx.ext.autodoc can import pterasoftware.
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..")))
 
-# Mock all runtime dependencies so autodoc can import pterasoftware without them
-# installed. This is safe because the documented functions (save, load,
-# set_up_logging) only use stdlib types in their signatures. autodoc_mock_imports
-# only takes effect during autodoc's build phase, not when conf.py executes, so
-# we also install a meta path finder to mock them in sys.modules before the
-# pterasoftware imports below trigger the full package import chain.
+# Mock all runtime dependencies so autodoc can import pterasoftware (via the
+# autofunction directives for save, load, and set_up_logging) without them
+# installed. This is safe because the documented functions only use stdlib
+# types in their signatures.
 autodoc_mock_imports = [
     "cmocean",
     "matplotlib",
@@ -26,45 +22,6 @@ autodoc_mock_imports = [
     "tqdm",
     "webp",
 ]
-
-
-class _MockModuleFinder:
-    """Meta path finder that returns MagicMock for mocked top-level packages."""
-
-    def __init__(self, mock_names):
-        self._mock_names = set(mock_names)
-
-    # noinspection PyUnusedLocal
-    def find_spec(self, fullname, path, target=None):
-        if fullname.split(".")[0] in self._mock_names:
-            return ModuleSpec(fullname, self, is_package=True)
-        return None
-
-    # noinspection PyUnusedLocal
-    # noinspection PyMethodMayBeStatic
-    def create_module(self, spec):
-        return MagicMock()
-
-    def exec_module(self, module):
-        pass
-
-
-sys.meta_path.insert(0, _MockModuleFinder(autodoc_mock_imports))
-
-# noinspection PyProtectedMember
-from pterasoftware._logging import set_up_logging as _set_up_logging
-
-# noinspection PyProtectedMember
-# noinspection PyProtectedMember
-from pterasoftware._serialization import load as _load
-from pterasoftware._serialization import save as _save
-
-# Override __module__ for public functions that live in private modules so
-# autodoc renders them with the public package path (e.g., pterasoftware.save
-# instead of pterasoftware._serialization.save).
-_save.__module__ = "pterasoftware"
-_load.__module__ = "pterasoftware"
-_set_up_logging.__module__ = "pterasoftware"
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -38,7 +38,6 @@ extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.mathjax",
@@ -180,6 +179,10 @@ napoleon_attr_annotations = True
 html_theme = "furo"
 html_title = "PteraSoftware"
 html_favicon = "favicon/favicon.ico"
+# Drop the "View this page" source link (and the _sources/*.txt dump it points
+# to) so no page exposes a link to its underlying source.
+html_show_sourcelink = False
+html_copy_source = False
 html_static_path = ["_static", "../_static", "Black_Text_Logo.png", "Logo.png"]
 # Optionally also copy to site root (may be ignored by some builders)
 html_extra_path = ["favicon"]
@@ -194,11 +197,7 @@ html_js_files = [
     "custom.js",
 ]
 
-# Furo: enable "Edit this page" with GitHub
 html_theme_options = {
-    "source_repository": "https://github.com/camUrban/PteraSoftware/",
-    "source_branch": "main",
-    "source_directory": "docs/website/",
     # Use black text logo in light mode (better contrast), normal logo in dark mode
     "light_logo": "Black_Text_Logo.png",
     "dark_logo": "Logo.png",
@@ -206,41 +205,7 @@ html_theme_options = {
     "sidebar_hide_name": True,
 }
 
-# For AutoAPI-generated pages, the default "Edit this page" points to a
-# generated .rst path that doesn't exist in the repo. Override the URL to
-# point to the corresponding Python source file in GitHub.
 REPO_ROOT = Path(__file__).resolve().parents[2]
-
-
-def _repo_rel_for_autoapi_page(pagename: str) -> str | None:
-    """Return a repo-relative path for an AutoAPI page's corresponding source file."""
-    if not pagename.startswith("api/"):
-        return None
-    rel = pagename[len("api/") :]
-    if rel.endswith("/index"):
-        rel = rel[: -len("/index")]
-    py_path = REPO_ROOT / (rel.replace("/", os.sep) + ".py")
-    if py_path.exists():
-        target = py_path
-    else:
-        init_path = REPO_ROOT / rel.replace("/", os.sep) / "__init__.py"
-        if init_path.exists():
-            target = init_path
-        else:
-            return None
-    return target.relative_to(REPO_ROOT).as_posix()
-
-
-# noinspection PyUnusedLocal
-def _html_page_context(app, pagename, templatename, context, doctree):
-    repo_rel = _repo_rel_for_autoapi_page(pagename)
-    if repo_rel:
-        context["theme_source_edit_link"] = (
-            f"https://github.com/camUrban/PteraSoftware/edit/main/{repo_rel}"
-        )
-        context["theme_source_view_link"] = (
-            f"https://github.com/camUrban/PteraSoftware/blob/main/{repo_rel}?plain=true"
-        )
 
 
 def _rewrite_repo_root_links(app, docname, source):
@@ -263,7 +228,6 @@ def _rewrite_repo_root_links(app, docname, source):
 
 def setup(app):
     app.connect("source-read", _rewrite_repo_root_links)
-    app.connect("html-page-context", _html_page_context)
 
     # Copy extra assets to the site root after build
     # noinspection PyShadowingNames

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.mathjax",
     "sphinx_copybutton",
+    "sphinx_design",
 ]
 
 myst_enable_extensions = [

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -159,6 +159,14 @@ suppress_warnings = [
 
 autosectionlabel_prefix_document = True
 
+# Render every Python signature with one parameter per line. Any signature
+# longer than this threshold (in characters) wraps so that each parameter sits
+# on its own indented line with a trailing comma and the closing parenthesis on
+# its own line. A threshold of one forces this multi-line layout for every
+# signature that takes at least one parameter, which keeps long class and
+# function parameter lists readable instead of running together on one line.
+python_maximum_signature_line_length = 1
+
 # AutoAPI renders docstrings as reStructuredText, where a vector magnitude written
 # with bars (for example, "|g_E|") parses as a substitution reference. Define those
 # tokens so the reference resolves to the literal barred text instead of emitting an

--- a/docs/website/examples/aeroelastic_unsteady_first_order_deformation.md
+++ b/docs/website/examples/aeroelastic_unsteady_first_order_deformation.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/aeroelastic_unsteady_first_order_deformation.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/aeroelastic_unsteady_first_order_deformation/animate.webp
+:alt: Animation of the aeroelastic unsteady ring VLM simulation with first-order wing deformation.
+:loading: lazy
+```

--- a/docs/website/examples/aeroelastic_unsteady_first_order_deformation_mixed_wings.md
+++ b/docs/website/examples/aeroelastic_unsteady_first_order_deformation_mixed_wings.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/aeroelastic_unsteady_first_order_deformation_mixed_wings.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/aeroelastic_unsteady_first_order_deformation_mixed_wings/animate.webp
+:alt: Animation of the aeroelastic unsteady ring VLM simulation with mixed rigid and deforming wings.
+:loading: lazy
+```

--- a/docs/website/examples/aeroelastic_unsteady_first_order_plotting.md
+++ b/docs/website/examples/aeroelastic_unsteady_first_order_plotting.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/aeroelastic_unsteady_first_order_plotting.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/aeroelastic_unsteady_first_order_plotting/net_deformation_curve_16_spring_constant.png
+:alt: Net wing deformation over time for a torsional spring constant of 16.
+:loading: lazy
+```

--- a/docs/website/examples/analyze_steady_trim.md
+++ b/docs/website/examples/analyze_steady_trim.md
@@ -3,3 +3,11 @@
 ```{literalinclude} ../../../examples/analyze_steady_trim.py
 :language: python
 ```
+
+## Output
+
+````{dropdown} Trim log
+```{literalinclude} ../../examples_expected_output/analyze_steady_trim/example_trim.log
+:language: text
+```
+````

--- a/docs/website/examples/analyze_unsteady_trim.md
+++ b/docs/website/examples/analyze_unsteady_trim.md
@@ -3,3 +3,11 @@
 ```{literalinclude} ../../../examples/analyze_unsteady_trim.py
 :language: python
 ```
+
+## Output
+
+````{dropdown} Trim log
+```{literalinclude} ../../examples_expected_output/analyze_unsteady_trim/example_trim.log
+:language: text
+```
+````

--- a/docs/website/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.md
+++ b/docs/website/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.md
@@ -3,3 +3,50 @@
 ```{literalinclude} ../../../examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/draw.webp
+:alt: Rendered geometry of the free-flight flapping-wing example airplane.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/animate.webp
+:alt: Animation of the free-flight flapping-wing simulation.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_position.png
+:alt: Airplane position over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_orientation.png
+:alt: Airplane orientation over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_velocity.png
+:alt: Airplane velocity over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_angular_velocity.png
+:alt: Airplane angular velocity over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_aerodynamic_angles.png
+:alt: Airplane aerodynamic angles over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_force_coefficients.png
+:alt: Airplane force coefficients over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping/example_airplane_moment_coefficients.png
+:alt: Airplane moment coefficients over time.
+:loading: lazy
+```

--- a/docs/website/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.md
+++ b/docs/website/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.md
@@ -3,3 +3,50 @@
 ```{literalinclude} ../../../examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/draw.webp
+:alt: Rendered geometry of the free-flight glider example airplane.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/animate.webp
+:alt: Animation of the free-flight glider simulation.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_position.png
+:alt: Airplane position over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_orientation.png
+:alt: Airplane orientation over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_velocity.png
+:alt: Airplane velocity over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_angular_velocity.png
+:alt: Airplane angular velocity over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_aerodynamic_angles.png
+:alt: Airplane aerodynamic angles over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_force_coefficients.png
+:alt: Airplane force coefficients over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/free_flight_unsteady_ring_vortex_lattice_method_solver_glider/example_airplane_moment_coefficients.png
+:alt: Airplane moment coefficients over time.
+:loading: lazy
+```

--- a/docs/website/examples/steady_convergence.md
+++ b/docs/website/examples/steady_convergence.md
@@ -3,3 +3,11 @@
 ```{literalinclude} ../../../examples/steady_convergence.py
 :language: python
 ```
+
+## Output
+
+````{dropdown} Convergence log
+```{literalinclude} ../../examples_expected_output/steady_convergence/example_convergence.log
+:language: text
+```
+````

--- a/docs/website/examples/steady_horseshoe_vortex_lattice_method_solver.md
+++ b/docs/website/examples/steady_horseshoe_vortex_lattice_method_solver.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/steady_horseshoe_vortex_lattice_method_solver.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/steady_horseshoe_vortex_lattice_method_solver/draw.webp
+:alt: Rendered geometry of the steady horseshoe VLM example airplane.
+:loading: lazy
+```

--- a/docs/website/examples/steady_ring_vortex_lattice_method_solver.md
+++ b/docs/website/examples/steady_ring_vortex_lattice_method_solver.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/steady_ring_vortex_lattice_method_solver.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/steady_ring_vortex_lattice_method_solver/draw.webp
+:alt: Rendered geometry of the steady ring VLM example airplane.
+:loading: lazy
+```

--- a/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_static.md
+++ b/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_static.md
@@ -3,3 +3,25 @@
 ```{literalinclude} ../../../examples/unsteady_ring_vortex_lattice_method_solver_static.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static/draw.webp
+:alt: Rendered geometry of the unsteady ring VLM static-geometry example airplane.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static/animate.webp
+:alt: Animation of the unsteady ring VLM simulation with static geometry.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static/example_airplane_force_coefficients.png
+:alt: Airplane force coefficients over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static/example_airplane_moment_coefficients.png
+:alt: Airplane moment coefficients over time.
+:loading: lazy
+```

--- a/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_static_ground_effect.md
+++ b/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_static_ground_effect.md
@@ -3,3 +3,25 @@
 ```{literalinclude} ../../../examples/unsteady_ring_vortex_lattice_method_solver_static_ground_effect.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static_ground_effect/draw.webp
+:alt: Rendered geometry of the unsteady ring VLM ground-effect example airplane.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static_ground_effect/animate.webp
+:alt: Animation of the unsteady ring VLM simulation with ground effect.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static_ground_effect/example_airplane_force_coefficients.png
+:alt: Airplane force coefficients over time.
+:loading: lazy
+```
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_static_ground_effect/example_airplane_moment_coefficients.png
+:alt: Airplane moment coefficients over time.
+:loading: lazy
+```

--- a/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_variable.md
+++ b/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_variable.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/unsteady_ring_vortex_lattice_method_solver_variable.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_variable/animate.webp
+:alt: Animation of the unsteady ring VLM simulation with flapping wings.
+:loading: lazy
+```

--- a/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_variable_formation.md
+++ b/docs/website/examples/unsteady_ring_vortex_lattice_method_solver_variable_formation.md
@@ -3,3 +3,10 @@
 ```{literalinclude} ../../../examples/unsteady_ring_vortex_lattice_method_solver_variable_formation.py
 :language: python
 ```
+
+## Output
+
+```{image} ../../examples_expected_output/unsteady_ring_vortex_lattice_method_solver_variable_formation/animate.webp
+:alt: Animation of the unsteady ring VLM simulation of an airplane formation.
+:loading: lazy
+```

--- a/docs/website/examples/unsteady_static_convergence.md
+++ b/docs/website/examples/unsteady_static_convergence.md
@@ -3,3 +3,11 @@
 ```{literalinclude} ../../../examples/unsteady_static_convergence.py
 :language: python
 ```
+
+## Output
+
+````{dropdown} Convergence log
+```{literalinclude} ../../examples_expected_output/unsteady_static_convergence/example_convergence.log
+:language: text
+```
+````

--- a/docs/website/examples/unsteady_variable_convergence.md
+++ b/docs/website/examples/unsteady_variable_convergence.md
@@ -3,3 +3,11 @@
 ```{literalinclude} ../../../examples/unsteady_variable_convergence.py
 :language: python
 ```
+
+## Output
+
+````{dropdown} Convergence log
+```{literalinclude} ../../examples_expected_output/unsteady_variable_convergence/example_convergence.log
+:language: text
+```
+````

--- a/docs/website/load.md
+++ b/docs/website/load.md
@@ -1,5 +1,5 @@
 # pterasoftware.load()
 
 ```{eval-rst}
-.. autofunction:: pterasoftware._serialization.load
+.. autofunction:: pterasoftware.load
 ```

--- a/docs/website/requirements_docs.txt
+++ b/docs/website/requirements_docs.txt
@@ -3,3 +3,4 @@ myst-parser>=3.0.1
 sphinx>=7.3
 sphinx-autoapi>=3.2.1
 sphinx-copybutton>=0.5.2
+sphinx-design>=0.6.0

--- a/docs/website/save.md
+++ b/docs/website/save.md
@@ -1,5 +1,5 @@
 # pterasoftware.save()
 
 ```{eval-rst}
-.. autofunction:: pterasoftware._serialization.save
+.. autofunction:: pterasoftware.save
 ```

--- a/docs/website/set_up_logging.md
+++ b/docs/website/set_up_logging.md
@@ -1,5 +1,5 @@
 # pterasoftware.set_up_logging()
 
 ```{eval-rst}
-.. autofunction:: pterasoftware._logging.set_up_logging
+.. autofunction:: pterasoftware.set_up_logging
 ```


### PR DESCRIPTION
# Description

This pull request is a focused cleanup and enhancement pass over the documentation website build. It removes the source-link machinery that exposed underlying source files, documents the public `save`, `load`, and `set_up_logging` functions under their canonical package path, forces every Python signature to render with one parameter per line, surfaces each example's expected output on its own page, and starts tracking a redacted benchmark host snapshot. None of these changes touch the `pterasoftware` package itself, so runtime behavior is unaffected.

## Motivation

The documentation site had accumulated several rough edges. The Furo "View this page" and "Edit this page" links, along with `sphinx.ext.viewcode`, exposed source files and required a custom meta path finder plus an `html-page-context` hook just to keep the AutoAPI edit links from pointing at nonexistent generated paths. The public serialization and logging helpers were documented under their private module paths (`pterasoftware._serialization.save` and similar), which leaked the private module layout into user-facing docs. Long class and function signatures ran together on a single line and were hard to read. Example pages showed only the source script with no indication of what running it produces. Finally, the published benchmark archive referenced host details that were not tracked anywhere in the repository. This pull request addresses each of these in turn.

## Relevant Issues

None.

## Changes

* In `docs/website/conf.py`, dropped `sphinx.ext.viewcode` from `extensions`, set `html_show_sourcelink = False` and `html_copy_source = False`, and removed the Furo `source_repository`, `source_branch`, and `source_directory` theme options so no page links to its underlying source.
* In `docs/website/conf.py`, removed the `_MockModuleFinder` meta path finder, the private `set_up_logging`, `load`, and `save` imports, the `__module__` overrides, and the `_repo_rel_for_autoapi_page` and `_html_page_context` helpers (and their `html-page-context` connection in `setup`), simplifying the autodoc-mock comment accordingly.
* Pointed the `autofunction` directives in `docs/website/save.md`, `docs/website/load.md`, and `docs/website/set_up_logging.md` at the public paths `pterasoftware.save`, `pterasoftware.load`, and `pterasoftware.set_up_logging`.
* Set `python_maximum_signature_line_length = 1` in `docs/website/conf.py` to render every parameterized signature with one parameter per line, and added a `dl.py dt.sig dl + .sig-paren` rule in `docs/website/_static/custom.css` to pull the closing parenthesis back by `2.5em` so it aligns under the first character of the signature.
* Added the `sphinx_design` extension to `extensions` in `docs/website/conf.py` and added `sphinx-design>=0.6.0` to `docs/website/requirements_docs.txt` to support the dropdown directives used for log output.
* Added an `## Output` section to each example page under `docs/website/examples/`, embedding the rendered `draw.webp`, `animate.webp`, and plot `png` images from `docs/examples_expected_output/` with descriptive alt text and lazy loading, and wrapping the trim and convergence `log` files in `{dropdown}` directives.
* Added the tracked benchmark host snapshot `docs/_static/benchmarks/host.json` describing the redacted OS, CPU, memory, GPU, and storage of the benchmark host, and added a negated ignore rule in `.gitignore` so it is re-included past the blanket `*.json` rule.

## Dependency Updates

Added `sphinx-design>=0.6.0` as a documentation build dependency in `docs/website/requirements_docs.txt`.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
