### PR TITLE
Check convergence per load coefficient

### DIFF
--- a/docs/examples_expected_output/steady_convergence/example_convergence.log
+++ b/docs/examples_expected_output/steady_convergence/example_convergence.log
@@ -3,68 +3,68 @@ INFO - pterasoftware.convergence - 	Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 		Chordwise Panels: 3
 INFO - pterasoftware.convergence - 			Iteration number: 1/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.277 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: inf
+INFO - pterasoftware.convergence - 			Simulation completed in 0.262 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 		Chordwise Panels: 4
 INFO - pterasoftware.convergence - 			Iteration number: 2/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.257 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 1.86%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.323 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 55.0% (limiting coefficient: cMY)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 5
 INFO - pterasoftware.convergence - 			Iteration number: 3/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.269 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 1.03%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.185 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 98.77% (limiting coefficient: cMY)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 6
 INFO - pterasoftware.convergence - 			Iteration number: 4/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.345 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 0.75%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.262 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 7
 INFO - pterasoftware.convergence - 			Iteration number: 5/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.176 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 0.45%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.401 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 8
 INFO - pterasoftware.convergence - 			Iteration number: 6/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.23 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 0.37%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.288 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 	Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 		Chordwise Panels: 3
 INFO - pterasoftware.convergence - 			Iteration number: 7/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.131 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: 0.71%
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: inf
+INFO - pterasoftware.convergence - 			Simulation completed in 0.149 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 		Chordwise Panels: 4
 INFO - pterasoftware.convergence - 			Iteration number: 8/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.239 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: 0.88%
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 1.84%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.131 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 55.72% (limiting coefficient: cMY)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 5
 INFO - pterasoftware.convergence - 			Iteration number: 9/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.253 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: 0.74%
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 1.09%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.208 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 93.77% (limiting coefficient: cMY)
 INFO - pterasoftware.convergence - 		Chordwise Panels: 6
 INFO - pterasoftware.convergence - 			Iteration number: 10/24
 INFO - pterasoftware.convergence - 			Starting simulation...
-INFO - pterasoftware.convergence - 			Simulation completed in 0.291 s
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from Panel aspect ratio: 0.51%
-INFO - pterasoftware.convergence - 			Maximum combined coefficient change from number of chordwise Panels: 0.7%
+INFO - pterasoftware.convergence - 			Simulation completed in 0.352 s
+INFO - pterasoftware.convergence - 			Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - The analysis found a converged case:
 INFO - pterasoftware.convergence - 	Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 	Chordwise Panels: 5
-INFO - pterasoftware.convergence - 	Simulation time: 0.269 s
+INFO - pterasoftware.convergence - 	Simulation time: 0.185 s
 INFO - pterasoftware.convergence - 	Spanwise Panels:
 INFO - pterasoftware.convergence - 		Leading Airplane:
 INFO - pterasoftware.convergence - 			Main Wing:
@@ -82,3 +82,4 @@ INFO - pterasoftware.convergence - 				WingCrossSection 3: None
 INFO - pterasoftware.convergence - 			Tail:
 INFO - pterasoftware.convergence - 				WingCrossSection 1: 6
 INFO - pterasoftware.convergence - 				WingCrossSection 2: None
+INFO - pterasoftware.convergence - Convergence analysis completed in 3.221 s

--- a/docs/examples_expected_output/unsteady_static_convergence/example_convergence.log
+++ b/docs/examples_expected_output/unsteady_static_convergence/example_convergence.log
@@ -8,1247 +8,1231 @@ INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 1/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.033333
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.146 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.032 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 2/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.025
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.03 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.39%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.031 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 3/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.02
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.074 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.51%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.123 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 4/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.016667
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.106 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.72%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.102 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 5/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.033333
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.04 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.23%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.111 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 36.99% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 6/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.025
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.092 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.95%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.038 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 76.38% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 80.81% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 7/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.02
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.111 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.99%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.069 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 8/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.016667
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.311 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.74%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.03%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.2 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 9/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.033333
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.044 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.58%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.028 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 46.46% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 10/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.025
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.056 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.77%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.054 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 67.79% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 52.18% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 11/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.02
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.323 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.32%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.44%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.175 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 90.9% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 84.34% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 12/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.016667
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 3.836 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.57%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.78%
+INFO - pterasoftware.convergence - 					Simulation completed in 4.533 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 76.17% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 13/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.033333
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.067 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.99%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.092 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 60.58% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 14/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.025
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.407 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.87%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.8%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.285 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 64.23% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 49.75% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 15/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.02
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 4.264 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 4.734 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 73.94% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 71.92% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 16/160
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	State: delta_time=0.016667
+INFO - pterasoftware.movements.movement - 		Mismatch: 0.0
+INFO - pterasoftware.movements.movement - Acceptable value reached.
+INFO - pterasoftware.movements.movement - Optimization complete.
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 5.325 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.28%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.667 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 94.75% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 		Chord lengths: 5
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 17/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.07 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.5%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.143 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 80.23% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 18/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.063 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.64%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.39%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.169 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 73.78% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 19/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.126 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.79%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.6%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.565 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 67.4% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 20/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.262 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.33%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.491 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 86.55% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 21/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.062 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.72%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.332 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 70.74% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 39.4% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 22/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.193 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.61%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.59%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.108 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 75.28% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 74.83% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 86.8% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 23/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.265 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.54%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.28%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.92%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.115 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 78.24% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 92.6% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 24/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.62 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.38%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.75%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.87%
+INFO - pterasoftware.convergence - 					Simulation completed in 2.348 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 87.27% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 25/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.155 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.67%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.63%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.138 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 73.06% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.52% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 26/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.186 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.58%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.79%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.47%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.085 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 76.83% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 66.59% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 54.07% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 27/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.18 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.7%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.01%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.801 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 70.14% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 28/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 5.635 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.49%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.11%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.283 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 81.41% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 81.27% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 29/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.129 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.64%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.202 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 74.6% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.56% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 30/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.041 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.89%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.58%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.082 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 78.28% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 63.25% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 51.35% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 31/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 5.951 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.73%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.88%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.41 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 70.33% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 65.16% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 32/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.05 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.03%
+INFO - pterasoftware.convergence - 					Simulation completed in 8.371 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 82.24% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Chord lengths: 6
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 33/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.412 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.94%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.035 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 34/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.108 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.01%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.38%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.094 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 35/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.116 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.73%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.33%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.098 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 36/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.169 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.87%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.46%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.178 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 37/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.167 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.05%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.91%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.067 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.81% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 38/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.101 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.99%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.61%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.56%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.096 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 73.83% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 90.76% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 39/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.13 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.1%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.93%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.02%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.117 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 40/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.321 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.86%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.76%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.63%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.701 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 41/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.075 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.66%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.09 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 44.91% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 42/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.196 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.97%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.81%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.35%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.091 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.8% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 55.2% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 43/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.769 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.08%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.72%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.12%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.1 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 69.26% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 44/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.202 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.92%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.41%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.95%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.8 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 84.31% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 45/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.148 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.0%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.125 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 58.89% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 46/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.882 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.91%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.46%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.861 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 62.6% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 52.3% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 47/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.104 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.84%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.28%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.77%
+INFO - pterasoftware.convergence - 					Simulation completed in 7.61 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 92.93% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 69.05% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 48/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.98 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.91%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.09%
+INFO - pterasoftware.convergence - 					Simulation completed in 7.861 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Chord lengths: 7
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 49/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.076 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.61%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.06 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 50/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.204 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.65%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.37%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.095 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 51/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.183 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.3%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.153 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 52/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.193 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.4%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.212 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 53/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.124 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.85%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.07 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 41.64% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 54/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.11 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.64%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.48%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.08 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 73.16% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 93.4% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 55/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.195 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.08%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.86%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.205 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 56/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.186 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.76%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.72%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.353 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 57/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.105 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.66%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.204 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 44.51% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 58/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.284 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.63%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.83%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.28%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.115 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.26% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 55.91% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 59/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.761 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.46%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.73%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.96%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.339 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 68.87% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 60/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.557 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.59%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.38%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.08%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.749 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 86.14% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 61/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.126 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.64%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.05%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.129 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 58.43% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 62/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.564 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.61%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.92%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.39%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.972 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 62.15% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 52.88% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 63/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.995 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.46%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.29%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.61%
+INFO - pterasoftware.convergence - 					Simulation completed in 7.471 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 92.46% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 75.73% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 64/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 9.36 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.59%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.22%
+INFO - pterasoftware.convergence - 					Simulation completed in 9.663 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 99.12% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 		Chord lengths: 8
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 65/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.093 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.42%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.037 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 66/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.174 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.44%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.37%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.11 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 67/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.136 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.42%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.28%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.206 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 68/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.471 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.38%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.36%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.238 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 69/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.092 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.45%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.82%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.075 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 42.14% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 70/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.095 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.43%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.63%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.43%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.152 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 72.69% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 95.19% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 71/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.235 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.41%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.08%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.84%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.186 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 72/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.366 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.38%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.76%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.69%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.059 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 73/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.066 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.44%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.7%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.118 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 44.22% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 74/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.128 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.42%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.83%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.23%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.164 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 64.89% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 56.36% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 75/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.856 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.67%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.01%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.618 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 71.09% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 76/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 8.236 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.36%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.01%
+INFO - pterasoftware.convergence - 					Simulation completed in 10.102 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 87.26% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 77/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.08 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.43%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.633 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 58.11% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 78/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.594 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.41%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.93%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.35%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.72 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 61.84% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 53.25% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 79/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 8.304 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.36%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.6%
+INFO - pterasoftware.convergence - 					Simulation completed in 8.443 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 87.72% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 76.17% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 80/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 10.521 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.21%
+INFO - pterasoftware.convergence - 					Simulation completed in 11.158 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 99.61% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 	Wake type: free
 INFO - pterasoftware.convergence - 		Chord lengths: 4
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 81/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.084 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.07 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 82/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.095 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.38%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.072 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 83/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.114 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.51%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.099 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 84/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.15 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.72%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.138 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 85/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
-INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.049 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.23%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
-INFO - pterasoftware.convergence - 				Chordwise Panels: 4
-INFO - pterasoftware.convergence - 					Iteration number: 86/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
 INFO - pterasoftware.convergence - 					Simulation completed in 0.134 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.94%
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 37.0% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
+INFO - pterasoftware.convergence - 				Chordwise Panels: 4
+INFO - pterasoftware.convergence - 					Iteration number: 86/160
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 0.13 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 76.56% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 81.13% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 87/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.158 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.98%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.142 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 88/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.056 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.74%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.03%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.869 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 89/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.066 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.58%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.122 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 46.57% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 90/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.105 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.76%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.69%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.093 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 67.99% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 52.34% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 91/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.61 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.31%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.44%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.761 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 91.54% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 84.34% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 92/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 5.588 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.77%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.266 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 76.35% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 93/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.11 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.99%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.094 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 60.74% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 94/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.761 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.86%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.8%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.194 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 64.49% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 49.85% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 95/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 5.37 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.776 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 74.15% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 72.05% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 96/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.373 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.12%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.28%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.785 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 94.94% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 		Chord lengths: 5
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 97/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.075 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.51%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.023 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 79.79% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 98/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.077 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.65%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.38%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.068 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 73.32% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 99/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.108 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.81%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.6%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.137 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 66.9% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 100/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.265 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.32%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.264 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 85.75% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 101/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.095 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.73%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.037 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 70.34% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 39.43% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 102/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.101 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.59%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.69%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.054 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 74.77% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 75.04% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 87.09% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 103/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.153 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.56%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.28%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.91%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.217 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 77.64% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 92.72% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 104/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.307 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.75%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.87%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.738 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 86.42% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 105/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.101 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.052 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 72.58% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.64% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 106/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.106 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.59%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.79%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.47%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.091 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 76.25% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 66.81% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 54.2% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 107/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.742 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.69%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.01%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.953 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 70.46% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 108/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.671 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.5%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.46%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.11%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.464 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 80.6% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 81.56% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 109/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.101 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.12%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.65%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.01%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.107 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 74.04% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.76% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 110/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.888 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.12%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.57%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.88%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.58%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.875 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 77.58% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 63.57% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 51.42% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 111/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.178 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.12%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.75%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.88%
+INFO - pterasoftware.convergence - 					Simulation completed in 7.221 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 69.63% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 65.14% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 112/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 7.941 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.49%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.02%
+INFO - pterasoftware.convergence - 					Simulation completed in 7.873 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 81.37% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Chord lengths: 6
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 113/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.076 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.143 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 114/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.108 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.38%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.052 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 115/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.142 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.74%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.33%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.097 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 6
 INFO - pterasoftware.convergence - 					Iteration number: 116/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.016667 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.186 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.88%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.46%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.172 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 117/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.032 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.91%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.105 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.85% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 118/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.084 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.0%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 1.61%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.56%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.099 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 74.06% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 91.02% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 119/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.136 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 1.11%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.92%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.02%
-INFO - pterasoftware.convergence - 				Chordwise Panels: 6
-INFO - pterasoftware.convergence - 					Iteration number: 120/160
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - All motion is static. Returning initial delta_time estimate.
-INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.281 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 0.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.87%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 0.75%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 0.63%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.195 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - The analysis found a converged case:
 INFO - pterasoftware.convergence - 	Wake type: prescribed
 INFO - pterasoftware.convergence - 	Chord lengths: 5
 INFO - pterasoftware.convergence - 	Panel aspect ratio: 4
-INFO - pterasoftware.convergence - 	Chordwise Panels: 5
-INFO - pterasoftware.convergence - 	Simulation completed in 0.126 s
+INFO - pterasoftware.convergence - 	Chordwise Panels: 4
+INFO - pterasoftware.convergence - 	Simulation completed in 0.169 s
 INFO - pterasoftware.convergence - 	Spanwise Panels:
 INFO - pterasoftware.convergence - 		Example Airplane:
 INFO - pterasoftware.convergence - 			Main Wing:
-INFO - pterasoftware.convergence - 				WingCrossSection 1: 4
+INFO - pterasoftware.convergence - 				WingCrossSection 1: 3
 INFO - pterasoftware.convergence - 				WingCrossSection 2: None
+INFO - pterasoftware.convergence - Convergence analysis completed in 190.974 s

