### PR TITLE
Refine edge-defined Wings in convergence

### DIFF
--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -97,6 +97,15 @@ def analyze_steady_convergence(
     return 1 for the converged value of Panel aspect ratio. In the code below, this
     state is referred to as a "saturated" Panel aspect ratio case.
 
+    Each Wing is refined according to how its spanwise mesh was defined. A non-edge-
+    defined Wing (one built from WingCrossSections) is refined by sweeping its number of
+    spanwise Panels to hit the target Panel aspect ratio, holding its WingCrossSections
+    fixed. An edge-defined Wing (one built from edge curves with Wing.from_edge_points)
+    is refined by resampling its stored edge curves into the number of WingCrossSections
+    that hits the target Panel aspect ratio, preserving its planform shape. An Airplane
+    may hold both kinds of Wing at once. A Wing that has been exploded into single-panel
+    strips cannot be refined and is rejected.
+
     :param ref_problem: The SteadyProblem whose converged parameters will be found.
     :param solver_type: Determines what type of steady solver will be used to analyze
         the SteadyProblem. The options are "steady horseshoe vortex lattice method" and
@@ -165,8 +174,9 @@ def analyze_steady_convergence(
 
     ref_airplanes = ref_problem.airplanes
 
-    # Reject any Wing whose spanwise mesh is not trapezoidal.
-    _reject_non_trapezoidal_wings(ref_airplanes, "analyze_steady_convergence")
+    # Reject any Wing that cannot be refined (any spanwise mesh other than trapezoidal
+    # or edge-defined).
+    _reject_unrefinable_wings(ref_airplanes, "analyze_steady_convergence")
 
     # Create lists containing each Panel aspect ratio and each number of chordwise
     # Panels to test.
@@ -209,6 +219,11 @@ def analyze_steady_convergence(
     # ref_wing_cross_section_id,
     num_spanwise_panels_cache: dict[tuple[int, int, int, int, int], int] = {}
 
+    # This is the analogous cache for edge-defined Wings, which are refined by their
+    # number of WingCrossSections rather than by their number of spanwise Panels. The key
+    # is a tuple of 4 ints: ar_id, chord_id, ref_airplane_id, ref_wing_id.
+    num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int] = {}
+
     # Begin iterating through the outer loop of Panel aspect ratios.
     for ar_id, panel_aspect_ratio in enumerate(panel_aspect_ratios_list):
         _logger.info("\tPanel aspect ratio: " + str(panel_aspect_ratio))
@@ -231,6 +246,7 @@ def analyze_steady_convergence(
                 num_chordwise_panels,
                 ref_problem,
                 num_spanwise_panels_cache,
+                num_wing_cross_sections_cache,
             )
             these_airplanes = this_problem.airplanes
 
@@ -416,6 +432,27 @@ def analyze_steady_convergence(
                     _logger.info("\t\t" + airplane.name + ":")
                     for wing_id, wing in enumerate(airplane.wings):
                         _logger.info("\t\t\t" + wing.name + ":")
+
+                        # An edge-defined Wing is refined by its number of
+                        # WingCrossSections rather than its number of spanwise Panels, so
+                        # report that instead.
+                        if wing.spanwise_mesh == "edge_defined":
+                            num_wing_cross_sections_key = (
+                                converged_ar_id,
+                                converged_chord_id,
+                                airplane_id,
+                                wing_id,
+                            )
+                            _logger.info(
+                                "\t\t\t\tWingCrossSections: "
+                                + str(
+                                    num_wing_cross_sections_cache[
+                                        num_wing_cross_sections_key
+                                    ]
+                                )
+                            )
+                            continue
+
                         for wing_cross_section_id, wing_cross_section in enumerate(
                             wing.wing_cross_sections
                         ):
@@ -462,6 +499,7 @@ def analyze_steady_convergence(
                         converged_chordwise_panels,
                         ref_problem,
                         num_spanwise_panels_cache,
+                        num_wing_cross_sections_cache,
                     )
                     if solver_type == "steady horseshoe vortex lattice method":
                         converged_solver = steady_horseshoe_vortex_lattice_method.SteadyHorseshoeVortexLatticeMethodSolver(
@@ -575,6 +613,18 @@ def analyze_unsteady_convergence(
     function will return 1 for the converged value of Panel aspect ratio and a free wake
     for the converged wake state. In the code below, this state is referred to as a
     "saturated" Panel aspect ratio or wake state.
+
+    Each Wing is refined according to how its spanwise mesh was defined. A non-edge-
+    defined Wing (one built from WingCrossSections) is refined by sweeping its number of
+    spanwise Panels to hit the target Panel aspect ratio, holding its WingCrossSections
+    fixed. An edge-defined Wing (one built from edge curves with Wing.from_edge_points)
+    is refined by resampling its stored edge curves into the number of WingCrossSections
+    that hits the target Panel aspect ratio, preserving its planform shape. An Airplane
+    may hold both kinds of Wing at once. A Wing that has been exploded into single-panel
+    strips cannot be refined and is rejected. Because resampling an edge-defined Wing
+    changes its number of WingCrossSections, its WingCrossSectionMovements must all be
+    static (the WingMovement's own flapping and sweeping motion is preserved); a non-
+    static WingCrossSectionMovement on an edge-defined Wing is rejected.
 
     :param ref_problem: The UnsteadyProblem whose converged parameters will be found.
         This must be a standard UnsteadyProblem, not a FreeFlightUnsteadyProblem or an
@@ -715,8 +765,9 @@ def analyze_unsteady_convergence(
 
     ref_airplane_movements = ref_movement.airplane_movements
 
-    # Reject any Wing whose spanwise mesh is not trapezoidal.
-    _reject_non_trapezoidal_wings(
+    # Reject any Wing that cannot be refined (any spanwise mesh other than trapezoidal or
+    # edge-defined).
+    _reject_unrefinable_wings(
         tuple(
             ref_airplane_movement.base_airplane
             for ref_airplane_movement in ref_airplane_movements
@@ -787,6 +838,11 @@ def analyze_unsteady_convergence(
     # ref_base_wing_cross_section_id,
     num_spanwise_panels_cache: dict[tuple[int, int, int, int, int], int] = {}
 
+    # This is the analogous cache for edge-defined Wings, which are refined by their
+    # number of WingCrossSections rather than by their number of spanwise Panels. The key
+    # is a tuple of 4 ints: ar_id, chord_id, ref_base_airplane_id, ref_base_wing_id.
+    num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int] = {}
+
     # Begin iterating through the outermost loop of wake states.
     for wake_id, wake in enumerate(wake_list):
         if wake:
@@ -832,6 +888,7 @@ def analyze_unsteady_convergence(
                         wake_length,
                         ref_problem,
                         num_spanwise_panels_cache,
+                        num_wing_cross_sections_cache,
                     )
 
                     # Create and run this iteration's
@@ -1109,6 +1166,27 @@ def analyze_unsteady_convergence(
                             ):
                                 base_wing = wing_movement.base_wing
                                 _logger.info("\t\t\t" + base_wing.name + ":")
+
+                                # An edge-defined Wing is refined by its number of
+                                # WingCrossSections rather than its number of spanwise
+                                # Panels, so report that instead.
+                                if base_wing.spanwise_mesh == "edge_defined":
+                                    num_wing_cross_sections_key = (
+                                        converged_ar_id,
+                                        converged_chord_id,
+                                        airplane_movement_id,
+                                        wing_movement_id,
+                                    )
+                                    _logger.info(
+                                        "\t\t\t\tWingCrossSections: "
+                                        + str(
+                                            num_wing_cross_sections_cache[
+                                                num_wing_cross_sections_key
+                                            ]
+                                        )
+                                    )
+                                    continue
+
                                 for (
                                     wing_cross_section_movement_id,
                                     wing_cross_section_movement,
@@ -1165,6 +1243,7 @@ def analyze_unsteady_convergence(
                                 converged_wake_length,
                                 ref_problem,
                                 num_spanwise_panels_cache,
+                                num_wing_cross_sections_cache,
                             )
                             converged_solver = unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(
                                 unsteady_problem=converged_problem
@@ -1208,14 +1287,17 @@ def _build_steady_problem(
     num_chordwise_panels: int,
     ref_problem: problems.SteadyProblem,
     num_spanwise_panels_cache: dict[tuple[int, int, int, int, int], int],
+    num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int],
 ) -> problems.SteadyProblem:
     """Builds the SteadyProblem for one convergence iteration.
 
     Each of the reference SteadyProblem's Airplanes is copied with the given Panel
-    aspect ratio and number of chordwise Panels. Each non-tip WingCrossSection's number
-    of spanwise Panels is resolved (and cached) to achieve the desired Panel aspect
-    ratio, and the copied Airplanes are wrapped in a new SteadyProblem with the
-    reference OperatingPoint.
+    aspect ratio and number of chordwise Panels. Each Wing is refined by its spanwise
+    mesh: a trapezoidal Wing has each non-tip WingCrossSection's number of spanwise
+    Panels resolved (and cached) to achieve the desired Panel aspect ratio, while an
+    edge-defined Wing has its stored edge curves resampled into the number of
+    WingCrossSections (also resolved and cached) that achieves it. The copied Airplanes
+    are wrapped in a new SteadyProblem with the reference OperatingPoint.
 
     :param ar_id: The index of the current Panel aspect ratio within the list of Panel
         aspect ratios being tested.
@@ -1228,8 +1310,12 @@ def _build_steady_problem(
         are copied.
     :param num_spanwise_panels_cache: The cache mapping a (Panel aspect ratio index,
         number of chordwise Panels index, Airplane index, Wing index, WingCrossSection
-        index) tuple to a previously calculated number of spanwise Panels. It is read
-        and updated in place.
+        index) tuple to a previously calculated number of spanwise Panels, used for
+        trapezoidal Wings. It is read and updated in place.
+    :param num_wing_cross_sections_cache: The cache mapping a (Panel aspect ratio index,
+        number of chordwise Panels index, Airplane index, Wing index) tuple to a
+        previously calculated number of WingCrossSections, used for edge-defined Wings.
+        It is read and updated in place.
     :return: The SteadyProblem for this iteration.
     """
     ref_airplanes = ref_problem.airplanes
@@ -1244,6 +1330,34 @@ def _build_steady_problem(
         these_wings = []
 
         for ref_wing_id, ref_wing in enumerate(ref_wings):
+
+            # An edge-defined Wing is refined by resampling its stored edge curves into
+            # the number of WingCrossSections that achieves the desired Panel aspect
+            # ratio, rather than by sweeping the number of spanwise Panels.
+            if ref_wing.spanwise_mesh == "edge_defined":
+                this_num_wing_cross_sections = _resolve_num_wing_cross_sections(
+                    ar_id,
+                    chord_id,
+                    ref_airplane_id,
+                    ref_wing_id,
+                    ref_airplane.name,
+                    ref_wing.name,
+                    "\t\t\t\t",
+                    num_wing_cross_sections_cache,
+                    lambda start: _get_num_wing_cross_sections_for_panel_ar(
+                        panel_aspect_ratio,
+                        num_chordwise_panels,
+                        ref_wing,
+                        start,
+                    ),
+                )
+                these_wings.append(
+                    _build_edge_defined_wing(
+                        ref_wing, num_chordwise_panels, this_num_wing_cross_sections
+                    )
+                )
+                continue
+
             ref_wing_cross_sections = ref_wing.wing_cross_sections
             these_wing_cross_sections = []
 
@@ -1343,15 +1457,22 @@ def _build_unsteady_problem(
     wake_length: int,
     ref_problem: problems.UnsteadyProblem,
     num_spanwise_panels_cache: dict[tuple[int, int, int, int, int], int],
+    num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int],
 ) -> problems.UnsteadyProblem:
     """Builds the UnsteadyProblem for one convergence iteration.
 
     Each of the reference Movement's AirplaneMovements (and its nested WingMovements and
     WingCrossSectionMovements) is copied with the given Panel aspect ratio and number of
-    chordwise Panels, preserving every motion parameter. Each non-tip WingCrossSection's
-    number of spanwise Panels is resolved (and cached) to achieve the desired Panel
-    aspect ratio, and the copied AirplaneMovements are wrapped in a new Movement (with
-    the given wake length) and UnsteadyProblem.
+    chordwise Panels, preserving every motion parameter. Each Wing is refined by its
+    spanwise mesh: a trapezoidal Wing has each non-tip WingCrossSection's number of
+    spanwise Panels resolved (and cached) to achieve the desired Panel aspect ratio,
+    while an edge-defined Wing has its stored edge curves resampled into the number of
+    WingCrossSections (also resolved and cached) that achieves it. An edge-defined
+    Wing's WingCrossSectionMovements must all be static, because resampling changes the
+    WingCrossSection count and so cannot preserve per-WingCrossSection motion; the
+    refined WingCrossSections are wrapped in motion free WingCrossSectionMovements and
+    the WingMovement's own motion parameters are copied. The copied AirplaneMovements
+    are wrapped in a new Movement (with the given wake length) and UnsteadyProblem.
 
     :param ar_id: The index of the current Panel aspect ratio within the list of Panel
         aspect ratios being tested.
@@ -1365,8 +1486,12 @@ def _build_unsteady_problem(
     :param ref_problem: The reference UnsteadyProblem whose Movement is copied.
     :param num_spanwise_panels_cache: The cache mapping a (Panel aspect ratio index,
         number of chordwise Panels index, Airplane index, Wing index, WingCrossSection
-        index) tuple to a previously calculated number of spanwise Panels. It is read
-        and updated in place.
+        index) tuple to a previously calculated number of spanwise Panels, used for
+        trapezoidal Wings. It is read and updated in place.
+    :param num_wing_cross_sections_cache: The cache mapping a (Panel aspect ratio index,
+        number of chordwise Panels index, Airplane index, Wing index) tuple to a
+        previously calculated number of WingCrossSections, used for edge-defined Wings.
+        It is read and updated in place.
     :return: The UnsteadyProblem for this iteration.
     """
     ref_movement = ref_problem.movement
@@ -1436,6 +1561,85 @@ def _build_unsteady_problem(
         for ref_wing_movement_id, ref_wing_movement in enumerate(ref_wing_movements):
             # 5.1. Reference the WingMovement's base Wing.
             ref_base_wing = ref_wing_movement.base_wing
+
+            # An edge-defined Wing is refined by resampling its stored edge curves into
+            # the number of WingCrossSections that achieves the desired Panel aspect
+            # ratio. Resampling changes the WingCrossSection count, so it cannot preserve
+            # per-WingCrossSection motion. Every WingCrossSectionMovement must therefore
+            # be static; the refined WingCrossSections are wrapped in motion free
+            # WingCrossSectionMovements and only the WingMovement's own motion is carried
+            # over.
+            if ref_base_wing.spanwise_mesh == "edge_defined":
+                for (
+                    ref_wing_cross_section_movement_id,
+                    ref_wing_cross_section_movement,
+                ) in enumerate(ref_wing_movement.wing_cross_section_movements):
+                    if np.any(ref_wing_cross_section_movement.ampLp_Wcsp_Lpp) or np.any(
+                        ref_wing_cross_section_movement.ampAngles_Wcsp_to_Wcs_ixyz
+                    ):
+                        raise ValueError(
+                            "analyze_unsteady_convergence cannot refine an edge-defined "
+                            "Wing whose WingCrossSectionMovements are not all static, "
+                            "because resampling the Wing changes its number of "
+                            "WingCrossSections. The WingCrossSectionMovement at index "
+                            f"{ref_wing_cross_section_movement_id} of the WingMovement "
+                            f'for the Wing named "{ref_base_wing.name}" is not static.'
+                        )
+
+                this_num_wing_cross_sections = _resolve_num_wing_cross_sections(
+                    ar_id,
+                    chord_id,
+                    ref_airplane_movement_id,
+                    ref_wing_movement_id,
+                    ref_base_airplane.name,
+                    ref_base_wing.name,
+                    "\t\t\t\t\t\t",
+                    num_wing_cross_sections_cache,
+                    lambda start: _get_num_wing_cross_sections_for_panel_ar(
+                        panel_aspect_ratio,
+                        num_chordwise_panels,
+                        ref_base_wing,
+                        start,
+                    ),
+                )
+
+                this_base_wing = _build_edge_defined_wing(
+                    ref_base_wing, num_chordwise_panels, this_num_wing_cross_sections
+                )
+
+                these_wing_cross_section_movements = [
+                    movements.wing_cross_section_movement.WingCrossSectionMovement(
+                        base_wing_cross_section=this_base_wing_cross_section
+                    )
+                    for this_base_wing_cross_section in (
+                        this_base_wing.wing_cross_sections
+                    )
+                ]
+
+                this_wing_movement = movements.wing_movement.WingMovement(
+                    # These values are copied from the reference WingMovement.
+                    ampLer_Gs_Cgs=ref_wing_movement.ampLer_Gs_Cgs,
+                    periodLer_Gs_Cgs=ref_wing_movement.periodLer_Gs_Cgs,
+                    spacingLer_Gs_Cgs=ref_wing_movement.spacingLer_Gs_Cgs,
+                    phaseLer_Gs_Cgs=ref_wing_movement.phaseLer_Gs_Cgs,
+                    ampAngles_Gs_to_Wn_ixyz=ref_wing_movement.ampAngles_Gs_to_Wn_ixyz,
+                    periodAngles_Gs_to_Wn_ixyz=(
+                        ref_wing_movement.periodAngles_Gs_to_Wn_ixyz
+                    ),
+                    spacingAngles_Gs_to_Wn_ixyz=(
+                        ref_wing_movement.spacingAngles_Gs_to_Wn_ixyz
+                    ),
+                    phaseAngles_Gs_to_Wn_ixyz=(
+                        ref_wing_movement.phaseAngles_Gs_to_Wn_ixyz
+                    ),
+                    # These values change.
+                    base_wing=this_base_wing,
+                    wing_cross_section_movements=these_wing_cross_section_movements,
+                )
+
+                these_base_wings.append(this_base_wing)
+                these_wing_movements.append(this_wing_movement)
+                continue
 
             # 5.2. Reference the WingMovement's list of WingCrossSectionMovements.
             ref_wing_cross_section_movements = (
@@ -1828,6 +2032,271 @@ def _get_wing_section_average_panel_aspect_ratio(
     return _average_panel_aspect_ratio
 
 
+def _build_edge_defined_wing(
+    ref_wing: geometry.wing.Wing,
+    num_chordwise_panels: int,
+    num_wing_cross_sections: int,
+) -> geometry.wing.Wing:
+    """Rebuilds an edge-defined Wing from its stored edge curves at a new resolution.
+
+    The reference Wing's stored leading edge and trailing edge curves are resampled into
+    the requested number of WingCrossSections with Wing.from_edge_points, reusing every
+    other geometric parameter (position, orientation, symmetry, chordwise spacing, and
+    tip trim) from the reference Wing. The single Airfoil is read from the reference
+    Wing's first WingCrossSection and shared across the rebuilt WingCrossSections, which
+    is safe because Airfoils are immutable.
+
+    :param ref_wing: The reference edge-defined Wing whose stored edge curves and
+        parameters are reused. Its spanwise_mesh must be "edge_defined".
+    :param num_chordwise_panels: The number of chordwise Panels to use. It must be a
+        positive int.
+    :param num_wing_cross_sections: The number of WingCrossSections to resample the edge
+        curves into. It must be an int of at least 2.
+    :return: The rebuilt edge-defined Wing.
+    """
+    # An edge-defined Wing always stores its edge curves and tip trim fraction, so these
+    # are never None here. The assertions narrow the accessors' optional types.
+    leadingEdgePoints_Wn_Ler = ref_wing.leadingEdgePoints_Wn_Ler
+    trailingEdgePoints_Wn_Ler = ref_wing.trailingEdgePoints_Wn_Ler
+    tip_trim_fraction = ref_wing.tip_trim_fraction
+    assert leadingEdgePoints_Wn_Ler is not None
+    assert trailingEdgePoints_Wn_Ler is not None
+    assert tip_trim_fraction is not None
+
+    return geometry.wing.Wing.from_edge_points(
+        leadingEdgePoints_Wn_Ler=leadingEdgePoints_Wn_Ler,
+        trailingEdgePoints_Wn_Ler=trailingEdgePoints_Wn_Ler,
+        num_wing_cross_sections=num_wing_cross_sections,
+        airfoil=ref_wing.wing_cross_sections[0].airfoil,
+        name=ref_wing.name,
+        Ler_Gs_Cgs=ref_wing.Ler_Gs_Cgs,
+        angles_Gs_to_Wn_ixyz=ref_wing.angles_Gs_to_Wn_ixyz,
+        symmetric=ref_wing.symmetric,
+        mirror_only=ref_wing.mirror_only,
+        symmetryNormal_G=ref_wing.symmetryNormal_G,
+        symmetryPoint_G_Cg=ref_wing.symmetryPoint_G_Cg,
+        num_chordwise_panels=num_chordwise_panels,
+        chordwise_spacing=ref_wing.chordwise_spacing,
+        tip_trim_fraction=tip_trim_fraction,
+    )
+
+
+def _get_num_wing_cross_sections_for_panel_ar(
+    desired_average_panel_aspect_ratio: int,
+    num_chordwise_panels: int,
+    ref_wing: geometry.wing.Wing,
+    start_val: int,
+) -> int:
+    """Calculates the number of WingCrossSections that gives an edge-defined Wing a
+    target average Panel aspect ratio.
+
+    An edge-defined Wing is refined by resampling its stored edge curves into more
+    WingCrossSections, not by adding spanwise Panels to fixed WingCrossSections, so the
+    number of WingCrossSections is the refinement knob. Increasing it monotonically
+    lowers the meshed average Panel aspect ratio.
+
+    Rather than estimate the count from a closed form, this searches for it by meshing.
+    A closed form built from the mean chord would undershoot the count on a tapered
+    planform, because average_panel_aspect_ratio is the mean of each Panel's individual
+    aspect ratio and is dominated by the small-chord tip Panels. Instead, the reference
+    Wing is rebuilt at trial WingCrossSection counts (with _build_edge_defined_wing),
+    each trial is meshed, and its average Panel aspect ratio is read. The search
+    proportionally jumps to bracket the target, then bisects to the crossing, and
+    returns whichever of the two counts straddling the target gives the closer average
+    Panel aspect ratio. This matches how the trapezoidal
+    _get_wing_section_num_spanwise_panels searches, so a target Panel aspect ratio means
+    the same physical thing for an edge-defined Wing as for a trapezoidal one. Only
+    meshing is performed here, never solving.
+
+    :param desired_average_panel_aspect_ratio: The target average Panel aspect ratio to
+        achieve. The Panel aspect ratio is the Panels' average y component length (in
+        wing cross section parent axes) divided by their average x component width (in
+        wing cross section parent axes). It must be a positive int.
+    :param num_chordwise_panels: The number of chordwise Panels to use. It must be a
+        positive int.
+    :param ref_wing: The reference edge-defined Wing whose stored edge curves are
+        resampled. Its spanwise_mesh must be "edge_defined".
+    :param start_val: The initial number of WingCrossSections to start the search from.
+        It must be a positive int and a lower bound on the result. Using a higher value
+        can speed up the search if a lower bound is already known.
+    :return: The number of WingCrossSections that gives an average Panel aspect ratio
+        closest to the desired value.
+    """
+    meshed_average_panel_aspect_ratios: dict[int, float] = {}
+
+    def average_panel_aspect_ratio_at(num_wing_cross_sections: int) -> float:
+        if num_wing_cross_sections not in meshed_average_panel_aspect_ratios:
+            refined_wing = _build_edge_defined_wing(
+                ref_wing, num_chordwise_panels, num_wing_cross_sections
+            )
+            refined_airplane = geometry.airplane.Airplane(wings=[refined_wing])
+            this_average_panel_aspect_ratio = refined_airplane.wings[
+                0
+            ].average_panel_aspect_ratio
+            assert this_average_panel_aspect_ratio is not None
+            meshed_average_panel_aspect_ratios[num_wing_cross_sections] = (
+                this_average_panel_aspect_ratio
+            )
+        return meshed_average_panel_aspect_ratios[num_wing_cross_sections]
+
+    # from_edge_points requires at least two WingCrossSections.
+    lower_num = max(int(start_val), 2)
+    lower_average_panel_aspect_ratio = average_panel_aspect_ratio_at(lower_num)
+
+    # If the starting count already meets the target, it is the smallest count that does,
+    # so return it.
+    if lower_average_panel_aspect_ratio <= desired_average_panel_aspect_ratio:
+        return lower_num
+
+    # Proportionally jump to bracket the target from above. The average Panel aspect ratio
+    # scales roughly as 1 / (num_wing_cross_sections - 1), so this estimate lands near the
+    # crossing in a few steps. Each jump strictly increases the count, and the aspect
+    # ratio falls toward zero as the count grows, so the loop terminates.
+    upper_num = lower_num
+    upper_average_panel_aspect_ratio = lower_average_panel_aspect_ratio
+    while upper_average_panel_aspect_ratio > desired_average_panel_aspect_ratio:
+        projected_num = 1 + round(
+            upper_average_panel_aspect_ratio
+            * (upper_num - 1)
+            / desired_average_panel_aspect_ratio
+        )
+        upper_num = max(projected_num, upper_num + 1)
+        upper_average_panel_aspect_ratio = average_panel_aspect_ratio_at(upper_num)
+
+    # Bisect between the count above the target (lower_num) and the count at or below it
+    # (upper_num) for the integer crossing.
+    while upper_num - lower_num > 1:
+        middle_num = (lower_num + upper_num) // 2
+        if (
+            average_panel_aspect_ratio_at(middle_num)
+            > desired_average_panel_aspect_ratio
+        ):
+            lower_num = middle_num
+        else:
+            upper_num = middle_num
+
+    # Return whichever of the two straddling counts gives the closer average Panel aspect
+    # ratio. On a tie, prefer the finer mesh (upper_num), matching the trapezoidal search.
+    lower_difference = abs(
+        average_panel_aspect_ratio_at(lower_num) - desired_average_panel_aspect_ratio
+    )
+    upper_difference = abs(
+        average_panel_aspect_ratio_at(upper_num) - desired_average_panel_aspect_ratio
+    )
+    if lower_difference < upper_difference:
+        return lower_num
+    return upper_num
+
+
+def _resolve_num_wing_cross_sections(
+    panel_aspect_ratio_id: int,
+    num_chordwise_panels_id: int,
+    airplane_id: int,
+    wing_id: int,
+    airplane_name: str,
+    wing_name: str,
+    log_indent: str,
+    num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int],
+    compute_num_wing_cross_sections: Callable[[int], int],
+) -> int:
+    """Resolves the number of WingCrossSections for one edge-defined Wing, using and
+    updating the shared cache.
+
+    The result for a given (Panel aspect ratio, number of chordwise Panels, Airplane,
+    Wing) combination is returned from the cache if present. Otherwise, the search
+    starts from a conservative lower bound (the smallest number of WingCrossSections
+    already found for this Wing at an incrementally coarser mesh, since the current
+    finer mesh must need at least that many), ``compute_num_wing_cross_sections`` is
+    called with that starting value to find the count, and the result is cached.
+
+    :param panel_aspect_ratio_id: The index of the current Panel aspect ratio within the
+        list of Panel aspect ratios being tested.
+    :param num_chordwise_panels_id: The index of the current number of chordwise Panels
+        within the list of numbers of chordwise Panels being tested.
+    :param airplane_id: The index of the current Airplane.
+    :param wing_id: The index of the current Wing within the Airplane.
+    :param airplane_name: The name of the current Airplane, used in the log messages.
+    :param wing_name: The name of the current Wing, used in the log messages.
+    :param log_indent: The leading whitespace prepended to the log messages so they nest
+        under the calling function's other log output.
+    :param num_wing_cross_sections_cache: The cache mapping a (Panel aspect ratio index,
+        number of chordwise Panels index, Airplane index, Wing index) tuple to a
+        previously calculated number of WingCrossSections. It is read and updated in
+        place.
+    :param compute_num_wing_cross_sections: A callable that takes a starting number of
+        WingCrossSections and returns the number of WingCrossSections that achieves the
+        desired Panel aspect ratio. It is called only on a cache miss.
+    :return: The number of WingCrossSections for the Wing.
+    """
+    num_wing_cross_sections_key = (
+        panel_aspect_ratio_id,
+        num_chordwise_panels_id,
+        airplane_id,
+        wing_id,
+    )
+
+    if num_wing_cross_sections_key in num_wing_cross_sections_cache:
+        _logger.debug(
+            f"{log_indent}Getting the cached number of WingCrossSections calculated for "
+            f"{airplane_name}'s {wing_name}..."
+        )
+        this_num_wing_cross_sections = num_wing_cross_sections_cache[
+            num_wing_cross_sections_key
+        ]
+    else:
+        # Start the search from a conservative lower bound: the smallest number of
+        # WingCrossSections already found for this Wing at an incrementally coarser mesh
+        # (in Panel aspect ratio, number of chordwise Panels, or both), since the current
+        # finer mesh must use at least that many. The floor is two, the fewest
+        # WingCrossSections an edge-defined Wing can have.
+        starting_num_wing_cross_sections = 2
+        last_ar_key = (
+            panel_aspect_ratio_id - 1,
+            num_chordwise_panels_id,
+            airplane_id,
+            wing_id,
+        )
+        last_chord_key = (
+            panel_aspect_ratio_id,
+            num_chordwise_panels_id - 1,
+            airplane_id,
+            wing_id,
+        )
+        last_ar_and_chord_key = (
+            panel_aspect_ratio_id - 1,
+            num_chordwise_panels_id - 1,
+            airplane_id,
+            wing_id,
+        )
+        last_cache_val = min(
+            num_wing_cross_sections_cache.get(last_ar_key, np.inf),
+            num_wing_cross_sections_cache.get(last_chord_key, np.inf),
+            num_wing_cross_sections_cache.get(last_ar_and_chord_key, np.inf),
+        )
+        if last_cache_val != np.inf:
+            starting_num_wing_cross_sections = int(last_cache_val)
+
+        _logger.debug(
+            f"{log_indent}Calculating the number of WingCrossSections for "
+            f"{airplane_name}'s {wing_name}, with a starting value of "
+            f"{starting_num_wing_cross_sections}..."
+        )
+
+        this_num_wing_cross_sections = compute_num_wing_cross_sections(
+            starting_num_wing_cross_sections
+        )
+
+        num_wing_cross_sections_cache[num_wing_cross_sections_key] = (
+            this_num_wing_cross_sections
+        )
+
+    _logger.debug(
+        f"{log_indent}Number of WingCrossSections: {this_num_wing_cross_sections}"
+    )
+
+    return this_num_wing_cross_sections
+
+
 def _validate_panel_aspect_ratio_bounds(
     panel_aspect_ratio_bounds: tuple[int, int],
 ) -> None:
@@ -1882,19 +2351,19 @@ def _validate_num_chordwise_panels_bounds(
         raise ValueError("Both values in num_chordwise_panels_bounds must be positive.")
 
 
-def _reject_non_trapezoidal_wings(
+def _reject_unrefinable_wings(
     ref_airplanes: tuple[geometry.airplane.Airplane, ...],
     analyze_function_name: str,
 ) -> None:
-    """Raises if any Wing in the reference Airplanes has a non-trapezoidal spanwise
-    mesh.
+    """Raises if any Wing in the reference Airplanes cannot be refined.
 
-    The convergence analysis functions refine a Wing by sweeping the number of spanwise
-    Panels while holding its WingCrossSections fixed, which is only meaningful for a
-    trapezoidal Wing. A Wing whose spanwise mesh is defined as single panel strips (for
-    example one built with explode_into_strips=True) would be silently subdivided along
-    the same geometry rather than refined, so its convergence result would be
-    misleading.
+    The convergence analysis functions refine a Wing by its spanwise mesh: a trapezoidal
+    Wing by sweeping the number of spanwise Panels while holding its WingCrossSections
+    fixed, and an edge-defined Wing (one built with Wing.from_edge_points) by resampling
+    its stored edge curves into more WingCrossSections. Both are supported. An exploded
+    Wing (one built with explode_into_strips=True) is already in single-panel-strip form
+    but carries no edge curves, so it can be neither resampled nor meaningfully swept
+    for Panel density, and it is rejected.
 
     :param ref_airplanes: A tuple of the reference Airplanes whose Wings are checked.
     :param analyze_function_name: The name of the calling analysis function, used in the
@@ -1903,11 +2372,14 @@ def _reject_non_trapezoidal_wings(
     """
     for ref_airplane in ref_airplanes:
         for ref_wing in ref_airplane.wings:
-            if ref_wing.spanwise_mesh != "trapezoidal":
+            if ref_wing.spanwise_mesh not in ("trapezoidal", "edge_defined"):
                 raise ValueError(
-                    f"{analyze_function_name} does not support Wings whose spanwise "
-                    f'mesh is not "trapezoidal". The Wing named "{ref_wing.name}" has a '
-                    f'spanwise mesh of "{ref_wing.spanwise_mesh}".'
+                    f"{analyze_function_name} cannot refine the Wing named "
+                    f'"{ref_wing.name}", whose spanwise mesh is '
+                    f'"{ref_wing.spanwise_mesh}". Convergence analysis can refine an '
+                    "edge-defined Wing (one built from edge curves) or a non-edge-defined "
+                    "Wing built from WingCrossSections, but not a Wing already exploded "
+                    "into single-panel strips."
                 )
 
 

--- a/tests/integration/fixtures/airplane_fixtures.py
+++ b/tests/integration/fixtures/airplane_fixtures.py
@@ -1,5 +1,7 @@
 """This module creates Airplanes to be used as fixtures."""
 
+import numpy as np
+
 import pterasoftware as ps
 
 
@@ -118,6 +120,113 @@ def make_exploded_validation_airplane():
         name="Exploded Validation Airplane",
     )
     return exploded_validation_airplane
+
+
+def make_edge_defined_validation_airplane():
+    """This function creates an Airplane with an edge-defined Wing to be used as a
+    fixture for testing the convergence functions' edge-defined refinement.
+
+    The Wing is built with Wing.from_edge_points, so its spanwise mesh marker is
+    "edge_defined". Its leading edge sweeps straight back and its trailing edge is
+    unswept, giving a straight tapered planform (a unit root chord tapering to a half
+    chord over a five meter half span) that PCHIP resampling reproduces exactly at any
+    number of WingCrossSections.
+
+    :return edge_defined_validation_airplane: Airplane
+        This is the Airplane fixture.
+    """
+    ys = np.linspace(0.0, 5.0, 30)
+    zeros = np.zeros_like(ys)
+    leadingEdgePoints_Wn_Ler = np.column_stack((0.1 * ys, ys, zeros))
+    trailingEdgePoints_Wn_Ler = np.column_stack((np.ones_like(ys), ys, zeros))
+
+    edge_defined_validation_airplane = ps.geometry.airplane.Airplane(
+        wings=[
+            ps.geometry.wing.Wing.from_edge_points(
+                leadingEdgePoints_Wn_Ler=leadingEdgePoints_Wn_Ler,
+                trailingEdgePoints_Wn_Ler=trailingEdgePoints_Wn_Ler,
+                num_wing_cross_sections=10,
+                airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+                name="Edge Wing",
+                symmetric=True,
+                symmetryNormal_G=(0.0, 1.0, 0.0),
+                symmetryPoint_G_Cg=(0.0, 0.0, 0.0),
+                num_chordwise_panels=8,
+            )
+        ],
+        name="Edge Defined Validation Airplane",
+    )
+    return edge_defined_validation_airplane
+
+
+def make_mixed_validation_airplane():
+    """This function creates an Airplane holding both a trapezoidal Wing and an
+    edge-defined Wing, to be used as a fixture for testing that the convergence functions
+    refine each Wing by its own spanwise mesh.
+
+    The trapezoidal Wing (spanwise mesh "trapezoidal") is refined by sweeping its number
+    of spanwise Panels, while the edge-defined Wing (spanwise mesh "edge_defined", built
+    with Wing.from_edge_points) is refined by resampling its stored edge curves. The
+    edge-defined Wing is placed behind the trapezoidal Wing so the two do not overlap.
+
+    :return mixed_validation_airplane: Airplane
+        This is the Airplane fixture.
+    """
+    ys = np.linspace(0.0, 5.0, 30)
+    zeros = np.zeros_like(ys)
+    leadingEdgePoints_Wn_Ler = np.column_stack((0.1 * ys, ys, zeros))
+    trailingEdgePoints_Wn_Ler = np.column_stack((np.ones_like(ys), ys, zeros))
+
+    mixed_validation_airplane = ps.geometry.airplane.Airplane(
+        wings=[
+            ps.geometry.wing.Wing(
+                wing_cross_sections=[
+                    ps.geometry.wing_cross_section.WingCrossSection(
+                        airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+                        num_spanwise_panels=8,
+                        chord=1.0,
+                        Lp_Wcsp_Lpp=(0.0, 0.0, 0.0),
+                        angles_Wcsp_to_Wcs_ixyz=(0.0, 0.0, 0.0),
+                        control_surface_symmetry_type="symmetric",
+                        control_surface_hinge_point=0.75,
+                        control_surface_deflection=0.0,
+                        spanwise_spacing="uniform",
+                    ),
+                    ps.geometry.wing_cross_section.WingCrossSection(
+                        airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+                        num_spanwise_panels=None,
+                        chord=1.0,
+                        Lp_Wcsp_Lpp=(0.0, 5.0, 0.0),
+                        angles_Wcsp_to_Wcs_ixyz=(0.0, 0.0, 0.0),
+                        control_surface_symmetry_type="symmetric",
+                        control_surface_hinge_point=0.75,
+                        control_surface_deflection=0.0,
+                        spanwise_spacing=None,
+                    ),
+                ],
+                name="Trapezoidal Wing",
+                symmetric=True,
+                symmetryNormal_G=(0.0, 1.0, 0.0),
+                symmetryPoint_G_Cg=(0.0, 0.0, 0.0),
+                num_chordwise_panels=8,
+                chordwise_spacing="uniform",
+            ),
+            ps.geometry.wing.Wing.from_edge_points(
+                leadingEdgePoints_Wn_Ler=leadingEdgePoints_Wn_Ler,
+                trailingEdgePoints_Wn_Ler=trailingEdgePoints_Wn_Ler,
+                num_wing_cross_sections=10,
+                airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+                name="Edge Wing",
+                Ler_Gs_Cgs=(4.0, 0.0, 0.0),
+                symmetric=True,
+                symmetryNormal_G=(0.0, 1.0, 0.0),
+                symmetryPoint_G_Cg=(0.0, 0.0, 0.0),
+                num_chordwise_panels=8,
+            ),
+        ],
+        name="Mixed Validation Airplane",
+    )
+    return mixed_validation_airplane
 
 
 def make_multiple_wing_steady_validation_airplane():

--- a/tests/integration/fixtures/movement_fixtures.py
+++ b/tests/integration/fixtures/movement_fixtures.py
@@ -63,6 +63,121 @@ def make_static_validation_movement():
     return unsteady_validation_movement
 
 
+def make_edge_defined_static_validation_movement():
+    """This function creates a static Movement over an edge-defined Airplane, to be used
+    as a fixture for testing the convergence functions' edge-defined refinement.
+
+    Every WingCrossSectionMovement is static, which edge-defined convergence requires,
+    since resampling the Wing changes its number of WingCrossSections.
+
+    :return edge_defined_validation_movement: Movement
+        This is the Movement fixture.
+    """
+    edge_defined_validation_airplane = (
+        airplane_fixtures.make_edge_defined_validation_airplane()
+    )
+    edge_defined_validation_operating_point = (
+        operating_point_fixtures.make_validation_operating_point()
+    )
+
+    edge_defined_wing_cross_section_movements = [
+        ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
+            base_wing_cross_section=wing_cross_section
+        )
+        for wing_cross_section in edge_defined_validation_airplane.wings[
+            0
+        ].wing_cross_sections
+    ]
+
+    edge_defined_wing_movement = ps.movements.wing_movement.WingMovement(
+        base_wing=edge_defined_validation_airplane.wings[0],
+        wing_cross_section_movements=edge_defined_wing_cross_section_movements,
+    )
+
+    edge_defined_airplane_movement = ps.movements.airplane_movement.AirplaneMovement(
+        base_airplane=edge_defined_validation_airplane,
+        wing_movements=[edge_defined_wing_movement],
+    )
+
+    edge_defined_operating_point_movement = (
+        ps.movements.operating_point_movement.OperatingPointMovement(
+            base_operating_point=edge_defined_validation_operating_point
+        )
+    )
+
+    edge_defined_validation_movement = ps.movements.movement.Movement(
+        airplane_movements=[edge_defined_airplane_movement],
+        operating_point_movement=edge_defined_operating_point_movement,
+        num_chords=6,
+    )
+
+    return edge_defined_validation_movement
+
+
+def make_edge_defined_non_static_validation_movement():
+    """This function creates a Movement over an edge-defined Airplane whose second
+    WingCrossSectionMovement pitches, to be used as a fixture for testing that
+    edge-defined convergence rejects non-static WingCrossSectionMovements.
+
+    Resampling an edge-defined Wing changes its number of WingCrossSections, so
+    per-WingCrossSection motion cannot be preserved. This Movement gives one interior
+    WingCrossSection a pitching motion so the convergence function must reject it.
+
+    :return edge_defined_non_static_validation_movement: Movement
+        This is the Movement fixture.
+    """
+    edge_defined_validation_airplane = (
+        airplane_fixtures.make_edge_defined_validation_airplane()
+    )
+    edge_defined_validation_operating_point = (
+        operating_point_fixtures.make_validation_operating_point()
+    )
+
+    edge_defined_wing_cross_sections = edge_defined_validation_airplane.wings[
+        0
+    ].wing_cross_sections
+    edge_defined_wing_cross_section_movements = [
+        ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
+            base_wing_cross_section=wing_cross_section
+        )
+        for wing_cross_section in edge_defined_wing_cross_sections
+    ]
+
+    # Replace an interior WingCrossSectionMovement with a pitching one. The root
+    # WingCrossSection cannot pitch, so the second WingCrossSection is used.
+    edge_defined_wing_cross_section_movements[1] = (
+        ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
+            base_wing_cross_section=edge_defined_wing_cross_sections[1],
+            ampAngles_Wcsp_to_Wcs_ixyz=(0.0, 5.0, 0.0),
+            periodAngles_Wcsp_to_Wcs_ixyz=(0.0, 1.0, 0.0),
+        )
+    )
+
+    edge_defined_wing_movement = ps.movements.wing_movement.WingMovement(
+        base_wing=edge_defined_validation_airplane.wings[0],
+        wing_cross_section_movements=edge_defined_wing_cross_section_movements,
+    )
+
+    edge_defined_airplane_movement = ps.movements.airplane_movement.AirplaneMovement(
+        base_airplane=edge_defined_validation_airplane,
+        wing_movements=[edge_defined_wing_movement],
+    )
+
+    edge_defined_operating_point_movement = (
+        ps.movements.operating_point_movement.OperatingPointMovement(
+            base_operating_point=edge_defined_validation_operating_point
+        )
+    )
+
+    edge_defined_non_static_validation_movement = ps.movements.movement.Movement(
+        airplane_movements=[edge_defined_airplane_movement],
+        operating_point_movement=edge_defined_operating_point_movement,
+        num_cycles=1,
+    )
+
+    return edge_defined_non_static_validation_movement
+
+
 def make_variable_validation_movement():
     """This function creates a Movement with variable geometry to be used as a fixture.
 

--- a/tests/integration/fixtures/problem_fixtures.py
+++ b/tests/integration/fixtures/problem_fixtures.py
@@ -51,6 +51,48 @@ def make_steady_multiple_wing_validation_problem():
     return steady_validation_problem
 
 
+def make_edge_defined_steady_validation_problem():
+    """This function creates a SteadyProblem with an edge-defined Airplane to be used as
+    a fixture.
+
+    :return edge_defined_steady_validation_problem: SteadyProblem
+        This is the SteadyProblem fixture.
+    """
+    edge_defined_validation_airplane = (
+        airplane_fixtures.make_edge_defined_validation_airplane()
+    )
+    steady_validation_operating_point = (
+        operating_point_fixtures.make_validation_operating_point()
+    )
+
+    edge_defined_steady_validation_problem = ps.problems.SteadyProblem(
+        airplanes=[edge_defined_validation_airplane],
+        operating_point=steady_validation_operating_point,
+    )
+
+    return edge_defined_steady_validation_problem
+
+
+def make_mixed_steady_validation_problem():
+    """This function creates a SteadyProblem with an Airplane holding both a trapezoidal
+    Wing and an edge-defined Wing, to be used as a fixture.
+
+    :return mixed_steady_validation_problem: SteadyProblem
+        This is the SteadyProblem fixture.
+    """
+    mixed_validation_airplane = airplane_fixtures.make_mixed_validation_airplane()
+    steady_validation_operating_point = (
+        operating_point_fixtures.make_validation_operating_point()
+    )
+
+    mixed_steady_validation_problem = ps.problems.SteadyProblem(
+        airplanes=[mixed_validation_airplane],
+        operating_point=steady_validation_operating_point,
+    )
+
+    return mixed_steady_validation_problem
+
+
 def make_unsteady_validation_problem_with_static_geometry():
     """This function creates an UnsteadyProblem with static geometry to be used as a
     fixture.
@@ -65,6 +107,43 @@ def make_unsteady_validation_problem_with_static_geometry():
     )
 
     return unsteady_validation_problem
+
+
+def make_edge_defined_unsteady_validation_problem():
+    """This function creates an UnsteadyProblem with an edge-defined Airplane and static
+    WingCrossSectionMovements, to be used as a fixture.
+
+    :return edge_defined_unsteady_validation_problem: UnsteadyProblem
+        This is the UnsteadyProblem fixture.
+    """
+    edge_defined_validation_movement = (
+        movement_fixtures.make_edge_defined_static_validation_movement()
+    )
+
+    edge_defined_unsteady_validation_problem = ps.problems.UnsteadyProblem(
+        movement=edge_defined_validation_movement
+    )
+
+    return edge_defined_unsteady_validation_problem
+
+
+def make_edge_defined_non_static_unsteady_validation_problem():
+    """This function creates an UnsteadyProblem with an edge-defined Airplane whose
+    WingCrossSectionMovements are not all static, to be used as a fixture for testing
+    that edge-defined convergence rejects it.
+
+    :return edge_defined_non_static_unsteady_validation_problem: UnsteadyProblem
+        This is the UnsteadyProblem fixture.
+    """
+    edge_defined_non_static_validation_movement = (
+        movement_fixtures.make_edge_defined_non_static_validation_movement()
+    )
+
+    edge_defined_non_static_unsteady_validation_problem = ps.problems.UnsteadyProblem(
+        movement=edge_defined_non_static_validation_movement
+    )
+
+    return edge_defined_non_static_unsteady_validation_problem
 
 
 def make_unsteady_validation_problem_with_variable_geometry():

--- a/tests/integration/test_steady_convergence.py
+++ b/tests/integration/test_steady_convergence.py
@@ -48,7 +48,7 @@ class TestSteadyConvergence(unittest.TestCase):
 
     def test_rejects_exploded_wing(self):
         """This method tests that the function rejects a SteadyProblem whose Airplane has
-        a Wing with a non-trapezoidal spanwise mesh.
+        an exploded Wing, which carries no edge curves and so cannot be refined.
 
         :return: None
         """
@@ -149,3 +149,59 @@ class TestSteadyConvergence(unittest.TestCase):
             ps.steady_ring_vortex_lattice_method.SteadyRingVortexLatticeMethodSolver,
         )
         self.assertIsNotNone(converged_solver.airplanes[0].forceCoefficients_W)
+
+    def test_edge_defined_steady_convergence(self):
+        """This method tests that the function finds pre-known convergence parameters for
+        a SteadyProblem whose Airplane has an edge-defined Wing, refined by resampling
+        its stored edge curves.
+
+        :return: None
+        """
+        edge_defined_steady_problem = (
+            problem_fixtures.make_edge_defined_steady_validation_problem()
+        )
+
+        converged_parameters = ps.convergence.analyze_steady_convergence(
+            ref_problem=edge_defined_steady_problem,
+            solver_type="steady ring vortex lattice method",
+            panel_aspect_ratio_bounds=(4, 2),
+            num_chordwise_panels_bounds=(1, 4),
+            convergence_criteria=5.0,
+        )
+
+        converged_panel_ar = converged_parameters[0]
+        converged_num_chordwise = converged_parameters[1]
+
+        panel_ar_ans = 4
+        num_chordwise_ans = 1
+
+        self.assertEqual(converged_panel_ar, panel_ar_ans)
+        self.assertEqual(converged_num_chordwise, num_chordwise_ans)
+        self.assertIsNone(converged_parameters[2])
+
+    def test_mixed_airplane_steady_convergence(self):
+        """This method tests that the function finds pre-known convergence parameters for
+        a SteadyProblem whose Airplane holds both a trapezoidal Wing and an edge-defined
+        Wing, refining each Wing by its own spanwise mesh.
+
+        :return: None
+        """
+        mixed_steady_problem = problem_fixtures.make_mixed_steady_validation_problem()
+
+        converged_parameters = ps.convergence.analyze_steady_convergence(
+            ref_problem=mixed_steady_problem,
+            solver_type="steady ring vortex lattice method",
+            panel_aspect_ratio_bounds=(4, 2),
+            num_chordwise_panels_bounds=(1, 4),
+            convergence_criteria=5.0,
+        )
+
+        converged_panel_ar = converged_parameters[0]
+        converged_num_chordwise = converged_parameters[1]
+
+        panel_ar_ans = 4
+        num_chordwise_ans = 1
+
+        self.assertEqual(converged_panel_ar, panel_ar_ans)
+        self.assertEqual(converged_num_chordwise, num_chordwise_ans)
+        self.assertIsNone(converged_parameters[2])

--- a/tests/integration/test_unsteady_convergence.py
+++ b/tests/integration/test_unsteady_convergence.py
@@ -57,7 +57,7 @@ class TestUnsteadyConvergence(unittest.TestCase):
 
     def test_rejects_exploded_wing(self):
         """This method tests that the function rejects an UnsteadyProblem whose Airplane
-        has a Wing with a non-trapezoidal spanwise mesh.
+        has an exploded Wing, which carries no edge curves and so cannot be refined.
 
         :return: None
         """
@@ -98,6 +98,75 @@ class TestUnsteadyConvergence(unittest.TestCase):
                 prescribed_wake=True,
                 free_wake=True,
                 num_chords_bounds=(1, 2),
+                panel_aspect_ratio_bounds=(4, 2),
+                num_chordwise_panels_bounds=(1, 4),
+                convergence_criteria=5.0,
+                show_solver_progress=False,
+            )
+
+    def test_edge_defined_unsteady_convergence(self):
+        """This method tests that the function finds pre-known convergence parameters for
+        an UnsteadyProblem whose Airplane has an edge-defined Wing with static
+        WingCrossSectionMovements.
+
+        :return: None
+        """
+        edge_defined_unsteady_problem = (
+            problem_fixtures.make_edge_defined_unsteady_validation_problem()
+        )
+
+        # The Panel aspect ratio and chordwise Panel bounds are kept tight because an
+        # edge-defined Wing refined to a fine Panel aspect ratio with many chordwise
+        # Panels needs many WingCrossSections, which makes the unsteady solves expensive.
+        # These bounds still span enough of each parameter direction to detect
+        # convergence.
+        converged_parameters = ps.convergence.analyze_unsteady_convergence(
+            ref_problem=edge_defined_unsteady_problem,
+            prescribed_wake=True,
+            free_wake=True,
+            num_chords_bounds=(1, 4),
+            panel_aspect_ratio_bounds=(4, 3),
+            num_chordwise_panels_bounds=(1, 3),
+            convergence_criteria=5.0,
+            show_solver_progress=False,
+        )
+
+        converged_wake_state = converged_parameters[0]
+        converged_num_chords = converged_parameters[1]
+        converged_panel_ar = converged_parameters[2]
+        converged_num_chordwise = converged_parameters[3]
+
+        wake_state_ans = True
+        num_chords_ans = 3
+        panel_ar_ans = 4
+        num_chordwise_ans = 1
+
+        self.assertEqual(converged_wake_state, wake_state_ans)
+        self.assertEqual(converged_num_chords, num_chords_ans)
+        self.assertEqual(converged_panel_ar, panel_ar_ans)
+        self.assertEqual(converged_num_chordwise, num_chordwise_ans)
+        self.assertIsNone(converged_parameters[4])
+
+    def test_rejects_non_static_edge_defined_movement(self):
+        """This method tests that the function rejects an UnsteadyProblem whose
+        edge-defined Wing carries a non-static WingCrossSectionMovement, which resampling
+        the Wing cannot preserve.
+
+        A non-static WingCrossSectionMovement makes the Movement variable, so num_cycles
+        bounds are supplied.
+
+        :return: None
+        """
+        edge_defined_non_static_problem = (
+            problem_fixtures.make_edge_defined_non_static_unsteady_validation_problem()
+        )
+
+        with self.assertRaisesRegex(ValueError, "static"):
+            ps.convergence.analyze_unsteady_convergence(
+                ref_problem=edge_defined_non_static_problem,
+                prescribed_wake=True,
+                free_wake=True,
+                num_cycles_bounds=(1, 2),
                 panel_aspect_ratio_bounds=(4, 2),
                 num_chordwise_panels_bounds=(1, 4),
                 convergence_criteria=5.0,

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -2,8 +2,13 @@
 
 import unittest
 
+import numpy as np
+
+import pterasoftware as ps
+
 # noinspection PyProtectedMember
 from pterasoftware import convergence
+from tests.unit.fixtures import geometry_fixtures
 
 
 class TestConvergedParameterId(unittest.TestCase):
@@ -68,3 +73,190 @@ class TestConvergedParameterId(unittest.TestCase):
             this_id=2, single=False, converged=True
         )
         self.assertIsInstance(result, int)
+
+
+class TestGetWingSectionNumSpanwisePanels(unittest.TestCase):
+    """This class contains methods for testing
+    convergence._get_wing_section_num_spanwise_panels, the search that picks a
+    non-edge-defined Wing section's number of spanwise Panels.
+    """
+
+    def setUp(self):
+        """Set up a root and tip WingCrossSection defining one wing section.
+
+        :return: None
+        """
+        self.root_wing_cross_section = (
+            geometry_fixtures.make_root_wing_cross_section_fixture()
+        )
+        self.tip_wing_cross_section = (
+            geometry_fixtures.make_tip_wing_cross_section_fixture()
+        )
+        self.num_chordwise_panels = 4
+        self.chordwise_spacing = "uniform"
+
+    def _average_panel_aspect_ratio(self, num_spanwise_panels):
+        """Meshes the wing section at a number of spanwise Panels and returns its average
+        Panel aspect ratio.
+        """
+        return convergence._get_wing_section_average_panel_aspect_ratio(
+            self.num_chordwise_panels,
+            self.chordwise_spacing,
+            self.root_wing_cross_section,
+            self.tip_wing_cross_section,
+            num_spanwise_panels,
+        )
+
+    def _num_spanwise_panels_for(self, target):
+        """Searches for the number of spanwise Panels that hits a target average Panel
+        aspect ratio, starting from the smallest valid count.
+        """
+        return convergence._get_wing_section_num_spanwise_panels(
+            desired_average_panel_aspect_ratio=target,
+            num_chordwise_panels=self.num_chordwise_panels,
+            chordwise_spacing=self.chordwise_spacing,
+            ref_root_wing_cross_section=self.root_wing_cross_section,
+            ref_tip_wing_cross_section=self.tip_wing_cross_section,
+            start_val=1,
+        )
+
+    def test_returns_int(self):
+        """Test that the number of spanwise Panels is returned as an int."""
+        self.assertIsInstance(self._num_spanwise_panels_for(4), int)
+
+    def test_result_is_closest_to_target(self):
+        """Test that the chosen number of spanwise Panels gives an average Panel aspect
+        ratio at least as close to the target as either neighboring count.
+        """
+        target = 4
+        result = self._num_spanwise_panels_for(target)
+
+        chosen_difference = abs(self._average_panel_aspect_ratio(result) - target)
+        upper_difference = abs(self._average_panel_aspect_ratio(result + 1) - target)
+        self.assertLessEqual(chosen_difference, upper_difference)
+
+        # The smallest valid number of spanwise Panels is one, so the lower neighbor only
+        # exists above that.
+        if result > 1:
+            lower_difference = abs(
+                self._average_panel_aspect_ratio(result - 1) - target
+            )
+            self.assertLessEqual(chosen_difference, lower_difference)
+
+    def test_smaller_target_needs_at_least_as_many_panels(self):
+        """Test that a smaller target Panel aspect ratio, a finer mesh, needs at least as
+        many spanwise Panels as a larger one.
+        """
+        self.assertGreaterEqual(
+            self._num_spanwise_panels_for(2), self._num_spanwise_panels_for(4)
+        )
+
+
+class TestGetNumWingCrossSectionsForPanelAr(unittest.TestCase):
+    """This class contains methods for testing
+    convergence._get_num_wing_cross_sections_for_panel_ar, the search that picks an
+    edge-defined Wing's number of WingCrossSections.
+    """
+
+    @staticmethod
+    def _tapered_edge_points():
+        """Builds straight, tapered leading and trailing edge curves.
+
+        The leading edge sweeps back from the origin to (0.5, 2.0, 0.0) and the trailing
+        edge is unswept at x = 1.0, so the chord tapers from a unit root chord to a 0.5
+        tip chord over a two meter half span.
+        """
+        ys = np.linspace(0.0, 2.0, 20)
+        zeros = np.zeros_like(ys)
+        leading = np.column_stack((0.25 * ys, ys, zeros))
+        trailing = np.column_stack((np.ones_like(ys), ys, zeros))
+        return leading, trailing
+
+    def _make_edge_wing(self, symmetric=False):
+        """Builds an edge-defined Wing from the tapered edge curves."""
+        leading, trailing = self._tapered_edge_points()
+        return ps.geometry.wing.Wing.from_edge_points(
+            leadingEdgePoints_Wn_Ler=leading,
+            trailingEdgePoints_Wn_Ler=trailing,
+            num_wing_cross_sections=5,
+            airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+            name="Edge Wing",
+            symmetric=symmetric,
+            symmetryNormal_G=(0.0, 1.0, 0.0) if symmetric else None,
+            symmetryPoint_G_Cg=(0.0, 0.0, 0.0) if symmetric else None,
+            num_chordwise_panels=4,
+        )
+
+    def setUp(self):
+        """Set up a reference edge-defined Wing.
+
+        :return: None
+        """
+        self.ref_wing = self._make_edge_wing()
+        self.num_chordwise_panels = 4
+
+    def _average_panel_aspect_ratio(self, num_wing_cross_sections):
+        """Rebuilds and meshes the edge-defined Wing at a number of WingCrossSections and
+        returns its average Panel aspect ratio.
+        """
+        refined_wing = convergence._build_edge_defined_wing(
+            self.ref_wing, self.num_chordwise_panels, num_wing_cross_sections
+        )
+        airplane = ps.geometry.airplane.Airplane(wings=[refined_wing])
+        average_panel_aspect_ratio = airplane.wings[0].average_panel_aspect_ratio
+        assert average_panel_aspect_ratio is not None
+        return average_panel_aspect_ratio
+
+    def _num_wing_cross_sections_for(self, target, ref_wing=None):
+        """Searches for the number of WingCrossSections that hits a target average Panel
+        aspect ratio, starting from the smallest valid count.
+        """
+        return convergence._get_num_wing_cross_sections_for_panel_ar(
+            desired_average_panel_aspect_ratio=target,
+            num_chordwise_panels=self.num_chordwise_panels,
+            ref_wing=self.ref_wing if ref_wing is None else ref_wing,
+            start_val=2,
+        )
+
+    def test_returns_int(self):
+        """Test that the number of WingCrossSections is returned as an int."""
+        self.assertIsInstance(self._num_wing_cross_sections_for(4), int)
+
+    def test_result_is_closest_to_target(self):
+        """Test that the chosen number of WingCrossSections gives an average Panel aspect
+        ratio at least as close to the target as either neighboring count.
+        """
+        target = 4
+        result = self._num_wing_cross_sections_for(target)
+
+        chosen_difference = abs(self._average_panel_aspect_ratio(result) - target)
+        upper_difference = abs(self._average_panel_aspect_ratio(result + 1) - target)
+        self.assertLessEqual(chosen_difference, upper_difference)
+
+        # An edge-defined Wing needs at least two WingCrossSections, so the lower neighbor
+        # only exists above that.
+        if result > 2:
+            lower_difference = abs(
+                self._average_panel_aspect_ratio(result - 1) - target
+            )
+            self.assertLessEqual(chosen_difference, lower_difference)
+
+    def test_smaller_target_needs_at_least_as_many_wing_cross_sections(self):
+        """Test that a smaller target Panel aspect ratio, a finer mesh, needs at least as
+        many WingCrossSections as a larger one.
+        """
+        self.assertGreaterEqual(
+            self._num_wing_cross_sections_for(2), self._num_wing_cross_sections_for(4)
+        )
+
+    def test_symmetric_matches_asymmetric(self):
+        """Test that the count is measured on the half span, so a symmetric Wing and an
+        asymmetric Wing built from the same half-span curves need the same count.
+        """
+        asymmetric_result = self._num_wing_cross_sections_for(
+            4, ref_wing=self._make_edge_wing(symmetric=False)
+        )
+        symmetric_result = self._num_wing_cross_sections_for(
+            4, ref_wing=self._make_edge_wing(symmetric=True)
+        )
+        self.assertEqual(asymmetric_result, symmetric_result)


### PR DESCRIPTION
# Description

This change extends the convergence analysis functions in `convergence.py` so they can refine edge-defined Wings, which are Wings built from leading and trailing edge curves with `Wing.from_edge_points`. Previously `analyze_steady_convergence` and `analyze_unsteady_convergence` only supported trapezoidal Wings, which they refine by sweeping the number of spanwise Panels while holding the WingCrossSections fixed. An edge-defined Wing cannot be refined that way in expected ways, so both functions now dispatch on each Wing's `spanwise_mesh`: a trapezoidal Wing is refined as before, while an edge-defined Wing is refined by resampling its stored edge curves into the number of WingCrossSections that achieves the target Panel aspect ratio, preserving its planform shape. A single Airplane may hold both kinds of Wing at once. Existing trapezoidal callers are unaffected.

## Motivation

Ptera Software can now build Wings directly from edge curves, but the convergence tools could not analyze them: any non-trapezoidal Wing was rejected outright. That left users of edge-defined geometry with no automated way to find a converged mesh, since an edge-defined planform has no natural WingCrossSection count to start from. Because an edge-defined Wing carries no fixed interior WingCrossSections to subdivide, the right refinement knob is the number of WingCrossSections the edge curves are resampled into, not the number of spanwise Panels per section. This change adds that refinement path so a target Panel aspect ratio means the same physical thing for an edge-defined Wing as for a trapezoidal one. Wings exploded into single-panel strips remain out of scope: they carry no edge curves and cannot be meaningfully refined, so they are still rejected.

## Relevant Issues

Partially addresses #147 and #148.

## Changes

* Renamed `_reject_non_trapezoidal_wings` to `_reject_unrefinable_wings` in `convergence.py` and relaxed its check to accept both `"trapezoidal"` and `"edge_defined"` spanwise meshes, rejecting only Wings (such as exploded single-panel-strip Wings) that can be neither swept nor resampled, with a rewritten error message that names the supported and unsupported cases.
* Added `_build_edge_defined_wing`, which rebuilds an edge-defined Wing from its stored `leadingEdgePoints_Wn_Ler` and `trailingEdgePoints_Wn_Ler` at a requested number of WingCrossSections via `Wing.from_edge_points`, reusing every other geometric parameter (position, orientation, symmetry, chordwise spacing, and tip trim) and sharing the reference Wing's immutable `Airfoil`.
* Added `_get_num_wing_cross_sections_for_panel_ar`, which finds the number of WingCrossSections that gives an edge-defined Wing a target average Panel aspect ratio by meshing trial counts rather than using a closed form, using a proportional jump to bracket the target followed by a bisection, and returning the straddling count whose average Panel aspect ratio is closest (preferring the finer mesh on a tie) to match the trapezoidal search's behavior.
* Added `_resolve_num_wing_cross_sections`, the edge-defined analog of the spanwise-Panel resolver, which reads and updates a shared cache and seeds each search from a conservative lower bound taken from the smallest count already found at an incrementally coarser mesh.
* Threaded a new `num_wing_cross_sections_cache` (keyed by Panel aspect ratio index, chordwise Panels index, Airplane index, and Wing index) through `analyze_steady_convergence`, `analyze_unsteady_convergence`, `_build_steady_problem`, and `_build_unsteady_problem`.
* Updated `_build_steady_problem` to dispatch on `spanwise_mesh`, resolving and building a resampled edge-defined Wing when appropriate and falling through to the existing trapezoidal path otherwise.
* Updated `_build_unsteady_problem` to do the same for movements, wrapping the resampled WingCrossSections in motion-free WingCrossSectionMovements while copying the WingMovement's own flapping and sweeping motion parameters onto a new `WingMovement`.
* Added a guard in `_build_unsteady_problem` that raises a `ValueError` if an edge-defined Wing's WingCrossSectionMovements are not all static, since resampling changes the WingCrossSection count and cannot preserve per-WingCrossSection motion.
* Updated the reporting loops in both analysis functions so that, for a converged edge-defined Wing, the log reports its number of WingCrossSections instead of iterating per-WingCrossSection spanwise Panel counts.
* Expanded the docstrings of `analyze_steady_convergence`, `analyze_unsteady_convergence`, `_build_steady_problem`, and `_build_unsteady_problem` to describe the per-mesh refinement behavior and the static-movement restriction for edge-defined Wings.
* Added unit tests in `tests/unit/test_convergence.py` covering both aspect ratio searches, and added integration coverage in `tests/integration/test_steady_convergence.py` and `tests/integration/test_unsteady_convergence.py` with supporting fixtures in `tests/integration/fixtures/airplane_fixtures.py`, `movement_fixtures.py`, and `problem_fixtures.py`.

## Dependency Updates

None.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