--- a/docs/examples_expected_output/unsteady_variable_convergence/example_convergence.log
+++ b/docs/examples_expected_output/unsteady_variable_convergence/example_convergence.log
@@ -10,902 +10,1634 @@ INFO - pterasoftware.convergence - 					Iteration number: 1/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 15 to 63
+INFO - pterasoftware.movements.movement - 	num_steps=15, delta_time=0.066667, mismatch=0.623622
+INFO - pterasoftware.movements.movement - 	num_steps=16, delta_time=0.0625, mismatch=0.561742
+INFO - pterasoftware.movements.movement - 	num_steps=17, delta_time=0.058824, mismatch=0.504374
+INFO - pterasoftware.movements.movement - 	num_steps=18, delta_time=0.055556, mismatch=0.451047
+INFO - pterasoftware.movements.movement - 	num_steps=19, delta_time=0.052632, mismatch=0.40133
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.354895
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.311431
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.270639
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.232305
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.196207
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.162155
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.129982
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.099537
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.070685
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.043302
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.018992
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.022764
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.038243
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.055424
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.075022
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.095544
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.115175
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.133977
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.151996
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.169282
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.185879
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.201826
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.217155
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.231919
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.246132
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.259828
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.273037
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.285783
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.29809
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.309981
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.321476
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.332594
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.343355
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.353774
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.363868
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.373652
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.38314
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.392345
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.401279
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.409955
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.418383
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.426574
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.434538
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.442278
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=30, delta_time=0.033333, mismatch=0.018992
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.193 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.179 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 2/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 20 to 83
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.625754
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.578771
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.534412
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.492459
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.452724
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.415041
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.379252
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.34522
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.312817
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.281936
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.252466
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.224316
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.197399
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.171636
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.146955
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.123289
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.100578
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.078763
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.057795
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.037624
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.019565
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.021118
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.029714
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.042152
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.055924
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.069982
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.084606
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.099759
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.114421
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.128613
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.142358
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.155677
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.168589
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.181113
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.193265
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.205063
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.216522
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.227654
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.238475
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.248997
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.259234
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.269195
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.278892
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.288335
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.297535
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.3065
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.315239
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.323761
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.332073
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.340184
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.348101
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.35583
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.363378
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.370751
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.377956
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.384997
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.391881
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.398613
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.405198
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.411639
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.417944
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.424114
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.430156
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.436068
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=40, delta_time=0.025, mismatch=0.019565
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.323 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.65%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.245 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 43.94% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 3/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 25 to 103
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.626804
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.588943
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.552795
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.518244
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.485189
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.453535
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.423194
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.394089
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.366145
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.339293
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.313474
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.288627
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.264699
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.24164
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.219404
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.197948
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.177231
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.157217
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.13787
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.119157
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.101049
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.083515
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.06653
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.050068
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.034105
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.019911
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.020048
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.025829
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.034549
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.044656
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.055638
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.067141
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.078688
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.090396
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.102394
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.114092
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.125488
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.136596
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.147425
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.157987
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.16829
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.178345
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.18816
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.197744
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.207103
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.216248
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.225184
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.233919
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.242459
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.250812
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.258982
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.266976
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.2748
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.282459
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.289958
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.297302
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.304495
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.311544
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.31845
+INFO - pterasoftware.movements.movement - 	num_steps=84, delta_time=0.011905, mismatch=0.32522
+INFO - pterasoftware.movements.movement - 	num_steps=85, delta_time=0.011765, mismatch=0.331857
+INFO - pterasoftware.movements.movement - 	num_steps=86, delta_time=0.011628, mismatch=0.338364
+INFO - pterasoftware.movements.movement - 	num_steps=87, delta_time=0.011494, mismatch=0.344746
+INFO - pterasoftware.movements.movement - 	num_steps=88, delta_time=0.011364, mismatch=0.351006
+INFO - pterasoftware.movements.movement - 	num_steps=89, delta_time=0.011236, mismatch=0.357148
+INFO - pterasoftware.movements.movement - 	num_steps=90, delta_time=0.011111, mismatch=0.363175
+INFO - pterasoftware.movements.movement - 	num_steps=91, delta_time=0.010989, mismatch=0.36909
+INFO - pterasoftware.movements.movement - 	num_steps=92, delta_time=0.01087, mismatch=0.374896
+INFO - pterasoftware.movements.movement - 	num_steps=93, delta_time=0.010753, mismatch=0.380596
+INFO - pterasoftware.movements.movement - 	num_steps=94, delta_time=0.010638, mismatch=0.386194
+INFO - pterasoftware.movements.movement - 	num_steps=95, delta_time=0.010526, mismatch=0.391691
+INFO - pterasoftware.movements.movement - 	num_steps=96, delta_time=0.010417, mismatch=0.39709
+INFO - pterasoftware.movements.movement - 	num_steps=97, delta_time=0.010309, mismatch=0.402395
+INFO - pterasoftware.movements.movement - 	num_steps=98, delta_time=0.010204, mismatch=0.407607
+INFO - pterasoftware.movements.movement - 	num_steps=99, delta_time=0.010101, mismatch=0.41273
+INFO - pterasoftware.movements.movement - 	num_steps=100, delta_time=0.01, mismatch=0.417764
+INFO - pterasoftware.movements.movement - 	num_steps=101, delta_time=0.009901, mismatch=0.422713
+INFO - pterasoftware.movements.movement - 	num_steps=102, delta_time=0.009804, mismatch=0.427579
+INFO - pterasoftware.movements.movement - 	num_steps=103, delta_time=0.009709, mismatch=0.432361
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=50, delta_time=0.02, mismatch=0.019911
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.307 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.47%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.219 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 69.26% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 4/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 15 to 63
+INFO - pterasoftware.movements.movement - 	num_steps=15, delta_time=0.066667, mismatch=0.62424
+INFO - pterasoftware.movements.movement - 	num_steps=16, delta_time=0.0625, mismatch=0.562363
+INFO - pterasoftware.movements.movement - 	num_steps=17, delta_time=0.058824, mismatch=0.504994
+INFO - pterasoftware.movements.movement - 	num_steps=18, delta_time=0.055556, mismatch=0.451665
+INFO - pterasoftware.movements.movement - 	num_steps=19, delta_time=0.052632, mismatch=0.401943
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.355503
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.312033
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.271234
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.232892
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.196786
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.162725
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.130544
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.100091
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.071231
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.043838
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.019205
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.023572
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.037828
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.056161
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.075004
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.095056
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.114695
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.133505
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.151531
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.168824
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.185428
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.201382
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.216718
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.231489
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.245707
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.25941
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.272625
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.285377
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.29769
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.309586
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.321087
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.332211
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.342976
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.353401
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.363499
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.373289
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.382781
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.39199
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.400929
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.409609
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.418042
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.426237
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.434206
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.44195
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=30, delta_time=0.033333, mismatch=0.019205
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.121 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.082 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.3% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 5/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 20 to 83
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.625991
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.579007
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.534646
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.492692
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.452955
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.41527
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.379479
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.345444
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.31304
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.282155
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.252683
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.224531
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.197611
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.171845
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.147162
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.123493
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.100779
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.078962
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.057991
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.037818
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.019721
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.021207
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.030009
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.042175
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.055778
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.070163
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.084653
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.099585
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.114248
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.128442
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.14219
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.155511
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.168425
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.180951
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.193105
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.204905
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.216366
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.227499
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.238322
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.248847
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.259084
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.269047
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.278746
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.288191
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.297392
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.306359
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.3151
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.323623
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.331937
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.340049
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.347967
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.355697
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.363247
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.370621
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.377827
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.38487
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.391755
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.398488
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.405074
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.411517
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.417823
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.423994
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.430037
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.435951
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=40, delta_time=0.025, mismatch=0.019721
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.176 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.23%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.31%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.159 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 66.98% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 66.74% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 6/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 25 to 103
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.626919
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.589058
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.552909
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.518357
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.485301
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.453646
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.423305
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.394198
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.366253
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.3394
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.31358
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.288732
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.264803
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.241743
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.219506
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.198048
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.177331
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.157316
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.137967
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.119254
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.101144
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.083609
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.066623
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.05016
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.034196
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.020003
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.020133
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.026061
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.034484
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.044763
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.055637
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.067066
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.07875
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.090431
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.102313
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.114011
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.125408
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.136517
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.147347
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.157909
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.168213
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.178269
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.188084
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.197669
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.207029
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.216174
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.225111
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.233847
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.242388
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.250741
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.258912
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.266907
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.274732
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.282391
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.28989
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.297235
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.304429
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.311478
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.318385
+INFO - pterasoftware.movements.movement - 	num_steps=84, delta_time=0.011905, mismatch=0.325155
+INFO - pterasoftware.movements.movement - 	num_steps=85, delta_time=0.011765, mismatch=0.331793
+INFO - pterasoftware.movements.movement - 	num_steps=86, delta_time=0.011628, mismatch=0.338301
+INFO - pterasoftware.movements.movement - 	num_steps=87, delta_time=0.011494, mismatch=0.344683
+INFO - pterasoftware.movements.movement - 	num_steps=88, delta_time=0.011364, mismatch=0.350944
+INFO - pterasoftware.movements.movement - 	num_steps=89, delta_time=0.011236, mismatch=0.357086
+INFO - pterasoftware.movements.movement - 	num_steps=90, delta_time=0.011111, mismatch=0.363114
+INFO - pterasoftware.movements.movement - 	num_steps=91, delta_time=0.010989, mismatch=0.369029
+INFO - pterasoftware.movements.movement - 	num_steps=92, delta_time=0.01087, mismatch=0.374836
+INFO - pterasoftware.movements.movement - 	num_steps=93, delta_time=0.010753, mismatch=0.380537
+INFO - pterasoftware.movements.movement - 	num_steps=94, delta_time=0.010638, mismatch=0.386134
+INFO - pterasoftware.movements.movement - 	num_steps=95, delta_time=0.010526, mismatch=0.391632
+INFO - pterasoftware.movements.movement - 	num_steps=96, delta_time=0.010417, mismatch=0.397032
+INFO - pterasoftware.movements.movement - 	num_steps=97, delta_time=0.010309, mismatch=0.402337
+INFO - pterasoftware.movements.movement - 	num_steps=98, delta_time=0.010204, mismatch=0.40755
+INFO - pterasoftware.movements.movement - 	num_steps=99, delta_time=0.010101, mismatch=0.412673
+INFO - pterasoftware.movements.movement - 	num_steps=100, delta_time=0.01, mismatch=0.417708
+INFO - pterasoftware.movements.movement - 	num_steps=101, delta_time=0.009901, mismatch=0.422657
+INFO - pterasoftware.movements.movement - 	num_steps=102, delta_time=0.009804, mismatch=0.427523
+INFO - pterasoftware.movements.movement - 	num_steps=103, delta_time=0.009709, mismatch=0.432306
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=50, delta_time=0.02, mismatch=0.020003
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.589 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.21%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 3.52%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.252 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 97.27% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 7/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 15 to 63
+INFO - pterasoftware.movements.movement - 	num_steps=15, delta_time=0.066667, mismatch=0.624555
+INFO - pterasoftware.movements.movement - 	num_steps=16, delta_time=0.0625, mismatch=0.56268
+INFO - pterasoftware.movements.movement - 	num_steps=17, delta_time=0.058824, mismatch=0.505311
+INFO - pterasoftware.movements.movement - 	num_steps=18, delta_time=0.055556, mismatch=0.45198
+INFO - pterasoftware.movements.movement - 	num_steps=19, delta_time=0.052632, mismatch=0.402257
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.355813
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.31234
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.271537
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.233192
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.197082
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.163016
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.130831
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.100374
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.071509
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.044112
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.019436
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.023673
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.038076
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.055992
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.075264
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.094807
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.11445
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.133263
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.151294
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.168591
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.185198
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.201155
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.216495
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.231269
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.245491
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.259197
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.272415
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.28517
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.297485
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.309384
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.320888
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.332015
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.342783
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.35321
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.363311
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.373103
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.382597
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.391809
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.400751
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.409433
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.417868
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.426065
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.434036
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.441782
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=30, delta_time=0.033333, mismatch=0.019436
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.17 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.148 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.81% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 8/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 20 to 83
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.62616
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.579176
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.534814
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.492859
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.45312
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.415434
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.379641
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.345605
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.313198
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.282312
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.252838
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.224684
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.197762
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.171994
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.147309
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.123639
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.100923
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.079104
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.058131
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.037956
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.01981
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.021219
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.030101
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.042195
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.055833
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.070054
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.084762
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.09946
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.114125
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.128321
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.14207
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.155392
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.168308
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.180835
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.192991
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.204792
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.216254
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.227389
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.238213
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.248739
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.258978
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.268942
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.278642
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.288088
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.29729
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.306258
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.315
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.323524
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.331839
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.339953
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.347872
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.355603
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.363153
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.370529
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.377736
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.384779
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.391666
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.3984
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.404986
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.41143
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.417736
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.423909
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.429952
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.435867
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=40, delta_time=0.025, mismatch=0.01981
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.239 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.81%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 6.13%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.444 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 57.92% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 9/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 25 to 103
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.627044
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.589182
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.553032
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.51848
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.485422
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.453766
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.423424
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.394316
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.36637
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.339516
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.313695
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.288845
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.264915
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.241854
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.219616
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.198157
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.177438
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.157422
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.138073
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.119358
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.101247
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.083711
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.066724
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.05026
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.034295
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.020063
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.020209
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.026087
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.034641
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.044715
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.05567
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.067075
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.078682
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.090485
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.102224
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.113923
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.125321
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.136431
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.147262
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.157825
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.16813
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.178186
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.188003
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.197588
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.206949
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.216095
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.225033
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.233769
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.242311
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.250665
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.258837
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.266832
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.274657
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.282317
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.289818
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.297163
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.304358
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.311407
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.318315
+INFO - pterasoftware.movements.movement - 	num_steps=84, delta_time=0.011905, mismatch=0.325086
+INFO - pterasoftware.movements.movement - 	num_steps=85, delta_time=0.011765, mismatch=0.331724
+INFO - pterasoftware.movements.movement - 	num_steps=86, delta_time=0.011628, mismatch=0.338232
+INFO - pterasoftware.movements.movement - 	num_steps=87, delta_time=0.011494, mismatch=0.344615
+INFO - pterasoftware.movements.movement - 	num_steps=88, delta_time=0.011364, mismatch=0.350877
+INFO - pterasoftware.movements.movement - 	num_steps=89, delta_time=0.011236, mismatch=0.35702
+INFO - pterasoftware.movements.movement - 	num_steps=90, delta_time=0.011111, mismatch=0.363047
+INFO - pterasoftware.movements.movement - 	num_steps=91, delta_time=0.010989, mismatch=0.368963
+INFO - pterasoftware.movements.movement - 	num_steps=92, delta_time=0.01087, mismatch=0.374771
+INFO - pterasoftware.movements.movement - 	num_steps=93, delta_time=0.010753, mismatch=0.380472
+INFO - pterasoftware.movements.movement - 	num_steps=94, delta_time=0.010638, mismatch=0.38607
+INFO - pterasoftware.movements.movement - 	num_steps=95, delta_time=0.010526, mismatch=0.391568
+INFO - pterasoftware.movements.movement - 	num_steps=96, delta_time=0.010417, mismatch=0.396969
+INFO - pterasoftware.movements.movement - 	num_steps=97, delta_time=0.010309, mismatch=0.402275
+INFO - pterasoftware.movements.movement - 	num_steps=98, delta_time=0.010204, mismatch=0.407488
+INFO - pterasoftware.movements.movement - 	num_steps=99, delta_time=0.010101, mismatch=0.412611
+INFO - pterasoftware.movements.movement - 	num_steps=100, delta_time=0.01, mismatch=0.417647
+INFO - pterasoftware.movements.movement - 	num_steps=101, delta_time=0.009901, mismatch=0.422596
+INFO - pterasoftware.movements.movement - 	num_steps=102, delta_time=0.009804, mismatch=0.427463
+INFO - pterasoftware.movements.movement - 	num_steps=103, delta_time=0.009709, mismatch=0.432246
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=50, delta_time=0.02, mismatch=0.020063
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.136 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.65%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 3.72%
+INFO - pterasoftware.convergence - 					Simulation completed in 3.758 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 60.61% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 10/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 15 to 63
+INFO - pterasoftware.movements.movement - 	num_steps=15, delta_time=0.066667, mismatch=0.624678
+INFO - pterasoftware.movements.movement - 	num_steps=16, delta_time=0.0625, mismatch=0.562803
+INFO - pterasoftware.movements.movement - 	num_steps=17, delta_time=0.058824, mismatch=0.505434
+INFO - pterasoftware.movements.movement - 	num_steps=18, delta_time=0.055556, mismatch=0.452103
+INFO - pterasoftware.movements.movement - 	num_steps=19, delta_time=0.052632, mismatch=0.402378
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.355934
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.312459
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.271655
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.233308
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.197197
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.16313
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.130943
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.100484
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.071617
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.044219
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.01951
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.023786
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.038153
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.056054
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.075219
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.094839
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.114355
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.13317
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.151202
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.1685
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.185108
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.201067
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.216408
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.231183
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.245407
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.259114
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.272333
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.285089
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.297406
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.309306
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.320811
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.331938
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.342708
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.353136
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.363238
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.373031
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.382526
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.391739
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.400681
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.409365
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.4178
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.425998
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.43397
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.441716
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=30, delta_time=0.033333, mismatch=0.01951
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.226 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.26 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 52.05% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 11/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 20 to 83
+INFO - pterasoftware.movements.movement - 	num_steps=20, delta_time=0.05, mismatch=0.626261
+INFO - pterasoftware.movements.movement - 	num_steps=21, delta_time=0.047619, mismatch=0.579277
+INFO - pterasoftware.movements.movement - 	num_steps=22, delta_time=0.045455, mismatch=0.534914
+INFO - pterasoftware.movements.movement - 	num_steps=23, delta_time=0.043478, mismatch=0.492959
+INFO - pterasoftware.movements.movement - 	num_steps=24, delta_time=0.041667, mismatch=0.453219
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.415532
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.379738
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.345701
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.313293
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.282406
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.252931
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.224775
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.197853
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.172084
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.147398
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.123726
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.101009
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.079189
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.058215
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.038039
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.019888
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.021331
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.030205
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.042221
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.055815
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.070098
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.084729
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.099455
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.114051
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.128248
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.141998
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.155321
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.168238
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.180766
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.192922
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.204724
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.216187
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.227323
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.238148
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.248674
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.258914
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.268879
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.27858
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.288026
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.297229
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.306198
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.31494
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.323465
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.331781
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.339895
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.347814
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.355546
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.363097
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.370473
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.377681
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.384725
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.391612
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.398346
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.404933
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.411378
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.417684
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.423857
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.429902
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.435816
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=40, delta_time=0.025, mismatch=0.019888
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.199 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.12%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 6.44%
+INFO - pterasoftware.convergence - 					Simulation completed in 2.855 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 54.97% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 12/96
 INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
 INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
 INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.movements.movement - Starting delta_time optimization.
+INFO - pterasoftware.movements.movement - 	Searching num_steps_per_lcm_cycle from 25 to 103
+INFO - pterasoftware.movements.movement - 	num_steps=25, delta_time=0.04, mismatch=0.627101
+INFO - pterasoftware.movements.movement - 	num_steps=26, delta_time=0.038462, mismatch=0.589238
+INFO - pterasoftware.movements.movement - 	num_steps=27, delta_time=0.037037, mismatch=0.553089
+INFO - pterasoftware.movements.movement - 	num_steps=28, delta_time=0.035714, mismatch=0.518536
+INFO - pterasoftware.movements.movement - 	num_steps=29, delta_time=0.034483, mismatch=0.485478
+INFO - pterasoftware.movements.movement - 	num_steps=30, delta_time=0.033333, mismatch=0.453821
+INFO - pterasoftware.movements.movement - 	num_steps=31, delta_time=0.032258, mismatch=0.423479
+INFO - pterasoftware.movements.movement - 	num_steps=32, delta_time=0.03125, mismatch=0.394371
+INFO - pterasoftware.movements.movement - 	num_steps=33, delta_time=0.030303, mismatch=0.366424
+INFO - pterasoftware.movements.movement - 	num_steps=34, delta_time=0.029412, mismatch=0.339569
+INFO - pterasoftware.movements.movement - 	num_steps=35, delta_time=0.028571, mismatch=0.313747
+INFO - pterasoftware.movements.movement - 	num_steps=36, delta_time=0.027778, mismatch=0.288897
+INFO - pterasoftware.movements.movement - 	num_steps=37, delta_time=0.027027, mismatch=0.264967
+INFO - pterasoftware.movements.movement - 	num_steps=38, delta_time=0.026316, mismatch=0.241905
+INFO - pterasoftware.movements.movement - 	num_steps=39, delta_time=0.025641, mismatch=0.219666
+INFO - pterasoftware.movements.movement - 	num_steps=40, delta_time=0.025, mismatch=0.198207
+INFO - pterasoftware.movements.movement - 	num_steps=41, delta_time=0.02439, mismatch=0.177488
+INFO - pterasoftware.movements.movement - 	num_steps=42, delta_time=0.02381, mismatch=0.157471
+INFO - pterasoftware.movements.movement - 	num_steps=43, delta_time=0.023256, mismatch=0.138121
+INFO - pterasoftware.movements.movement - 	num_steps=44, delta_time=0.022727, mismatch=0.119406
+INFO - pterasoftware.movements.movement - 	num_steps=45, delta_time=0.022222, mismatch=0.101294
+INFO - pterasoftware.movements.movement - 	num_steps=46, delta_time=0.021739, mismatch=0.083758
+INFO - pterasoftware.movements.movement - 	num_steps=47, delta_time=0.021277, mismatch=0.06677
+INFO - pterasoftware.movements.movement - 	num_steps=48, delta_time=0.020833, mismatch=0.050305
+INFO - pterasoftware.movements.movement - 	num_steps=49, delta_time=0.020408, mismatch=0.03434
+INFO - pterasoftware.movements.movement - 	num_steps=50, delta_time=0.02, mismatch=0.020098
+INFO - pterasoftware.movements.movement - 	num_steps=51, delta_time=0.019608, mismatch=0.020235
+INFO - pterasoftware.movements.movement - 	num_steps=52, delta_time=0.019231, mismatch=0.026109
+INFO - pterasoftware.movements.movement - 	num_steps=53, delta_time=0.018868, mismatch=0.034658
+INFO - pterasoftware.movements.movement - 	num_steps=54, delta_time=0.018519, mismatch=0.044736
+INFO - pterasoftware.movements.movement - 	num_steps=55, delta_time=0.018182, mismatch=0.055679
+INFO - pterasoftware.movements.movement - 	num_steps=56, delta_time=0.017857, mismatch=0.067061
+INFO - pterasoftware.movements.movement - 	num_steps=57, delta_time=0.017544, mismatch=0.078702
+INFO - pterasoftware.movements.movement - 	num_steps=58, delta_time=0.017241, mismatch=0.090462
+INFO - pterasoftware.movements.movement - 	num_steps=59, delta_time=0.016949, mismatch=0.102226
+INFO - pterasoftware.movements.movement - 	num_steps=60, delta_time=0.016667, mismatch=0.113883
+INFO - pterasoftware.movements.movement - 	num_steps=61, delta_time=0.016393, mismatch=0.125281
+INFO - pterasoftware.movements.movement - 	num_steps=62, delta_time=0.016129, mismatch=0.136391
+INFO - pterasoftware.movements.movement - 	num_steps=63, delta_time=0.015873, mismatch=0.147223
+INFO - pterasoftware.movements.movement - 	num_steps=64, delta_time=0.015625, mismatch=0.157786
+INFO - pterasoftware.movements.movement - 	num_steps=65, delta_time=0.015385, mismatch=0.168092
+INFO - pterasoftware.movements.movement - 	num_steps=66, delta_time=0.015152, mismatch=0.178148
+INFO - pterasoftware.movements.movement - 	num_steps=67, delta_time=0.014925, mismatch=0.187965
+INFO - pterasoftware.movements.movement - 	num_steps=68, delta_time=0.014706, mismatch=0.197551
+INFO - pterasoftware.movements.movement - 	num_steps=69, delta_time=0.014493, mismatch=0.206913
+INFO - pterasoftware.movements.movement - 	num_steps=70, delta_time=0.014286, mismatch=0.216059
+INFO - pterasoftware.movements.movement - 	num_steps=71, delta_time=0.014085, mismatch=0.224997
+INFO - pterasoftware.movements.movement - 	num_steps=72, delta_time=0.013889, mismatch=0.233734
+INFO - pterasoftware.movements.movement - 	num_steps=73, delta_time=0.013699, mismatch=0.242276
+INFO - pterasoftware.movements.movement - 	num_steps=74, delta_time=0.013514, mismatch=0.25063
+INFO - pterasoftware.movements.movement - 	num_steps=75, delta_time=0.013333, mismatch=0.258802
+INFO - pterasoftware.movements.movement - 	num_steps=76, delta_time=0.013158, mismatch=0.266798
+INFO - pterasoftware.movements.movement - 	num_steps=77, delta_time=0.012987, mismatch=0.274623
+INFO - pterasoftware.movements.movement - 	num_steps=78, delta_time=0.012821, mismatch=0.282284
+INFO - pterasoftware.movements.movement - 	num_steps=79, delta_time=0.012658, mismatch=0.289784
+INFO - pterasoftware.movements.movement - 	num_steps=80, delta_time=0.0125, mismatch=0.29713
+INFO - pterasoftware.movements.movement - 	num_steps=81, delta_time=0.012346, mismatch=0.304325
+INFO - pterasoftware.movements.movement - 	num_steps=82, delta_time=0.012195, mismatch=0.311375
+INFO - pterasoftware.movements.movement - 	num_steps=83, delta_time=0.012048, mismatch=0.318283
+INFO - pterasoftware.movements.movement - 	num_steps=84, delta_time=0.011905, mismatch=0.325054
+INFO - pterasoftware.movements.movement - 	num_steps=85, delta_time=0.011765, mismatch=0.331692
+INFO - pterasoftware.movements.movement - 	num_steps=86, delta_time=0.011628, mismatch=0.338201
+INFO - pterasoftware.movements.movement - 	num_steps=87, delta_time=0.011494, mismatch=0.344584
+INFO - pterasoftware.movements.movement - 	num_steps=88, delta_time=0.011364, mismatch=0.350846
+INFO - pterasoftware.movements.movement - 	num_steps=89, delta_time=0.011236, mismatch=0.356989
+INFO - pterasoftware.movements.movement - 	num_steps=90, delta_time=0.011111, mismatch=0.363017
+INFO - pterasoftware.movements.movement - 	num_steps=91, delta_time=0.010989, mismatch=0.368933
+INFO - pterasoftware.movements.movement - 	num_steps=92, delta_time=0.01087, mismatch=0.374741
+INFO - pterasoftware.movements.movement - 	num_steps=93, delta_time=0.010753, mismatch=0.380442
+INFO - pterasoftware.movements.movement - 	num_steps=94, delta_time=0.010638, mismatch=0.386041
+INFO - pterasoftware.movements.movement - 	num_steps=95, delta_time=0.010526, mismatch=0.391539
+INFO - pterasoftware.movements.movement - 	num_steps=96, delta_time=0.010417, mismatch=0.39694
+INFO - pterasoftware.movements.movement - 	num_steps=97, delta_time=0.010309, mismatch=0.402246
+INFO - pterasoftware.movements.movement - 	num_steps=98, delta_time=0.010204, mismatch=0.40746
+INFO - pterasoftware.movements.movement - 	num_steps=99, delta_time=0.010101, mismatch=0.412583
+INFO - pterasoftware.movements.movement - 	num_steps=100, delta_time=0.01, mismatch=0.417619
+INFO - pterasoftware.movements.movement - 	num_steps=101, delta_time=0.009901, mismatch=0.422569
+INFO - pterasoftware.movements.movement - 	num_steps=102, delta_time=0.009804, mismatch=0.427436
+INFO - pterasoftware.movements.movement - 	num_steps=103, delta_time=0.009709, mismatch=0.432219
+INFO - pterasoftware.movements.movement - Optimization complete. Best: num_steps_per_lcm_cycle=50, delta_time=0.02, mismatch=0.020098
+INFO - pterasoftware.convergence - 					Optimized delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 13.423 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.8%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 5.2%
+INFO - pterasoftware.convergence - 					Simulation completed in 17.417 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 81.38% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Cycles: 2
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 13/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.255 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 2.94%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.117 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 42.45% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 14/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.547 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.03%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.04%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.266 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 63.72% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 58.91% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 15/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.496 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.09%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.63%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.456 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 53.85% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 78.61% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 16/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.478 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.197 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 42.75% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.99% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 17/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.354 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.25%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.26%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.279 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 65.09% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.52% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 95.5% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 18/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.549 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.28%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.56%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.581 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 53.44% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 95.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 19/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.342 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.35%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.287 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 43.63% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.05% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 20/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.521 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.5%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.67%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.431 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 66.79% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 56.65% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 21/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 3.876 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.58%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.42%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.269 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 52.92% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.3% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 22/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.478 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.49%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.52%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 1.952 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 44.35% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 51.04% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 23/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 3.525 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.71%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.32%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.89%
+INFO - pterasoftware.convergence - 					Simulation completed in 4.3 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 68.45% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 53.9% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 24/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 22.601 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.74%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.91%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.78%
+INFO - pterasoftware.convergence - 					Simulation completed in 24.376 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 52.82% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 79.91% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Cycles: 3
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 25/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.197 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.223 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 26/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.392 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.04%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.375 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 58.8% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 27/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.937 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.63%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.686 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 78.59% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 28/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.349 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.221 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.89% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 29/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.483 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.26%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.407 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.49% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 95.5% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 30/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.7 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.56%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.172 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 94.96% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 31/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.336 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.293 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.04% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 32/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.74 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.67%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.568 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 56.63% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 33/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.647 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.42%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.718 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.28% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 34/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.587 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.53%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 2.081 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 51.03% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 35/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 4.797 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.32%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.89%
+INFO - pterasoftware.convergence - 					Simulation completed in 5.613 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 53.88% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 36/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 33.07 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.92%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.78%
+INFO - pterasoftware.convergence - 					Simulation completed in 32.104 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 79.88% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Cycles: 4
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 37/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.276 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.218 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 38/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.673 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.04%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.48 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 58.76% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 39/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.922 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.63%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.912 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 78.58% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 40/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.326 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.298 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.87% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 41/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.673 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.26%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.701 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.48% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 95.49% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 42/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 3.285 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.39%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.56%
+INFO - pterasoftware.convergence - 					Simulation completed in 3.747 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 94.94% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 43/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.418 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.521 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.03% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 44/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.205 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.67%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.096 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 56.62% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 45/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 9.315 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.95%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.42%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.723 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.27% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 46/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.782 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.53%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 1.335 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 51.02% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 47/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 6.034 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.32%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.89%
+INFO - pterasoftware.convergence - 					Simulation completed in 6.412 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 53.88% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 48/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 46.155 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.92%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.77%
+INFO - pterasoftware.convergence - 					Simulation completed in 44.256 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 79.87% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 	Wake type: free
 INFO - pterasoftware.convergence - 		Cycles: 1
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 49/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.096 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.86%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.12 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 50/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.164 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.81%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.169 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 42.77% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 51/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.347 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.66%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.306 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 68.83% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 52/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.107 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.79%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.93%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 1.047 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 45.21% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 53/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.217 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.66%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.16%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.45%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.187 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 67.23% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 65.26% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 54/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.297 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.49%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.15%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 3.7%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.389 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 97.56% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 99.96% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 55/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.131 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.49%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.32%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.178 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.89% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 56/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.271 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.4%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.69%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 6.22%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.255 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 58.07% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 57/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 2.369 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.22%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.52%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 3.91%
+INFO - pterasoftware.convergence - 					Simulation completed in 3.022 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 60.78% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 58/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.218 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.19%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.25%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.203 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 52.12% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 59/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 1.524 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.09%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.0%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 6.55%
+INFO - pterasoftware.convergence - 					Simulation completed in 2.009 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 55.06% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 60/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 13.649 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.0%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.7%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 5.3%
+INFO - pterasoftware.convergence - 					Simulation completed in 13.933 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 81.43% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Cycles: 2
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 61/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.17 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.05%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.2 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 42.39% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 62/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.302 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.2%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.41%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.15%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.291 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 63.73% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 57.51% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 63/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
 INFO - pterasoftware.convergence - 					Simulation completed in 0.52 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.18%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.6%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.64%
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 50.71% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 79.47% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 64/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.186 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.99%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.33%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.288 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 42.62% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 46.25% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 65/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.368 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.62%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.33%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.32%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.348 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 64.97% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.9% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 96.64% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 66/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.635 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 9.79%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.27%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.58%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.621 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 50.43% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 95.51% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 67/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.298 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.68%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.53%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.52%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.255 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 43.34% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.24% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 68/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.554 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.77%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 6.85%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.86%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.57%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.614 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 65.54% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 56.99% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 69/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 4.136 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.72%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 10.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.7%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.41%
+INFO - pterasoftware.convergence - 					Simulation completed in 4.572 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 50.17% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.75% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 70/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 0.702 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.36%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 3.65%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.37%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.395 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 43.85% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 51.4% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 71/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 3.899 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.42%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 7.02%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 4.13%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.83%
+INFO - pterasoftware.convergence - 					Simulation completed in 4.358 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 65.44% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 54.25% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 72/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 70.83 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.47%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 10.17%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.8%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.73%
+INFO - pterasoftware.convergence - 					Simulation completed in 27.716 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 50.3% (limiting coefficient: cMY)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 80.19% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 		Cycles: 3
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 4
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 73/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 19.676 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.248 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 74/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 31.114 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.2%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 4.15%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.968 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 57.55% (limiting coefficient: cFZ)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 75/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 58.734 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.18%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: inf
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.64%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.985 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: not yet checked
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 79.44% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 			Panel aspect ratio: 3
 INFO - pterasoftware.convergence - 				Chordwise Panels: 3
 INFO - pterasoftware.convergence - 					Iteration number: 76/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.032258 (31 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 9.125 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 1.99%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 5.14%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: inf
+INFO - pterasoftware.convergence - 					Simulation completed in 0.422 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 46.25% (limiting coefficient: cFZ)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
 INFO - pterasoftware.convergence - 				Chordwise Panels: 4
 INFO - pterasoftware.convergence - 					Iteration number: 77/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.02439 (41 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 32.111 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.07%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 3.33%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 2.32%
+INFO - pterasoftware.convergence - 					Simulation completed in 0.64 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 65.87% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 96.61% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - 				Chordwise Panels: 5
 INFO - pterasoftware.convergence - 					Iteration number: 78/96
-INFO - pterasoftware.movements.movement - Starting analytical delta_time optimization.
-INFO - pterasoftware.movements.movement - 	Result: delta_time=0.019608 (51 steps per LCM period)
-INFO - pterasoftware.movements.movement - Analytical optimization complete.
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
 INFO - pterasoftware.convergence - 					Starting simulation...
-INFO - pterasoftware.convergence - 					Simulation completed in 66.608 s
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake type: 2.04%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from wake length: 0.06%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from Panel aspect ratio: 2.27%
-INFO - pterasoftware.convergence - 					Maximum combined coefficient change from chordwise Panels: 1.58%
+INFO - pterasoftware.convergence - 					Simulation completed in 1.234 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 95.48% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Panel aspect ratio: 2
+INFO - pterasoftware.convergence - 				Chordwise Panels: 3
+INFO - pterasoftware.convergence - 					Iteration number: 79/96
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 2.095 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 40.22% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
+INFO - pterasoftware.convergence - 				Chordwise Panels: 4
+INFO - pterasoftware.convergence - 					Iteration number: 80/96
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 0.88 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 56.95% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 				Chordwise Panels: 5
+INFO - pterasoftware.convergence - 					Iteration number: 81/96
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.02 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 7.35 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 59.73% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 			Panel aspect ratio: 1
+INFO - pterasoftware.convergence - 				Chordwise Panels: 3
+INFO - pterasoftware.convergence - 					Iteration number: 82/96
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.033333 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 0.661 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 51.38% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: not yet checked
+INFO - pterasoftware.convergence - 				Chordwise Panels: 4
+INFO - pterasoftware.convergence - 					Iteration number: 83/96
+INFO - pterasoftware.convergence - 					Cached delta_time: 0.025 s
+INFO - pterasoftware.convergence - 					Starting simulation...
+INFO - pterasoftware.convergence - 					Simulation completed in 6.71 s
+INFO - pterasoftware.convergence - 					Wake type convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Wake length convergence metric: 100.0% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Panel aspect ratio convergence metric: 54.26% (limiting coefficient: cFX)
+INFO - pterasoftware.convergence - 					Number of chordwise Panels convergence metric: 100.0% (limiting coefficient: cFX)
 INFO - pterasoftware.convergence - The analysis found a converged case:
 INFO - pterasoftware.convergence - 	Wake type: prescribed
 INFO - pterasoftware.convergence - 	Cycles: 2
-INFO - pterasoftware.convergence - 	Panel aspect ratio: 4
-INFO - pterasoftware.convergence - 	Chordwise Panels: 4
-INFO - pterasoftware.convergence - 	Simulation completed in 0.547 s
+INFO - pterasoftware.convergence - 	Panel aspect ratio: 1
+INFO - pterasoftware.convergence - 	Chordwise Panels: 3
+INFO - pterasoftware.convergence - 	Simulation completed in 1.952 s
 INFO - pterasoftware.convergence - 	Spanwise Panels:
 INFO - pterasoftware.convergence - 		Example Airplane:
 INFO - pterasoftware.convergence - 			Main Wing:
-INFO - pterasoftware.convergence - 				WingCrossSection 1: 3
+INFO - pterasoftware.convergence - 				WingCrossSection 1: 9
 INFO - pterasoftware.convergence - 				WingCrossSection 2: None
 INFO - pterasoftware.convergence - 			Reflected Main Wing:
-INFO - pterasoftware.convergence - 				WingCrossSection 1: 3
+INFO - pterasoftware.convergence - 				WingCrossSection 1: 9
 INFO - pterasoftware.convergence - 				WingCrossSection 2: None
+INFO - pterasoftware.convergence - Convergence analysis completed in 294.129 s

--- a/examples/steady_convergence.py
+++ b/examples/steady_convergence.py
@@ -163,14 +163,15 @@ del operating_point
 
 # Run the steady convergence analysis. This will run several simulations, modifying
 # average Panel aspect ratio and number of chordwise Panels with each iteration. Once
-# it detects that the net load coefficients haven't change by more than the
-# convergence criteria (measured as an absolute percent error), it will return the
-# parameters it found to result in a converged solution. See the
+# it detects that each load coefficient has stopped changing by more than the relative
+# tolerance (rtol) plus the absolute tolerance (atol) between successive meshes, it will
+# return the parameters it found to result in a converged solution. See the
 # analyze_steady_convergence function docstring for more details.
 ps.convergence.analyze_steady_convergence(
     ref_problem=steady_problem,
     solver_type="steady ring vortex lattice method",
     panel_aspect_ratio_bounds=(4, 1),
     num_chordwise_panels_bounds=(3, 8),
-    convergence_criteria=1.0,
+    rtol=0.01,
+    atol=0.001,
 )

--- a/examples/unsteady_static_convergence.py
+++ b/examples/unsteady_static_convergence.py
@@ -97,10 +97,11 @@ del example_movement
 
 # Run the unsteady convergence analysis. This will run several simulations, modifying
 # the wake state, wake length, average Panel aspect ratio, and number of chordwise
-# Panels with each iteration. Once it detects that the net load coefficients haven't
-# change by more than the convergence criteria (measured as an absolute percent
-# error), it will return the parameters it found to result in a converged solution.
-# See the analyze_unsteady_convergence function docstring for more details.
+# Panels with each iteration. Once it detects that each load coefficient has stopped
+# changing by more than the relative tolerance (rtol) plus the absolute tolerance (atol)
+# between successive meshes, it will return the parameters it found to result in a
+# converged solution. See the analyze_unsteady_convergence function docstring for more
+# details.
 ps.convergence.analyze_unsteady_convergence(
     ref_problem=example_problem,
     prescribed_wake=True,
@@ -108,6 +109,7 @@ ps.convergence.analyze_unsteady_convergence(
     num_chords_bounds=(4, 8),
     panel_aspect_ratio_bounds=(4, 1),
     num_chordwise_panels_bounds=(3, 6),
-    convergence_criteria=1.0,
+    rtol=0.01,
+    atol=0.001,
     show_solver_progress=False,
 )

--- a/examples/unsteady_variable_convergence.py
+++ b/examples/unsteady_variable_convergence.py
@@ -121,10 +121,11 @@ del example_movement
 
 # Run the unsteady convergence analysis. This will run several simulations, modifying
 # the wake state, wake length, average Panel aspect ratio, and number of chordwise
-# Panels with each iteration. Once it detects that the net load coefficients haven't
-# change by more than the convergence criteria (measured as an absolute percent
-# error), it will return the parameters it found to result in a converged solution.
-# See the analyze_unsteady_convergence function docstring for more details.
+# Panels with each iteration. Once it detects that each load coefficient has stopped
+# changing by more than the relative tolerance (rtol) plus the absolute tolerance (atol)
+# between successive meshes, it will return the parameters it found to result in a
+# converged solution. See the analyze_unsteady_convergence function docstring for more
+# details.
 ps.convergence.analyze_unsteady_convergence(
     ref_problem=example_problem,
     prescribed_wake=True,
@@ -132,6 +133,7 @@ ps.convergence.analyze_unsteady_convergence(
     num_cycles_bounds=(1, 4),
     panel_aspect_ratio_bounds=(4, 1),
     num_chordwise_panels_bounds=(3, 5),
-    convergence_criteria=2.5,
+    rtol=0.025,
+    atol=0.001,
     show_solver_progress=False,
 )

--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -34,6 +34,11 @@ from . import (
 
 _logger = _logging.get_logger("convergence")
 
+# The labels of the six load coefficients that convergence is checked against, in the
+# order they are stored: the three force coefficients followed by the three moment
+# coefficients.
+_COEFFICIENT_LABELS = ("cFX", "cFY", "cFZ", "cMX", "cMY", "cMZ")
+
 
 # TEST: Assess how comprehensive this function's integration tests are and update or
 #  extend them if needed.
@@ -42,7 +47,9 @@ def analyze_steady_convergence(
     solver_type: str,
     panel_aspect_ratio_bounds: tuple[int, int] = (4, 1),
     num_chordwise_panels_bounds: tuple[int, int] = (3, 12),
-    convergence_criteria: float | int = 5.0,
+    rtol: float | int = 0.05,
+    atol: float | int = 0.001,
+    coefficient_mask: tuple[bool, bool, bool, bool, bool, bool] | None = None,
     resolve_converged_solver: bool | np.bool_ = False,
 ) -> (
     tuple[
@@ -63,26 +70,21 @@ def analyze_steady_convergence(
     their Wings' numbers of chordwise Panels. These values are iterated over via two
     nested for loops (with the number of chordwise Panels as the inner loop).
 
-    With each new combination of these values, the SteadyProblem is solved, and its
-    resultant load coefficients are stored. Each Airplanes' three force coefficients are
-    combined by taking their root-sum-square to find the resultant force coefficient.
-    Then, the absolute percent change (APE) of each Airplanes' resultant force
-    coefficient is found between this iteration, and the iterations with incrementally
-    coarser meshes in the two parameter directions (panel aspect ratio and number of
-    chordwise panels). These two steps are repeated for the three moment coefficients.
+    With each new combination of these values, the SteadyProblem is solved, and each
+    Airplane's six load coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ) are stored. Then,
+    convergence is checked per coefficient between this iteration and the iterations
+    with incrementally coarser meshes in the two parameter directions (Panel aspect
+    ratio and number of chordwise Panels). A coefficient is converged in a parameter
+    direction when its absolute change from the coarser iteration is at most atol + rtol
+    * max(abs(this), abs(coarser)). A parameter direction is converged when every
+    unmasked coefficient of every Airplane is converged in that direction, so a multi-
+    Airplane study converges only once all its Airplanes have.
 
-    The maximums of the resultant force coefficient APEs and resultant moment
-    coefficient APEs are found. This leaves us with two maximum APEs, one for each
-    parameter direction, per Airplane. Next, we take the maximum of each parameter
-    directions' APEs across all Airplanes, leaving us with two maximum APEs total. If
-    either of the parameter direction APEs is below the convergence criteria, then this
-    iteration has found a converged solution for that parameter direction.
-
-    If an iteration's two APEs are both below the converged criteria, then we exit the
-    nested for loops and return the converged parameters. However, the converged
-    parameters are actually the values incrementally coarser than the final values
-    (because the incrementally coarser values were found to be within the convergence
-    criteria percent difference from the final values).
+    If an iteration is converged in both parameter directions, then we exit the nested
+    for loops and return the converged parameters. However, the converged parameters are
+    actually the values incrementally coarser than the final values, because refining
+    from the coarser values to the final ones changed every unmasked coefficient by
+    within the tolerance.
 
     **Notes:**
 
@@ -120,13 +122,21 @@ def analyze_steady_convergence(
     :param num_chordwise_panels_bounds: A tuple of two ints, in ascending order, that
         determines the range of values to use for the Wings' numbers of chordwise
         panels. The default is (3, 12).
-    :param convergence_criteria: A positive number (int or float) that determines the
-        point at which the function considers the simulation to have converged.
-        Specifically, it is the maximum absolute percent change in the combined load
-        coefficients. Therefore, it is in units of percent. Refer to the description in
-        this function's docstring for more details on how it affects the solver. In
-        short, set this value to 5.0 for a lenient convergence, and 1.0 for a strict
-        convergence. Values are converted to floats internally. The default is 5.0.
+    :param rtol: A positive number (int or float) giving the relative tolerance for the
+        per-coefficient convergence check. A coefficient is converged in a parameter
+        direction when its absolute change from the incrementally coarser iteration is
+        at most atol + rtol * max(abs(this), abs(coarser)). Set this smaller for a
+        stricter convergence. Values are converted to floats internally. The default is
+        0.05.
+    :param atol: A positive number (int or float) giving the absolute tolerance floor
+        for the per-coefficient convergence check. It keeps coefficients that sit near
+        zero from being held to an unreachable relative tolerance. Values are converted
+        to floats internally. The default is 0.001.
+    :param coefficient_mask: A tuple of six bools that determines which of the six load
+        coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ, in that order) must converge, or
+        None to require all six. At least one element must be True. Use this to ignore
+        coefficients that are physically irrelevant to the analysis. The default is
+        None.
     :param resolve_converged_solver: A bool for whether to recreate and run the solver
         at the converged parameters and return it. Because finding convergence is
         expensive, this defaults to False, in which case the returned solver is None.
@@ -159,10 +169,18 @@ def analyze_steady_convergence(
     # Validate the num_chordwise_panels_bounds parameter.
     _validate_num_chordwise_panels_bounds(num_chordwise_panels_bounds)
 
-    # Validate the convergence_criteria parameter.
-    convergence_criteria = _parameter_validation.number_in_range_return_float(
-        convergence_criteria, "convergence_criteria", min_val=0.0, min_inclusive=False
+    # Validate the rtol parameter.
+    rtol = _parameter_validation.number_in_range_return_float(
+        rtol, "rtol", min_val=0.0, min_inclusive=False
     )
+
+    # Validate the atol parameter.
+    atol = _parameter_validation.number_in_range_return_float(
+        atol, "atol", min_val=0.0, min_inclusive=False
+    )
+
+    # Validate the coefficient_mask parameter.
+    coefficient_mask_array = _validate_coefficient_mask(coefficient_mask)
 
     # Validate the resolve_converged_solver parameter.
     resolve_converged_solver = _parameter_validation.boolLike_return_bool(
@@ -193,19 +211,15 @@ def analyze_steady_convergence(
     iter_times = np.zeros(
         (len(panel_aspect_ratios_list), len(num_chordwise_panels_list)), dtype=float
     )
-    combinedForceCoefficients = np.zeros(
+
+    # Each iteration stores the six load coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ) of
+    # each Airplane, in that order, along the last axis.
+    coefficients = np.zeros(
         (
             len(panel_aspect_ratios_list),
             len(num_chordwise_panels_list),
             len(ref_airplanes),
-        ),
-        dtype=float,
-    )
-    combinedMomentCoefficients = np.zeros(
-        (
-            len(panel_aspect_ratios_list),
-            len(num_chordwise_panels_list),
-            len(ref_airplanes),
+            6,
         ),
         dtype=float,
     )
@@ -273,103 +287,85 @@ def analyze_steady_convergence(
             iter_stop = time.time()
             this_iter_time = iter_stop - iter_start
 
-            # Create and fill ndarrays with each of this iteration's Airplanes'
-            # combined load coefficients.
-            theseCombinedForceCoefficients = np.zeros(len(these_airplanes), dtype=float)
-            theseCombinedMomentCoefficients = np.zeros(
-                len(these_airplanes), dtype=float
-            )
+            # Create and fill an ndarray with each of this iteration's Airplanes' six
+            # load coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ).
+            theseCoefficients = np.zeros((len(these_airplanes), 6), dtype=float)
 
             for airplane_id, airplane in enumerate(these_airplanes):
                 _forceCoefficients_W = airplane.forceCoefficients_W
                 assert _forceCoefficients_W is not None
 
-                theseCombinedForceCoefficients[airplane_id] = np.linalg.norm(
-                    _forceCoefficients_W
-                )
-
                 _momentCoefficients_W_CgP1 = airplane.momentCoefficients_W_CgP1
                 assert _momentCoefficients_W_CgP1 is not None
 
-                theseCombinedMomentCoefficients[airplane_id] = np.linalg.norm(
-                    _momentCoefficients_W_CgP1
-                )
+                theseCoefficients[airplane_id, 0:3] = _forceCoefficients_W
+                theseCoefficients[airplane_id, 3:6] = _momentCoefficients_W_CgP1
 
-            # Populate the ndarrays that store information from all the iterations with
+            # Populate the ndarray that stores information from all the iterations with
             # the data from this iteration.
-            combinedForceCoefficients[ar_id, chord_id, :] = (
-                theseCombinedForceCoefficients
-            )
-            combinedMomentCoefficients[ar_id, chord_id, :] = (
-                theseCombinedMomentCoefficients
-            )
+            coefficients[ar_id, chord_id, :, :] = theseCoefficients
             iter_times[ar_id, chord_id] = this_iter_time
 
             _logger.info(
                 "\t\t\tSimulation completed in " + str(round(this_iter_time, 3)) + " s"
             )
 
-            max_ar_pc = np.inf
-            max_chord_pc = np.inf
+            # Check per-coefficient convergence in each parameter direction against the
+            # incrementally coarser iteration. A direction cannot be checked on its first
+            # value, where there is no coarser iteration to compare against, so it starts
+            # as not converged.
+            ar_converged = False
+            chord_converged = False
 
-            # If this isn't the first Panel aspect ratio, calculate the Panel aspect
-            # ratio APE.
+            # If this isn't the first Panel aspect ratio, check convergence in the Panel
+            # aspect ratio direction.
             if ar_id > 0:
-                lastArCombinedForceCoefficients = combinedForceCoefficients[
-                    ar_id - 1, chord_id, :
-                ]
-                lastArCombinedMomentCoefficients = combinedMomentCoefficients[
-                    ar_id - 1, chord_id, :
-                ]
-                max_ar_pc = max(
-                    _max_combined_percent_change(
-                        theseCombinedForceCoefficients,
-                        lastArCombinedForceCoefficients,
-                    ),
-                    _max_combined_percent_change(
-                        theseCombinedMomentCoefficients,
-                        lastArCombinedMomentCoefficients,
-                    ),
+                ar_converged, ar_metric, ar_limiting_id = (
+                    _check_coefficient_convergence(
+                        theseCoefficients,
+                        coefficients[ar_id - 1, chord_id, :, :],
+                        rtol,
+                        atol,
+                        coefficient_mask_array,
+                    )
                 )
 
                 _logger.info(
-                    "\t\t\tMaximum combined coefficient change from Panel aspect "
-                    "ratio: " + str(round(max_ar_pc, 2)) + "%"
+                    "\t\t\tPanel aspect ratio convergence metric: "
+                    + str(round(ar_metric, 2))
+                    + "% (limiting coefficient: "
+                    + _COEFFICIENT_LABELS[ar_limiting_id]
+                    + ")"
                 )
             else:
                 _logger.info(
-                    "\t\t\tMaximum combined coefficient change from Panel aspect "
-                    "ratio: " + str(max_ar_pc)
+                    "\t\t\tPanel aspect ratio convergence metric: not yet checked"
                 )
 
-            # If this isn't the first number of chordwise Panels, calculate the
-            # number of chordwise Panels APE.
+            # If this isn't the first number of chordwise Panels, check convergence in
+            # the number of chordwise Panels direction.
             if chord_id > 0:
-                lastChordCombinedForceCoefficients = combinedForceCoefficients[
-                    ar_id, chord_id - 1, :
-                ]
-                lastChordCombinedMomentCoefficients = combinedMomentCoefficients[
-                    ar_id, chord_id - 1, :
-                ]
-                max_chord_pc = max(
-                    _max_combined_percent_change(
-                        theseCombinedForceCoefficients,
-                        lastChordCombinedForceCoefficients,
-                    ),
-                    _max_combined_percent_change(
-                        theseCombinedMomentCoefficients,
-                        lastChordCombinedMomentCoefficients,
-                    ),
+                chord_converged, chord_metric, chord_limiting_id = (
+                    _check_coefficient_convergence(
+                        theseCoefficients,
+                        coefficients[ar_id, chord_id - 1, :, :],
+                        rtol,
+                        atol,
+                        coefficient_mask_array,
+                    )
                 )
 
                 _logger.info(
-                    "\t\t\tMaximum combined coefficient change from number of "
-                    "chordwise Panels: " + str(round(max_chord_pc, 2)) + "%"
+                    "\t\t\tNumber of chordwise Panels convergence metric: "
+                    + str(round(chord_metric, 2))
+                    + "% (limiting coefficient: "
+                    + _COEFFICIENT_LABELS[chord_limiting_id]
+                    + ")"
                 )
             else:
                 _logger.info(
-                    "\t\t\tMaximum combined coefficient change from number of "
-                    "chordwise Panels: " + str(max_chord_pc)
+                    "\t\t\tNumber of chordwise Panels convergence metric: not yet "
+                    "checked"
                 )
 
             # Consider the Panel aspect ratio value to be saturated if it is equal to
@@ -381,11 +377,6 @@ def analyze_steady_convergence(
             # of chordwise Panels were specified.
             single_ar = len(panel_aspect_ratios_list) == 1
             single_chord = len(num_chordwise_panels_list) == 1
-
-            # Check if this iteration is converged with respect to the Panel aspect
-            # ratio and/or the number of chordwise Panels.
-            ar_converged = max_ar_pc < convergence_criteria
-            chord_converged = max_chord_pc < convergence_criteria
 
             # Consider each convergence parameter to have "passed" if it is
             # converged, single, or saturated.
@@ -545,7 +536,9 @@ def analyze_unsteady_convergence(
     num_chords_bounds: tuple[int, int] | None = None,
     panel_aspect_ratio_bounds: tuple[int, int] = (4, 1),
     num_chordwise_panels_bounds: tuple[int, int] = (3, 12),
-    convergence_criteria: float | int = 5.0,
+    rtol: float | int = 0.05,
+    atol: float | int = 0.001,
+    coefficient_mask: tuple[bool, bool, bool, bool, bool, bool] | None = None,
     show_solver_progress: bool | np.bool_ = True,
     resolve_converged_solver: bool | np.bool_ = False,
 ) -> (
@@ -574,30 +567,24 @@ def analyze_unsteady_convergence(
     the number of chordwise Panels.
 
     With each new combination of these values, the UnsteadyProblem is solved, and each
-    Airplanes' final load coefficients are stored. As this function deals with
-    UnsteadyProblems, it considers the final load coefficients to be the final-cycle's
-    RMS load coefficients for UnsteadyProblems with variable geometry, and the final
-    time step's load coefficients for static geometry cases. For each Airplane, the
-    three final force coefficients are combined by taking their root-sum-square to find
-    the resultant final force coefficient for that Airplane. Then, the absolute percent
-    change (APE) of this Airplane's resultant final force coefficient is found between
-    this iteration and the iterations with incrementally coarser meshes in all four
-    parameter directions (wake state, wake length, Panel aspect ratio, and number of
-    chordwise Panels). These steps are repeated for the three final moment coefficients.
+    Airplane's six final load coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ) are stored. As
+    this function deals with UnsteadyProblems, it considers the final load coefficients
+    to be the final cycle's mean load coefficients (the signed time-average over the
+    final cycle) for UnsteadyProblems with variable geometry, and the final time step's
+    load coefficients for static geometry cases. Then, convergence is checked per
+    coefficient between this iteration and the iterations with incrementally coarser
+    meshes in all four parameter directions (wake state, wake length, Panel aspect
+    ratio, and number of chordwise Panels). A coefficient is converged in a parameter
+    direction when its absolute change from the coarser iteration is at most atol + rtol
+    * max(abs(this), abs(coarser)). A parameter direction is converged when every
+    unmasked coefficient of every Airplane is converged in that direction, so a multi-
+    Airplane study converges only once all its Airplanes have.
 
-    For each Airplane, the maximums of the resultant final force coefficient APEs and
-    resultant final moment coefficient APEs are found. This leaves us with four maximum
-    APEs per Airplane, one for each parameter direction. Next, we find the maximum
-    across all the Airplanes for each parameter directions' maximum APE. Now, we are
-    left with four maximum APEs total. If any of the four parameter direction APEs is
-    below the convergence criteria, then this iteration has found a converged solution
-    for that parameter direction.
-
-    If an iteration's four APEs are all below the converged criteria, then we exit the
+    If an iteration is converged in all four parameter directions, then we exit the
     nested for loops and return the converged parameters. However, the converged
-    parameters are actually the values incrementally coarser than the final values (
-    because the incrementally coarser values were found to be within the convergence
-    criteria percent difference from the final values).
+    parameters are actually the values incrementally coarser than the final values,
+    because refining from the coarser values to the final ones changed every unmasked
+    coefficient by within the tolerance.
 
     **Notes:**
 
@@ -660,13 +647,21 @@ def analyze_unsteady_convergence(
     :param num_chordwise_panels_bounds: A tuple of two ints, in ascending order, that
         determines the range of values to use for the Wings' numbers of chordwise
         panels. The default is (3, 12).
-    :param convergence_criteria: A positive number (int or float) that determines the
-        point at which the function considers the simulation to have converged.
-        Specifically, it is the maximum absolute percent change in the combined load
-        coefficients. Therefore, it is in units of percent. Refer to the description in
-        this function's docstring for more details on how it affects the solver. In
-        short, set this value to 5.0 for a lenient convergence, and 1.0 for a strict
-        convergence. Values are converted to floats internally. The default is 5.0.
+    :param rtol: A positive number (int or float) giving the relative tolerance for the
+        per-coefficient convergence check. A coefficient is converged in a parameter
+        direction when its absolute change from the incrementally coarser iteration is
+        at most atol + rtol * max(abs(this), abs(coarser)). Set this smaller for a
+        stricter convergence. Values are converted to floats internally. The default is
+        0.05.
+    :param atol: A positive number (int or float) giving the absolute tolerance floor
+        for the per-coefficient convergence check. It keeps coefficients that sit near
+        zero from being held to an unreachable relative tolerance. Values are converted
+        to floats internally. The default is 0.001.
+    :param coefficient_mask: A tuple of six bools that determines which of the six load
+        coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ, in that order) must converge, or
+        None to require all six. At least one element must be True. Use this to ignore
+        coefficients that are physically irrelevant to the analysis. The default is
+        None.
     :param show_solver_progress: Set this to True to show the TQDM progress bar during
         each run of the unsteady solver. For showing progress bars and displaying log
         statements, set up logging using the setup_logging function. It can be a bool or
@@ -745,10 +740,18 @@ def analyze_unsteady_convergence(
     # Validate the num_chordwise_panels_bounds parameter.
     _validate_num_chordwise_panels_bounds(num_chordwise_panels_bounds)
 
-    # Validate the convergence_criteria parameter.
-    convergence_criteria = _parameter_validation.number_in_range_return_float(
-        convergence_criteria, "convergence_criteria", min_val=0.0, min_inclusive=False
+    # Validate the rtol parameter.
+    rtol = _parameter_validation.number_in_range_return_float(
+        rtol, "rtol", min_val=0.0, min_inclusive=False
     )
+
+    # Validate the atol parameter.
+    atol = _parameter_validation.number_in_range_return_float(
+        atol, "atol", min_val=0.0, min_inclusive=False
+    )
+
+    # Validate the coefficient_mask parameter.
+    coefficient_mask_array = _validate_coefficient_mask(coefficient_mask)
 
     # Validate the show_solver_progress parameter.
     show_solver_progress = _parameter_validation.boolLike_return_bool(
@@ -812,14 +815,16 @@ def analyze_unsteady_convergence(
         ),
         dtype=float,
     )
-    combinedFinalLoadCoefficients = np.zeros(
+    # Each iteration stores the six final load coefficients (cFX, cFY, cFZ, cMX, cMY,
+    # cMZ) of each Airplane, in that order, along the last axis.
+    finalCoefficients = np.zeros(
         (
             len(wake_list),
             len(wake_lengths_list),
             len(panel_aspect_ratios_list),
             len(num_chordwise_panels_list),
             len(ref_airplane_movements),
-            2,
+            6,
         ),
         dtype=float,
     )
@@ -909,45 +914,38 @@ def analyze_unsteady_convergence(
                     iter_stop = time.time()
                     this_iter_time = iter_stop - iter_start
 
-                    # Create and fill ndarrays with each of this iteration's Airplanes'
-                    # combined final load coefficients.
-                    theseCombinedFinalLoadCoefficients = np.zeros(
-                        (len(ref_airplane_movements), 2), dtype=float
+                    # Create and fill an ndarray with each of this iteration's Airplanes'
+                    # six final load coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ).
+                    theseFinalCoefficients = np.zeros(
+                        (len(ref_airplane_movements), 6), dtype=float
                     )
 
                     for airplane_id in range(len(ref_airplane_movements)):
-                        # If this UnsteadyProblem is static, then get it's combined
-                        # final load coefficients. If it's variable, get the combined
-                        # final RMS load coefficients.
+                        # For static geometry, the final load coefficients are the final
+                        # time step's. For variable geometry, they are the mean over the
+                        # final cycle (the signed time-average).
                         if static:
-                            combinedFinalForceCoefficient = np.linalg.norm(
+                            theseFinalCoefficients[airplane_id, 0:3] = (
                                 this_problem.finalForceCoefficients_W[airplane_id]
                             )
-                            combinedFinalMomentCoefficient = np.linalg.norm(
+                            theseFinalCoefficients[airplane_id, 3:6] = (
                                 this_problem.finalMomentCoefficients_W_CgP1[airplane_id]
                             )
                         else:
-                            combinedFinalForceCoefficient = np.linalg.norm(
-                                this_problem.finalRmsForceCoefficients_W[airplane_id]
+                            theseFinalCoefficients[airplane_id, 0:3] = (
+                                this_problem.finalMeanForceCoefficients_W[airplane_id]
                             )
-                            combinedFinalMomentCoefficient = np.linalg.norm(
-                                this_problem.finalRmsMomentCoefficients_W_CgP1[
+                            theseFinalCoefficients[airplane_id, 3:6] = (
+                                this_problem.finalMeanMomentCoefficients_W_CgP1[
                                     airplane_id
                                 ]
                             )
 
-                        theseCombinedFinalLoadCoefficients[airplane_id, 0] = (
-                            combinedFinalForceCoefficient
-                        )
-                        theseCombinedFinalLoadCoefficients[airplane_id, 1] = (
-                            combinedFinalMomentCoefficient
-                        )
-
-                    # Populate the ndarrays that store information from all the
+                    # Populate the ndarray that stores information from all the
                     # iterations with the data from this iteration.
-                    combinedFinalLoadCoefficients[
-                        wake_id, length_id, ar_id, chord_id, :, :
-                    ] = theseCombinedFinalLoadCoefficients
+                    finalCoefficients[wake_id, length_id, ar_id, chord_id, :, :] = (
+                        theseFinalCoefficients
+                    )
                     iter_times[wake_id, length_id, ar_id, chord_id] = this_iter_time
 
                     _logger.info(
@@ -956,100 +954,123 @@ def analyze_unsteady_convergence(
                         + " s"
                     )
 
-                    max_wake_pc = np.inf
-                    max_length_pc = np.inf
-                    max_ar_pc = np.inf
-                    max_chord_pc = np.inf
+                    # Check per-coefficient convergence in each parameter direction
+                    # against the incrementally coarser iteration. A direction cannot be
+                    # checked on its first value, where there is no coarser iteration to
+                    # compare against, so it starts as not converged.
+                    wake_converged = False
+                    length_converged = False
+                    ar_converged = False
+                    chord_converged = False
 
-                    # If this isn't the first wake state, calculate the wake state APE.
+                    # If this isn't the first wake state, check convergence in the wake
+                    # state direction.
                     if wake_id > 0:
-                        lastWakeCombinedFinalLoadCoefficients = (
-                            combinedFinalLoadCoefficients[
-                                wake_id - 1, length_id, ar_id, chord_id, :, :
-                            ]
-                        )
-                        max_wake_pc = _max_combined_percent_change(
-                            theseCombinedFinalLoadCoefficients,
-                            lastWakeCombinedFinalLoadCoefficients,
+                        wake_converged, wake_metric, wake_limiting_id = (
+                            _check_coefficient_convergence(
+                                theseFinalCoefficients,
+                                finalCoefficients[
+                                    wake_id - 1, length_id, ar_id, chord_id, :, :
+                                ],
+                                rtol,
+                                atol,
+                                coefficient_mask_array,
+                            )
                         )
 
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from wake "
-                            "type: " + str(round(max_wake_pc, 2)) + "%"
+                            "\t\t\t\t\tWake type convergence metric: "
+                            + str(round(wake_metric, 2))
+                            + "% (limiting coefficient: "
+                            + _COEFFICIENT_LABELS[wake_limiting_id]
+                            + ")"
                         )
                     else:
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from wake "
-                            "type: " + str(max_wake_pc)
+                            "\t\t\t\t\tWake type convergence metric: not yet checked"
                         )
 
-                    # If this isn't the first wake length, calculate the wake length
-                    # APE.
+                    # If this isn't the first wake length, check convergence in the wake
+                    # length direction.
                     if length_id > 0:
-                        lastLengthCombinedFinalLoadCoefficients = (
-                            combinedFinalLoadCoefficients[
-                                wake_id, length_id - 1, ar_id, chord_id, :, :
-                            ]
-                        )
-                        max_length_pc = _max_combined_percent_change(
-                            theseCombinedFinalLoadCoefficients,
-                            lastLengthCombinedFinalLoadCoefficients,
+                        length_converged, length_metric, length_limiting_id = (
+                            _check_coefficient_convergence(
+                                theseFinalCoefficients,
+                                finalCoefficients[
+                                    wake_id, length_id - 1, ar_id, chord_id, :, :
+                                ],
+                                rtol,
+                                atol,
+                                coefficient_mask_array,
+                            )
                         )
 
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from wake "
-                            "length: " + str(round(max_length_pc, 2)) + "%"
+                            "\t\t\t\t\tWake length convergence metric: "
+                            + str(round(length_metric, 2))
+                            + "% (limiting coefficient: "
+                            + _COEFFICIENT_LABELS[length_limiting_id]
+                            + ")"
                         )
                     else:
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from wake "
-                            "length: " + str(max_length_pc)
+                            "\t\t\t\t\tWake length convergence metric: not yet checked"
                         )
 
-                    # If this isn't the first Panel aspect ratio, calculate the Panel
-                    # aspect ratio APE.
+                    # If this isn't the first Panel aspect ratio, check convergence in
+                    # the Panel aspect ratio direction.
                     if ar_id > 0:
-                        lastArCombinedFinalLoadCoefficients = (
-                            combinedFinalLoadCoefficients[
-                                wake_id, length_id, ar_id - 1, chord_id, :, :
-                            ]
-                        )
-                        max_ar_pc = _max_combined_percent_change(
-                            theseCombinedFinalLoadCoefficients,
-                            lastArCombinedFinalLoadCoefficients,
+                        ar_converged, ar_metric, ar_limiting_id = (
+                            _check_coefficient_convergence(
+                                theseFinalCoefficients,
+                                finalCoefficients[
+                                    wake_id, length_id, ar_id - 1, chord_id, :, :
+                                ],
+                                rtol,
+                                atol,
+                                coefficient_mask_array,
+                            )
                         )
 
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from Panel "
-                            "aspect ratio: " + str(round(max_ar_pc, 2)) + "%"
+                            "\t\t\t\t\tPanel aspect ratio convergence metric: "
+                            + str(round(ar_metric, 2))
+                            + "% (limiting coefficient: "
+                            + _COEFFICIENT_LABELS[ar_limiting_id]
+                            + ")"
                         )
                     else:
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from Panel "
-                            "aspect ratio: " + str(max_ar_pc)
+                            "\t\t\t\t\tPanel aspect ratio convergence metric: not yet "
+                            "checked"
                         )
 
-                    # If this isn't the first number of chordwise Panels, calculate
-                    # the number of chordwise Panels APE.
+                    # If this isn't the first number of chordwise Panels, check
+                    # convergence in the number of chordwise Panels direction.
                     if chord_id > 0:
-                        lastChordCombinedFinalLoadCoefficients = (
-                            combinedFinalLoadCoefficients[
-                                wake_id, length_id, ar_id, chord_id - 1, :, :
-                            ]
-                        )
-                        max_chord_pc = _max_combined_percent_change(
-                            theseCombinedFinalLoadCoefficients,
-                            lastChordCombinedFinalLoadCoefficients,
+                        chord_converged, chord_metric, chord_limiting_id = (
+                            _check_coefficient_convergence(
+                                theseFinalCoefficients,
+                                finalCoefficients[
+                                    wake_id, length_id, ar_id, chord_id - 1, :, :
+                                ],
+                                rtol,
+                                atol,
+                                coefficient_mask_array,
+                            )
                         )
 
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from "
-                            "chordwise Panels: " + str(round(max_chord_pc, 2)) + "%"
+                            "\t\t\t\t\tNumber of chordwise Panels convergence metric: "
+                            + str(round(chord_metric, 2))
+                            + "% (limiting coefficient: "
+                            + _COEFFICIENT_LABELS[chord_limiting_id]
+                            + ")"
                         )
                     else:
                         _logger.info(
-                            "\t\t\t\t\tMaximum combined coefficient change from "
-                            "chordwise Panels: " + str(max_chord_pc)
+                            "\t\t\t\t\tNumber of chordwise Panels convergence metric: "
+                            "not yet checked"
                         )
 
                     # Consider the Panel aspect ratio value to be saturated if it is
@@ -1066,13 +1087,6 @@ def analyze_unsteady_convergence(
                     single_length = len(wake_lengths_list) == 1
                     single_ar = len(panel_aspect_ratios_list) == 1
                     single_chord = len(num_chordwise_panels_list) == 1
-
-                    # Check if the iteration is converged with respect to any of the
-                    # four convergence parameters.
-                    wake_converged = max_wake_pc < convergence_criteria
-                    length_converged = max_length_pc < convergence_criteria
-                    ar_converged = max_ar_pc < convergence_criteria
-                    chord_converged = max_chord_pc < convergence_criteria
 
                     # Consider each convergence parameter to have "passed" if it is
                     # converged, single, or saturated.
@@ -2383,32 +2397,93 @@ def _reject_unrefinable_wings(
                 )
 
 
-def _max_combined_percent_change(
-    these_combined_coefficients: np.ndarray,
-    coarser_combined_coefficients: np.ndarray,
-) -> float:
-    """Calculates the maximum absolute percent change between an iteration's combined
-    load coefficients and those of an incrementally coarser iteration.
+def _validate_coefficient_mask(
+    coefficient_mask: tuple[bool, bool, bool, bool, bool, bool] | None,
+) -> np.ndarray:
+    """Validates the coefficient_mask parameter shared by the convergence analysis
+    functions and returns it as an ndarray.
 
-    The percent change is taken elementwise as the absolute difference divided by the
-    coarser value, scaled to a percentage, and the maximum across all elements is
-    returned.
-
-    :param these_combined_coefficients: An ndarray of this iteration's combined load
-        coefficients.
-    :param coarser_combined_coefficients: An ndarray, of the same shape, of the
-        incrementally coarser iteration's combined load coefficients.
-    :return: The maximum absolute percent change across all elements, as a float.
+    :param coefficient_mask: A tuple of six bools that determines which of the six load
+        coefficients (cFX, cFY, cFZ, cMX, cMY, cMZ) must converge, or None to require
+        all six. At least one element must be True.
+    :return: A (6,) ndarray of bools representing the validated mask.
     """
-    return float(
-        np.max(
-            100
-            * np.abs(
-                (these_combined_coefficients - coarser_combined_coefficients)
-                / coarser_combined_coefficients
-            )
-        )
+    if coefficient_mask is None:
+        return np.ones(6, dtype=bool)
+    if not isinstance(coefficient_mask, tuple):
+        raise TypeError("coefficient_mask must be a tuple or None.")
+    if len(coefficient_mask) != 6:
+        raise ValueError("coefficient_mask must have exactly six elements.")
+    if not all(isinstance(element, bool) for element in coefficient_mask):
+        raise TypeError("Every element in coefficient_mask must be a bool.")
+    if not any(coefficient_mask):
+        raise ValueError("At least one element in coefficient_mask must be True.")
+    return np.array(coefficient_mask, dtype=bool)
+
+
+def _check_coefficient_convergence(
+    these_coefficients: np.ndarray,
+    coarser_coefficients: np.ndarray,
+    rtol: float,
+    atol: float,
+    coefficient_mask: np.ndarray,
+) -> tuple[bool, float, int]:
+    """Checks per-coefficient convergence between an iteration's load coefficients and
+    those of an incrementally coarser iteration.
+
+    For each of the six load coefficients of each Airplane, the error is the absolute
+    difference between this iteration's coefficient and the coarser iteration's, and the
+    tolerance is atol + rtol * max(abs(this), abs(coarser)). A coefficient is converged
+    when its error is less than or equal to its tolerance. The iteration is converged
+    only when every unmasked coefficient of every Airplane has converged, so a multi-
+    Airplane study converges only once all its Airplanes have.
+
+    A convergence metric accompanies the result for logging. It is a percentage that is
+    100.0 when a coefficient has converged and falls toward 0.0 as its error grows past
+    its tolerance, so a lower metric means a coefficient is further from converging. The
+    minimum metric across the unmasked coefficients of all Airplanes and the index of
+    the coefficient that attains it are returned to identify the limiting coefficient.
+
+    :param these_coefficients: A (M,6) ndarray of floats, where M is the number of
+        Airplanes, of this iteration's six load coefficients (cFX, cFY, cFZ, cMX, cMY,
+        cMZ) for each Airplane.
+    :param coarser_coefficients: A (M,6) ndarray of floats, of the same shape, of the
+        incrementally coarser iteration's six load coefficients for each Airplane.
+    :param rtol: The relative tolerance. It must be a positive float.
+    :param atol: The absolute tolerance floor for coefficients near zero. It must be a
+        positive float.
+    :param coefficient_mask: A (6,) ndarray of bools that determines which of the six
+        load coefficients must converge. At least one element is True.
+    :return: A tuple of a bool, a float, and an int. In order, whether every unmasked
+        coefficient of every Airplane has converged, the minimum convergence metric
+        (percentage) across the unmasked coefficients of all Airplanes, and the index
+        within the six coefficients of the limiting coefficient (the one attaining that
+        minimum metric).
+    """
+    errors = np.abs(these_coefficients - coarser_coefficients)
+    tolerances = atol + rtol * np.maximum(
+        np.abs(these_coefficients), np.abs(coarser_coefficients)
     )
+    converged = errors <= tolerances
+
+    all_converged = bool(np.all(converged[:, coefficient_mask]))
+
+    # The metric is 100.0 for a converged coefficient (including one with zero error) and
+    # falls toward 0.0 as the error grows past its tolerance.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        metrics = np.where(
+            errors == 0.0,
+            100.0,
+            100.0 * np.minimum(1.0, tolerances / errors),
+        )
+
+    # Exclude the masked-out coefficients from the limiting-coefficient search by setting
+    # their metrics to infinity. The mask has shape (6,) and broadcasts across Airplanes.
+    masked_metrics = np.where(coefficient_mask, metrics, np.inf)
+    min_metric = float(np.min(masked_metrics))
+    limiting_coefficient_id = int(np.argmin(masked_metrics) % 6)
+
+    return all_converged, min_metric, limiting_coefficient_id
 
 
 def _resolve_num_spanwise_panels(

--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -613,6 +613,12 @@ def analyze_unsteady_convergence(
     static (the WingMovement's own flapping and sweeping motion is preserved); a non-
     static WingCrossSectionMovement on an edge-defined Wing is rejected.
 
+    The time step is not a convergence parameter. Each iteration instead optimizes its
+    own delta_time for its mesh with Movement's iterative optimizer, so every solve uses
+    the time step that is correct for its geometry and motion. The optimum depends only
+    on the mesh, so it is computed once per Panel aspect ratio and number of chordwise
+    Panels and reused across every wake state and wake length at that mesh.
+
     :param ref_problem: The UnsteadyProblem whose converged parameters will be found.
         This must be a standard UnsteadyProblem, not a FreeFlightUnsteadyProblem or an
         AeroelasticUnsteadyProblem, neither of which is supported.
@@ -848,6 +854,12 @@ def analyze_unsteady_convergence(
     # is a tuple of 4 ints: ar_id, chord_id, ref_base_airplane_id, ref_base_wing_id.
     num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int] = {}
 
+    # This caches the optimized delta_time for each mesh, keyed on a tuple of 2 ints:
+    # ar_id, chord_id. The optimum depends only on the mesh (the geometry and motion),
+    # not on the wake state or wake length, so it is reused across every wake-state and
+    # wake-length combination at that mesh.
+    delta_time_cache: dict[tuple[int, int], float] = {}
+
     # Begin iterating through the outermost loop of wake states.
     for wake_id, wake in enumerate(wake_list):
         if wake:
@@ -894,6 +906,7 @@ def analyze_unsteady_convergence(
                         ref_problem,
                         num_spanwise_panels_cache,
                         num_wing_cross_sections_cache,
+                        delta_time_cache,
                     )
 
                     # Create and run this iteration's
@@ -1258,6 +1271,7 @@ def analyze_unsteady_convergence(
                                 ref_problem,
                                 num_spanwise_panels_cache,
                                 num_wing_cross_sections_cache,
+                                delta_time_cache,
                             )
                             converged_solver = unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(
                                 unsteady_problem=converged_problem
@@ -1472,6 +1486,7 @@ def _build_unsteady_problem(
     ref_problem: problems.UnsteadyProblem,
     num_spanwise_panels_cache: dict[tuple[int, int, int, int, int], int],
     num_wing_cross_sections_cache: dict[tuple[int, int, int, int], int],
+    delta_time_cache: dict[tuple[int, int], float],
 ) -> problems.UnsteadyProblem:
     """Builds the UnsteadyProblem for one convergence iteration.
 
@@ -1487,6 +1502,12 @@ def _build_unsteady_problem(
     refined WingCrossSections are wrapped in motion free WingCrossSectionMovements and
     the WingMovement's own motion parameters are copied. The copied AirplaneMovements
     are wrapped in a new Movement (with the given wake length) and UnsteadyProblem.
+
+    The Movement's time step is optimized for this iteration's mesh with Movement's
+    iterative delta_time optimizer. The optimum depends only on the mesh, so it is
+    resolved once per (Panel aspect ratio index, number of chordwise Panels index) and
+    cached, then reused across every wake-state and wake-length combination at that
+    mesh.
 
     :param ar_id: The index of the current Panel aspect ratio within the list of Panel
         aspect ratios being tested.
@@ -1506,6 +1527,9 @@ def _build_unsteady_problem(
         number of chordwise Panels index, Airplane index, Wing index) tuple to a
         previously calculated number of WingCrossSections, used for edge-defined Wings.
         It is read and updated in place.
+    :param delta_time_cache: The cache mapping a (Panel aspect ratio index, number of
+        chordwise Panels index) tuple to a previously optimized delta_time for that
+        mesh. It is read and updated in place.
     :return: The UnsteadyProblem for this iteration.
     """
     ref_movement = ref_problem.movement
@@ -1822,18 +1846,43 @@ def _build_unsteady_problem(
         # 9. Append the AirplaneMovement copy to the list of AirplaneMovement copies.
         these_airplane_movements.append(this_airplane_movement)
 
+    # Resolve the time step for this mesh. The optimum depends only on the mesh, so on a
+    # cache miss the iterative optimizer finds it (delta_time="optimize"), and on a hit
+    # the cached value is reused. The Movement resolves the string to a float, which is
+    # read back and cached below.
+    delta_time_key = (ar_id, chord_id)
+    this_delta_time: str | float = delta_time_cache.get(delta_time_key, "optimize")
+
     # Create a new Movement for this iteration.
     if static:
         this_movement = movements.movement.Movement(
             airplane_movements=these_airplane_movements,
             operating_point_movement=ref_operating_point_movement,
             num_chords=wake_length,
+            delta_time=this_delta_time,
         )
     else:
         this_movement = movements.movement.Movement(
             airplane_movements=these_airplane_movements,
             operating_point_movement=ref_operating_point_movement,
             num_cycles=wake_length,
+            delta_time=this_delta_time,
+        )
+
+    # Cache the optimized delta_time on a miss so it is reused across the other
+    # wake-state and wake-length combinations at this mesh.
+    if delta_time_key not in delta_time_cache:
+        delta_time_cache[delta_time_key] = this_movement.delta_time
+        _logger.info(
+            "\t\t\t\t\tOptimized delta_time: "
+            + str(round(this_movement.delta_time, 6))
+            + " s"
+        )
+    else:
+        _logger.info(
+            "\t\t\t\t\tCached delta_time: "
+            + str(round(this_movement.delta_time, 6))
+            + " s"
         )
 
     # Create a new UnsteadyProblem for this iteration.

--- a/tests/integration/fixtures/airplane_fixtures.py
+++ b/tests/integration/fixtures/airplane_fixtures.py
@@ -9,16 +9,6 @@ def make_steady_validation_airplane():
     """This function creates an Airplane to be used as a fixture for testing steady
     solvers.
 
-    The parameters of this Airplane were found to be converged based on the following
-    call to analyze_steady_convergence:
-    converged_parameters = ps.convergence.analyze_steady_convergence(
-        ref_problem=steady_validation_problem,
-        solver_type="steady horseshoe vortex lattice method",
-        panel_aspect_ratio_bounds=(4, 1),
-        num_chordwise_panels_bounds=(3, 20),
-        convergence_criteria=0.1,
-    ).
-
     :return steady_validation_airplane: Airplane
         This is the Airplane fixture.
     """
@@ -233,16 +223,6 @@ def make_multiple_wing_steady_validation_airplane():
     """This function creates an Airplane with multiple Wings to be used as a fixture
     for testing steady solvers.
 
-    The parameters of this Airplane were found to be converged based on the following
-    call to analyze_steady_convergence:
-    converged_parameters = ps.convergence.analyze_steady_convergence(
-        ref_problem=steady_validation_problem,
-        solver_type="steady horseshoe vortex lattice method",
-        panel_aspect_ratio_bounds=(4, 1),
-        num_chordwise_panels_bounds=(3, 20),
-        convergence_criteria=0.1,
-    ).
-
     :return multiple_wing_steady_validation_airplane: Airplane
         This is the Airplane fixture.
     """
@@ -352,19 +332,6 @@ def make_multiple_wing_steady_validation_airplane():
 def make_symmetric_unsteady_validation_airplane():
     """This function creates a symmetric Airplane to be used as a fixture for testing
     unsteady solvers.
-
-    The parameters of this Airplane were found to be converged based on the following
-    call to analyze_unsteady_convergence:
-    converged_parameters = ps.convergence.analyze_unsteady_convergence(
-        ref_problem=unsteady_validation_problem,
-        prescribed_wake=True,
-        free_wake=True,
-        num_chords_bounds=(3, 9),
-        panel_aspect_ratio_bounds=(4, 1),
-        num_chordwise_panels_bounds=(4, 11),
-        coefficient_mask=[True, False, True, False, True, False],
-        convergence_criteria=1.0,
-    ).
 
     :return symmetric_unsteady_validation_airplane: Airplane
         This is the Airplane fixture.

--- a/tests/integration/test_steady_convergence.py
+++ b/tests/integration/test_steady_convergence.py
@@ -33,7 +33,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady horseshoe vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
         )
 
         converged_panel_ar = converged_parameters[0]
@@ -63,7 +64,8 @@ class TestSteadyConvergence(unittest.TestCase):
                 solver_type="steady ring vortex lattice method",
                 panel_aspect_ratio_bounds=(4, 2),
                 num_chordwise_panels_bounds=(1, 4),
-                convergence_criteria=5.0,
+                rtol=0.05,
+                atol=0.001,
             )
 
     def test_steady_ring_convergence(self):
@@ -77,7 +79,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady ring vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
         )
 
         converged_panel_ar = converged_parameters[0]
@@ -101,7 +104,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady horseshoe vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
             resolve_converged_solver=True,
         )
 
@@ -131,7 +135,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady ring vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
             resolve_converged_solver=True,
         )
 
@@ -166,7 +171,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady ring vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
         )
 
         converged_panel_ar = converged_parameters[0]
@@ -193,7 +199,8 @@ class TestSteadyConvergence(unittest.TestCase):
             solver_type="steady ring vortex lattice method",
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 4),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
         )
 
         converged_panel_ar = converged_parameters[0]

--- a/tests/integration/test_unsteady_convergence.py
+++ b/tests/integration/test_unsteady_convergence.py
@@ -35,7 +35,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
             num_chords_bounds=(1, 4),
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 5),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
             show_solver_progress=False,
         )
 
@@ -100,7 +101,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
                 num_chords_bounds=(1, 2),
                 panel_aspect_ratio_bounds=(4, 2),
                 num_chordwise_panels_bounds=(1, 4),
-                convergence_criteria=5.0,
+                rtol=0.05,
+                atol=0.001,
                 show_solver_progress=False,
             )
 
@@ -127,7 +129,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
             num_chords_bounds=(1, 4),
             panel_aspect_ratio_bounds=(4, 3),
             num_chordwise_panels_bounds=(1, 3),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
             show_solver_progress=False,
         )
 
@@ -169,7 +172,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
                 num_cycles_bounds=(1, 2),
                 panel_aspect_ratio_bounds=(4, 2),
                 num_chordwise_panels_bounds=(1, 4),
-                convergence_criteria=5.0,
+                rtol=0.05,
+                atol=0.001,
                 show_solver_progress=False,
             )
 
@@ -186,7 +190,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
             num_chords_bounds=(1, 4),
             panel_aspect_ratio_bounds=(4, 2),
             num_chordwise_panels_bounds=(1, 5),
-            convergence_criteria=5.0,
+            rtol=0.05,
+            atol=0.001,
             show_solver_progress=False,
             resolve_converged_solver=True,
         )

--- a/tests/unit/test_convergence.py
+++ b/tests/unit/test_convergence.py
@@ -260,3 +260,133 @@ class TestGetNumWingCrossSectionsForPanelAr(unittest.TestCase):
             4, ref_wing=self._make_edge_wing(symmetric=True)
         )
         self.assertEqual(asymmetric_result, symmetric_result)
+
+
+class TestValidateCoefficientMask(unittest.TestCase):
+    """This class contains methods for testing
+    convergence._validate_coefficient_mask.
+    """
+
+    def test_none_returns_all_true(self):
+        """Test that None returns a (6,) mask of all True."""
+        result = convergence._validate_coefficient_mask(None)
+        self.assertTrue(np.array_equal(result, np.ones(6, dtype=bool)))
+
+    def test_tuple_is_returned_as_bool_array(self):
+        """Test that a valid tuple is returned as an equivalent (6,) bool ndarray."""
+        result = convergence._validate_coefficient_mask(
+            (True, False, True, False, True, False)
+        )
+        self.assertTrue(
+            np.array_equal(result, np.array([1, 0, 1, 0, 1, 0], dtype=bool))
+        )
+
+    def test_non_tuple_raises_type_error(self):
+        """Test that a non-tuple, non-None mask raises a TypeError."""
+        with self.assertRaises(TypeError):
+            convergence._validate_coefficient_mask([True] * 6)
+
+    def test_wrong_length_raises_value_error(self):
+        """Test that a mask without exactly six elements raises a ValueError."""
+        with self.assertRaises(ValueError):
+            convergence._validate_coefficient_mask((True, True, True))
+
+    def test_non_bool_element_raises_type_error(self):
+        """Test that a mask with a non-bool element raises a TypeError."""
+        with self.assertRaises(TypeError):
+            convergence._validate_coefficient_mask((True, 1, True, True, True, True))
+
+    def test_all_false_raises_value_error(self):
+        """Test that a mask with no True element raises a ValueError."""
+        with self.assertRaises(ValueError):
+            convergence._validate_coefficient_mask((False,) * 6)
+
+
+class TestCheckCoefficientConvergence(unittest.TestCase):
+    """This class contains methods for testing
+    convergence._check_coefficient_convergence.
+    """
+
+    def setUp(self):
+        """Set up a full mask and the tolerances used across the tests.
+
+        :return: None
+        """
+        self.mask = np.ones(6, dtype=bool)
+        self.rtol = 0.05
+        self.atol = 0.001
+
+    def test_identical_coefficients_converge(self):
+        """Test that identical coefficients converge with a perfect metric."""
+        these = np.array([[1.0, 0.0, 2.0, 0.1, 0.0, 0.05]])
+        converged, metric, _ = convergence._check_coefficient_convergence(
+            these, these.copy(), self.rtol, self.atol, self.mask
+        )
+        self.assertTrue(converged)
+        self.assertEqual(metric, 100.0)
+
+    def test_large_relative_change_does_not_converge(self):
+        """Test that a coefficient changing by more than the relative tolerance does not
+        converge and is reported as the limiting coefficient.
+        """
+        coarser = np.array([[1.0, 0.0, 2.0, 0.1, 0.0, 0.05]])
+        these = coarser.copy()
+        these[0, 2] = 2.5
+        converged, _, limiting_id = convergence._check_coefficient_convergence(
+            these, coarser, self.rtol, self.atol, self.mask
+        )
+        self.assertFalse(converged)
+        self.assertEqual(limiting_id, 2)
+
+    def test_masked_out_coefficient_is_ignored(self):
+        """Test that masking out the only offending coefficient makes the check
+        converge.
+        """
+        coarser = np.array([[1.0, 0.0, 2.0, 0.1, 0.0, 0.05]])
+        these = coarser.copy()
+        these[0, 2] = 2.5
+        mask = np.array([True, True, False, True, True, True], dtype=bool)
+        converged, _, _ = convergence._check_coefficient_convergence(
+            these, coarser, self.rtol, self.atol, mask
+        )
+        self.assertTrue(converged)
+
+    def test_absolute_tolerance_floors_near_zero(self):
+        """Test that a coefficient near zero converges via the absolute tolerance floor
+        even though its relative change is large.
+        """
+        these = np.zeros((1, 6), dtype=float)
+        coarser = np.zeros((1, 6), dtype=float)
+        coarser[0, 0] = 0.5 * self.atol
+        converged, _, _ = convergence._check_coefficient_convergence(
+            these, coarser, self.rtol, self.atol, self.mask
+        )
+        self.assertTrue(converged)
+
+    def test_all_airplanes_must_converge(self):
+        """Test that the check fails when any one Airplane has an unconverged
+        coefficient.
+        """
+        coarser = np.array(
+            [
+                [1.0, 0.0, 2.0, 0.1, 0.0, 0.05],
+                [1.0, 0.0, 2.0, 0.1, 0.0, 0.05],
+            ]
+        )
+        these = coarser.copy()
+        these[1, 0] = 2.0
+        converged, _, limiting_id = convergence._check_coefficient_convergence(
+            these, coarser, self.rtol, self.atol, self.mask
+        )
+        self.assertFalse(converged)
+        self.assertEqual(limiting_id, 0)
+
+    def test_returns_bool_float_int(self):
+        """Test that the result is a bool, a float, and an int."""
+        these = np.array([[1.0, 0.0, 2.0, 0.1, 0.0, 0.05]])
+        converged, metric, limiting_id = convergence._check_coefficient_convergence(
+            these, these.copy(), self.rtol, self.atol, self.mask
+        )
+        self.assertIsInstance(converged, bool)
+        self.assertIsInstance(metric, float)
+        self.assertIsInstance(limiting_id, int)


### PR DESCRIPTION
# Description

This reworks how `analyze_steady_convergence` and `analyze_unsteady_convergence` in `convergence.py` decide that a study has converged. The previous approach combined each `Airplane`'s three force coefficients (and, separately, its three moment coefficients) into a single resultant by root-sum-square, then declared a parameter direction converged when the maximum absolute percent change of those resultants fell below one `convergence_criteria` percentage. That single scalar could mask meaningful drift in an individual coefficient and could not express "converge on lift and pitching moment but ignore side force." The new approach checks each of the six load coefficients (`cFX`, `cFY`, `cFZ`, `cMX`, `cMY`, `cMZ`) of every `Airplane` independently: a coefficient is converged in a parameter direction when its absolute change from the incrementally coarser iteration is at most `atol + rtol * max(abs(this), abs(coarser))`, and a direction is converged only when every unmasked coefficient of every `Airplane` passes. The single `convergence_criteria` parameter is replaced by `rtol`, `atol`, and an optional `coefficient_mask`.

Two further changes ride along. For unsteady variable-geometry studies, the final load coefficients used for the comparison are now the signed mean over the final cycle rather than the final-cycle RMS, which better reflects the cycle-averaged loads a user cares about. And the unsteady solver now optimizes the time step per mesh instead of inheriting a fixed one: each `(Panel aspect ratio, number of chordwise Panels)` mesh resolves its own `delta_time` via `Movement`'s iterative optimizer, cached and reused across every wake-state and wake-length combination at that mesh so the optimizer runs only once per mesh.

## Motivation

Convergence should be judged on the quantities a user actually reports, and a root-sum-square resultant does not do that: it can hide a coefficient that is still drifting while the combined magnitude looks stable, and it forces every coefficient to be treated as equally relevant even when some (for example, side force on a symmetric case) are physically negligible and never settle in a relative sense. Splitting the tolerance into a relative part (`rtol`) and an absolute floor (`atol`) also fixes the near-zero problem, where a coefficient hovering around zero can never meet a purely relative threshold. Separately, using a single fixed time step across wildly different meshes made the unsteady convergence result partly an artifact of that step rather than of the mesh; optimizing `delta_time` per mesh removes that confound so each solve uses the step that is correct for its own geometry and motion.

## Relevant Issues

Partially addresses #147 and #148.

## Changes

* Replaced the `convergence_criteria` parameter of `analyze_steady_convergence` and `analyze_unsteady_convergence` with `rtol` (default `0.05`), `atol` (default `0.001`), and `coefficient_mask` (default `None`, meaning all six coefficients must converge), each validated at the top of both functions.
* Reworked both functions to store all six load coefficients (`cFX`, `cFY`, `cFZ`, `cMX`, `cMY`, `cMZ`) of each `Airplane` per iteration in a single `coefficients` / `finalCoefficients` ndarray, replacing the separate root-sum-square `combinedForceCoefficients` and `combinedMomentCoefficients` arrays.
* Added `_check_coefficient_convergence`, which computes per-coefficient convergence against the incrementally coarser iteration using the `atol + rtol * max(abs(this), abs(coarser))` tolerance, requires every unmasked coefficient of every `Airplane` to pass, and returns a logging metric plus the index of the limiting coefficient.
* Added `_validate_coefficient_mask`, which normalizes `None` to a `(6,)` all-`True` mask and rejects masks that are not six-element tuples of bools or that have no `True` element.
* Removed `_max_combined_percent_change`, which the resultant-based check no longer needs.
* Added the module-level `_COEFFICIENT_LABELS` tuple and updated the per-direction log lines to report a convergence metric and name the limiting coefficient, or "not yet checked" on a direction's first value.
* Switched unsteady variable-geometry convergence to compare the final cycle's signed mean load coefficients (`finalMeanForceCoefficients_W`, `finalMeanMomentCoefficients_W_CgP1`) instead of the final-cycle RMS coefficients.
* Made `analyze_unsteady_convergence` optimize `delta_time` per mesh: `_build_unsteady_problem` now takes a `delta_time_cache`, passes `delta_time="optimize"` to `Movement` on a cache miss, reads back and caches the resolved value keyed on `(ar_id, chord_id)`, and logs whether the step was optimized or reused.
* Updated `examples/steady_convergence.py`, `examples/unsteady_static_convergence.py`, and `examples/unsteady_variable_convergence.py` to call the analysis functions with `rtol` and `atol`, and refreshed their comments and expected `example_convergence.log` outputs.
* Updated `tests/integration/test_steady_convergence.py` and `tests/integration/test_unsteady_convergence.py` to pass `rtol` and `atol`, and removed stale `convergence_criteria` docstrings from the fixture builders in `tests/integration/fixtures/airplane_fixtures.py`.
* Added `TestValidateCoefficientMask` and `TestCheckCoefficientConvergence` to `tests/unit/test_convergence.py`, covering mask validation, per-coefficient and multi-`Airplane` convergence, masking out an offending coefficient, the near-zero absolute-tolerance floor, and the returned `(bool, float, int)` types.

## Dependency Updates

None.

## Change Magnitude

**Major**: Large change that adds significant new functionality, changes existing behavior, or may affect many parts of the codebase.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
