### PR TITLE
Adopt octowrap for comment wrapping

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,6 @@ Identify the option that best describes the impact of your change, then delete t
 * [ ] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
 * [ ] Code locally passes all tests in the `tests` package.
 * [ ] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
-* [ ] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, and `pre-commit-hooks` GitHub actions.
+* [ ] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
 * [ ] This PR passes the `mypy` GitHub action.
 * [ ] This PR passes all the `tests` GitHub actions.

--- a/.github/workflows/octowrap.yml
+++ b/.github/workflows/octowrap.yml
@@ -1,0 +1,27 @@
+name: octowrap
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  octowrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.13
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run octowrap hook
+        run: pre-commit run --all-files octowrap

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,6 +84,16 @@ repos:
         exclude: ^docs/_static/benchmarks/.*\.html$
   - repo: local
     hooks:
+      - id: octowrap
+        name: checker  octowrap
+        entry: "bash -c 'output=$(octowrap --check \"$@\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then echo \"$output\" | grep -v -e \"would be reformatted\" -e \"^$\"; echo; echo \"Run: octowrap -i .\"; exit 1; fi' --"
+        language: python
+        additional_dependencies: [octowrap==0.6.2]
+        types: [python]
+        # Pre-commit batches the passed filenames to parallelize hook invocations, and
+        # each failing batch would print the hint line independently. Serializing
+        # guarantees a single invocation, so the hint prints exactly once.
+        require_serial: true
       - id: ascii-only
         name: checker  ascii-only
         entry: python scripts/check_ascii_only.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ Requires Python 3.11, but active development is done in 3.13
         - `isort.yml`
         - `label-sync.yml`
         - `mypy.yml`
+        - `octowrap.yml`
         - `pre-commit-hooks.yml`
         - `publish.yml`
         - `tests.yml`

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -83,6 +83,7 @@ If a legitimate reason to violate this rule arises (a contribution must include 
 - For division, use a slash surrounded by spaces (e.g., "a / b").
 - For equals signs in inline equations and value descriptions, surround with spaces (e.g., "area = 0.5", not "area=0.5").
 - For approximately-equal, use a tilde surrounded by spaces (e.g., "a ~ b").
+- When writing tuples or vectors in prose, include a space after each comma (e.g., "(1.0, 2.0, 3.0)", not "(1.0,2.0,3.0)").
 - When referring to axes, coordinates, or planes, use lowercase letters without hyphens between coordinate letters and descriptors (e.g., "x axis", "y component", "xz plane", "z direction"). Never use uppercase letters for axis references in text.
 - Always end *.py file with an empty line.
 - Preserve existing comment structure and detail level.

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -14,6 +14,8 @@ Guidelines when writing comments, docstrings, and documentation for Ptera Softwa
     - BAD: "update the Wing objects" (unnecessary)
 - **"WingCrossSection" and "wing cross section"**: Do not use "WCS" (or any other abbreviation). Also, never hyphenate "cross section".
 - **Abstract references**: When referring to abstractions, use lowercase and separate individual words with a space (e.g. "an airplane's wings are used to generate lift" and "the cross section of a wing typically has a streamlined shape known as an airfoil"). This is to distinguish them from code objects.
+- **"strip leading edge point"**: When spelled out in prose, do not capitalize "strip leading edge point" unless it starts a sentence.
+- **"V-tail"**: Always write "V-tail" (capital V, hyphenated) in prose. Never use "v-tail", "v tail", "Vtail", or other variants. Identifier strings keep their canonical form and are not affected: variable names like `v_tail_movement` and string literals like `"V-Tail"` stay as-is.
 - **CRITICAL**: Follow the formalized coordinate system naming conventions exactly as described in the `AXES_POINTS_AND_FRAMES.md` and `ANGLE_VECTORS_AND_TRANSFORMATIONS.md` documents when writing about or referencing in text vector-valued variables or things such as transformation and rotation matrices.
 
 ## Running CodeSpell
@@ -75,16 +77,23 @@ If a legitimate reason to violate this rule arises (a contribution must include 
 ## Miscellaneous Guidelines
 
 - Avoid abbreviations in text unless they are well-known in the context.
+- Avoid semicolons in prose. Replace them with commas, colons, or sentence breaks.
 - For subtraction, use a hyphen surrounded by spaces (e.g., "a - b").
 - For multiplication, use a lowercase x or an asterisk, both surrounded by spaces (e.g., "8 x 8 panels" or "2 * pi"). Compound units are exempt: write them without spaces (e.g., "N*m", "kg*m^2", and "N*m*s/rad").
+- For division, use a slash surrounded by spaces (e.g., "a / b").
+- For equals signs in inline equations and value descriptions, surround with spaces (e.g., "area = 0.5", not "area=0.5").
 - For approximately-equal, use a tilde surrounded by spaces (e.g., "a ~ b").
 - When referring to axes, coordinates, or planes, use lowercase letters without hyphens between coordinate letters and descriptors (e.g., "x axis", "y component", "xz plane", "z direction"). Never use uppercase letters for axis references in text.
 - Always end *.py file with an empty line.
 - Preserve existing comment structure and detail level.
-- Write comments as complete sentences ending with a period.
+- Write comments as complete sentences starting with a capital letter and ending with a period. This means actual complete sentences with a subject and verb, not fragments with punctuation stapled on.
 - Prefer comments on their own line above the code they describe.
 - Use American English spelling (e.g., "color" not "colour", "center" not "centre").
 - Write a simulation time increment as either "time step" or "step"; the two terms are interchangeable. When using the two-word form, always write it as "time step", never "timestep" or "time-step".
 - In markdown files, always include a blank line after a header line. Also precede them with a blank line, except for header lines that happen to also be the first line in their file.
 - In markdown files, do not use trailing whitespace for line breaks. Markdown already handles breaks between paragraphs, list items, and headings.
+- When writing numerals that represent float values in prose, include a trailing ".0" (e.g., "1.0" not "1", "0.0" not "0") when the context describes float-valued quantities.
+- Include a space between a numeral and its unit (e.g., "0.5 m" not "0.5m", "1.0 s" not "1.0s").
+- Capitalize the first word after a colon only if what follows is a complete sentence. Keep it lowercase for fragments, lists, or continuations.
+- Do not use asterisks for bold or italics, and do not capitalize or use all caps for emphasis in comments.
 - In markdown files, do not use hard line wrapping.

--- a/docs/WRITING_STYLE.md
+++ b/docs/WRITING_STYLE.md
@@ -16,33 +16,39 @@ Guidelines when writing comments, docstrings, and documentation for Ptera Softwa
 - **Abstract references**: When referring to abstractions, use lowercase and separate individual words with a space (e.g. "an airplane's wings are used to generate lift" and "the cross section of a wing typically has a streamlined shape known as an airfoil"). This is to distinguish them from code objects.
 - **"strip leading edge point"**: When spelled out in prose, do not capitalize "strip leading edge point" unless it starts a sentence.
 - **"V-tail"**: Always write "V-tail" (capital V, hyphenated) in prose. Never use "v-tail", "v tail", "Vtail", or other variants. Identifier strings keep their canonical form and are not affected: variable names like `v_tail_movement` and string literals like `"V-Tail"` stay as-is.
+- **"time step"**: Write a simulation time increment as either "time step" or "step"; the two terms are interchangeable. When using the two-word form, always write it as "time step", never "timestep" or "time-step".
+- **Axis references**: When referring to axes, coordinates, or planes, use lowercase letters without hyphens between coordinate letters and descriptors (e.g., "x axis", "y component", "xz plane", "z direction"). Never use uppercase letters for axis references in text.
+- **Abbreviations**: Avoid abbreviations in text unless they are well-known in the context.
 - **CRITICAL**: Follow the formalized coordinate system naming conventions exactly as described in the `AXES_POINTS_AND_FRAMES.md` and `ANGLE_VECTORS_AND_TRANSFORMATIONS.md` documents when writing about or referencing in text vector-valued variables or things such as transformation and rotation matrices.
 
-## Running CodeSpell
+## Sentence Structure
 
-CodeSpell is configured as a pre-commit hook. Run it with:
+- Write comments as complete sentences starting with a capital letter and ending with a period. This means actual complete sentences with a subject and verb, not fragments with punctuation stapled on.
+- Preserve existing comment structure and detail level.
+- Prefer comments on their own line above the code they describe.
+- Avoid semicolons in prose. Replace them with commas, colons, or sentence breaks.
+- Capitalize the first word after a colon only if what follows is a complete sentence. Keep it lowercase for fragments, lists, or continuations.
+- Use American English spelling (e.g., "color" not "colour", "center" not "centre").
+- Do not use asterisks for bold or italics, and do not capitalize or use all caps for emphasis in comments.
+- Never use doubled hyphens (`--`) as an em dash substitute. Restructure the sentence instead: split it into two sentences, use a comma, use a colon, or place the clause in parentheses. See [How to Handle Each Forbidden Case](#how-to-handle-each-forbidden-case) for the full em dash and en dash rules.
 
-```shell
-pre-commit run --all-files codespell
-```
+## Math and Numbers
 
-## Running docformatter
+- For subtraction, use a hyphen surrounded by spaces (e.g., "a - b").
+- For multiplication, use a lowercase x or an asterisk, both surrounded by spaces (e.g., "8 x 8 panels" or "2 * pi"). Compound units are exempt: write them without spaces (e.g., "N*m", "kg*m^2", and "N*m*s/rad").
+- For division, use a slash surrounded by spaces (e.g., "a / b").
+- For equals signs in inline equations and value descriptions, surround with spaces (e.g., "area = 0.5", not "area=0.5").
+- For approximately-equal, use a tilde surrounded by spaces (e.g., "a ~ b").
+- When writing tuples or vectors in prose, include a space after each comma (e.g., "(1.0, 2.0, 3.0)", not "(1.0,2.0,3.0)").
+- When writing numerals that represent float values in prose, include a trailing ".0" (e.g., "1.0" not "1", "0.0" not "0") when the context describes float-valued quantities.
+- Include a space between a numeral and its unit (e.g., "0.5 m" not "0.5m", "1.0 s" not "1.0s").
 
-docformatter is configured as a pre-commit hook. Run it with:
+## File Formatting
 
-```shell
-pre-commit run --all-files docformatter
-```
-
-## Running ascii-only
-
-ascii-only is configured as a pre-commit hook that enforces the [ASCII Only](#ascii-only) rule below. Run it with:
-
-```shell
-pre-commit run --all-files ascii-only
-```
-
-The hook reports each violation with its line, column, the offending character, its Unicode code point and name, and its UTF-8 byte sequence. The check is read-only; it never modifies files. Qt Designer `.ui` files are excluded because Qt regenerates them on every save.
+- Always end *.py files with an empty line.
+- In markdown files, always include a blank line after a header line. Also precede them with a blank line, except for header lines that happen to also be the first line in their file.
+- In markdown files, do not use trailing whitespace for line breaks. Markdown already handles breaks between paragraphs, list items, and headings.
+- In markdown files, do not use hard line wrapping.
 
 ## ASCII Only
 
@@ -74,27 +80,28 @@ The constraint is on what you author. Content quoted verbatim from external sour
 
 If a legitimate reason to violate this rule arises (a contribution must include a file with Unicode contents, or correctness requires a specific Unicode character), flag it in the PR description rather than assume.
 
-## Miscellaneous Guidelines
+## Running CodeSpell
 
-- Avoid abbreviations in text unless they are well-known in the context.
-- Avoid semicolons in prose. Replace them with commas, colons, or sentence breaks.
-- For subtraction, use a hyphen surrounded by spaces (e.g., "a - b").
-- For multiplication, use a lowercase x or an asterisk, both surrounded by spaces (e.g., "8 x 8 panels" or "2 * pi"). Compound units are exempt: write them without spaces (e.g., "N*m", "kg*m^2", and "N*m*s/rad").
-- For division, use a slash surrounded by spaces (e.g., "a / b").
-- For equals signs in inline equations and value descriptions, surround with spaces (e.g., "area = 0.5", not "area=0.5").
-- For approximately-equal, use a tilde surrounded by spaces (e.g., "a ~ b").
-- When writing tuples or vectors in prose, include a space after each comma (e.g., "(1.0, 2.0, 3.0)", not "(1.0,2.0,3.0)").
-- When referring to axes, coordinates, or planes, use lowercase letters without hyphens between coordinate letters and descriptors (e.g., "x axis", "y component", "xz plane", "z direction"). Never use uppercase letters for axis references in text.
-- Always end *.py file with an empty line.
-- Preserve existing comment structure and detail level.
-- Write comments as complete sentences starting with a capital letter and ending with a period. This means actual complete sentences with a subject and verb, not fragments with punctuation stapled on.
-- Prefer comments on their own line above the code they describe.
-- Use American English spelling (e.g., "color" not "colour", "center" not "centre").
-- Write a simulation time increment as either "time step" or "step"; the two terms are interchangeable. When using the two-word form, always write it as "time step", never "timestep" or "time-step".
-- In markdown files, always include a blank line after a header line. Also precede them with a blank line, except for header lines that happen to also be the first line in their file.
-- In markdown files, do not use trailing whitespace for line breaks. Markdown already handles breaks between paragraphs, list items, and headings.
-- When writing numerals that represent float values in prose, include a trailing ".0" (e.g., "1.0" not "1", "0.0" not "0") when the context describes float-valued quantities.
-- Include a space between a numeral and its unit (e.g., "0.5 m" not "0.5m", "1.0 s" not "1.0s").
-- Capitalize the first word after a colon only if what follows is a complete sentence. Keep it lowercase for fragments, lists, or continuations.
-- Do not use asterisks for bold or italics, and do not capitalize or use all caps for emphasis in comments.
-- In markdown files, do not use hard line wrapping.
+CodeSpell is configured as a pre-commit hook. Run it with:
+
+```shell
+pre-commit run --all-files codespell
+```
+
+## Running docformatter
+
+docformatter is configured as a pre-commit hook. Run it with:
+
+```shell
+pre-commit run --all-files docformatter
+```
+
+## Running ascii-only
+
+ascii-only is configured as a pre-commit hook that enforces the [ASCII Only](#ascii-only) rule above. Run it with:
+
+```shell
+pre-commit run --all-files ascii-only
+```
+
+The hook reports each violation with its line, column, the offending character, its Unicode code point and name, and its UTF-8 byte sequence. The check is read-only; it never modifies files. Qt Designer `.ui` files are excluded because Qt regenerates them on every save.

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -8,9 +8,9 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..")))
 
 # Mock all runtime dependencies so autodoc can import pterasoftware (via the
-# autofunction directives for save, load, and set_up_logging) without them
-# installed. This is safe because the documented functions only use stdlib
-# types in their signatures.
+# autofunction directives for save, load, and set_up_logging) without them installed.
+# This is safe because the documented functions only use stdlib types in their
+# signatures.
 autodoc_mock_imports = [
     "cmocean",
     "matplotlib",
@@ -112,24 +112,24 @@ myst_substitutions = _load_benchmark_host_info()
 # Suppress warnings that are informational or unavoidable
 suppress_warnings = [
     "toc.not_included",  # Template files not in toctree (expected)
-    "autosectionlabel.*",  # Duplicate labels from {include} directive pulling in source files
+    # Duplicate labels from {include} directive pulling in source files.
+    "autosectionlabel.*",
 ]
 
 autosectionlabel_prefix_document = True
 
-# Render every Python signature with one parameter per line. Any signature
-# longer than this threshold (in characters) wraps so that each parameter sits
-# on its own indented line with a trailing comma and the closing parenthesis on
-# its own line. A threshold of one forces this multi-line layout for every
-# signature that takes at least one parameter, which keeps long class and
-# function parameter lists readable instead of running together on one line.
+# Render every Python signature with one parameter per line. Any signature longer than
+# this threshold (in characters) wraps so that each parameter sits on its own indented
+# line with a trailing comma and the closing parenthesis on its own line. A threshold of
+# one forces this multi-line layout for every signature that takes at least one
+# parameter, which keeps long class and function parameter lists readable instead of
+# running together on one line.
 python_maximum_signature_line_length = 1
 
-# AutoAPI renders docstrings as reStructuredText, where a vector magnitude written
-# with bars (for example, "|g_E|") parses as a substitution reference. Define those
-# tokens so the reference resolves to the literal barred text instead of emitting an
-# "Undefined substitution referenced" build error, without annotating the docstrings
-# themselves.
+# AutoAPI renders docstrings as reStructuredText, where a vector magnitude written with
+# bars (for example, "|g_E|") parses as a substitution reference. Define those tokens so
+# the reference resolves to the literal barred text instead of emitting an "Undefined
+# substitution referenced" build error, without annotating the docstrings themselves.
 rst_prolog = r"""
 .. |g_E| replace:: \|g_E\|
 """
@@ -151,8 +151,8 @@ exclude_patterns = [
     "../lambert_2015_2_3__2_4",
     "../RUNNING_TESTS_AND_TYPE_CHECKS.md",
     "../examples_expected_output",
-    # Exclude source markdown files to avoid duplicate autosectionlabel labels
-    # (they are included into docs/website/ files, so we only want one copy processed)
+    # Exclude source markdown files to avoid duplicate autosectionlabel labels (they are
+    # included into docs/website/ files, so we only want one copy processed).
     "../ANGLE_VECTORS_AND_TRANSFORMATIONS.md",
     "../AXES_POINTS_AND_FRAMES.md",
     "../CLASSES_AND_IMMUTABILITY.md",
@@ -181,8 +181,8 @@ napoleon_attr_annotations = True
 html_theme = "furo"
 html_title = "PteraSoftware"
 html_favicon = "favicon/favicon.ico"
-# Drop the "View this page" source link (and the _sources/*.txt dump it points
-# to) so no page exposes a link to its underlying source.
+# Drop the "View this page" source link (and the _sources/*.txt dump it points to) so no
+# page exposes a link to its underlying source.
 html_show_sourcelink = False
 html_copy_source = False
 html_static_path = ["_static", "../_static", "Black_Text_Logo.png", "Logo.png"]

--- a/examples/aeroelastic_unsteady_first_order_deformation.py
+++ b/examples/aeroelastic_unsteady_first_order_deformation.py
@@ -7,15 +7,13 @@ main wing deforms under its own aerodynamic loads."""
 # pterasoftware" in your terminal.
 import pterasoftware as ps
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 
-# Initialize the WingCrossSection parameters.
-# Define the offsets for the spacing.
+# Initialize the WingCrossSection parameters. Define the offsets for the spacing.
 num_spanwise_panels = 2
 Lp_Wcsp_Lpp_Offsets = (0.1, 0.5, 0.0)
 cross_section_chords = [1.75, 1.75, 1.75, 1.75, 1.65, 1.55, 1.4, 1.2, 1.0]
@@ -67,12 +65,12 @@ wing_1 = ps.geometry.wing.Wing(
     chordwise_spacing="uniform",
 )
 
-# Actually generate the airplane. The V-tail is added as a second lifting surface but
-# is not split into deformation strips, because it follows prescribed rigid motion
-# rather than deforming. The solver deforms each wing from its own aerodynamic loads,
-# but only wings backed by an AeroelasticWingMovement; the V-tail uses a standard
-# WingMovement and stays rigid. Leaving the tail rigid also keeps its movement
-# definition simpler, since it then needs no per-strip cross sections.
+# Actually generate the Airplane. The V-tail is added as a second lifting surface but is
+# not split into deformation strips, because it follows prescribed rigid motion rather
+# than deforming. The solver deforms each Wing from its own aerodynamic loads, but only
+# Wings backed by an AeroelasticWingMovement. The V-tail uses a standard WingMovement
+# and stays rigid. Leaving the tail rigid also keeps its movement definition simpler,
+# since it then needs no per-strip WingCrossSections.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         wing_1,
@@ -131,12 +129,12 @@ example_airplane = ps.geometry.airplane.Airplane(
 )
 
 # The main Wing was defined to have symmetric=True, mirror_only=False, and with a
-# symmetry plane offset non-coincident with the Wing's axes yz plane. Therefore,
-# that Wing had type 5 symmetry (see the Wing class documentation for more details on
-# symmetry types). Therefore, it was actually split into two Wings, the with the
-# second Wing being a reflected version of the first. Therefore, we need to define a
-# WingMovement for this reflected Wing. To start, we'll first define the reflected
-# main wing's root and tip WingCrossSections' WingCrossSectionMovements.
+# symmetry plane offset non-coincident with the Wing's axes yz plane. Therefore, that
+# Wing had type 5 symmetry (see the Wing class documentation for more details on
+# symmetry types). Therefore, it was actually split into two Wings, the with the second
+# Wing being a reflected version of the first. Therefore, we need to define a
+# WingMovement for this reflected Wing. To start, we'll first define the reflected main
+# wing's root and tip WingCrossSections' WingCrossSectionMovements.
 
 # Define the WingCrossSectionMovement parameters.
 dephase_x = 0.0
@@ -185,10 +183,10 @@ for i in range(len(example_airplane.wings[0].wing_cross_sections)):
         reflected_wcs_movements_list.append(wcs_movement)
 
 
-# Now define the v-tail's root and tip WingCrossSections' WingCrossSectionMovements.
-# The V-tail is not an aeroelastic surface, so we use standard WingCrossSectionMovements
-# and a standard WingMovement. This keeps the V-tail mesh consistent across all time
-# steps without applying any structural deformation.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements. The
+# V-tail is not an aeroelastic surface, so we use standard WingCrossSectionMovements and
+# a standard WingMovement. This keeps the V-tail mesh consistent across all time steps
+# without applying any structural deformation.
 v_tail_root_wcs_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[2].wing_cross_sections[0],
@@ -222,7 +220,7 @@ v_tail_tip_wcs_movement = (
 dephase = 169.0
 
 # Now define the main wing's AeroelasticWingMovement, the reflected main wing's
-# AeroelasticWingMovement, and the v-tail's AeroelasticWingMovement.
+# AeroelasticWingMovement, and the V-tail's AeroelasticWingMovement.
 main_wing_movement = ps.movements.aeroelastic_wing_movement.AeroelasticWingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=main_wcs_movements_list,
@@ -311,9 +309,9 @@ example_operating_point_movement = (
 # Delete the extraneous pointer.
 del example_operating_point
 
-# Define the AeroelasticMovement. This contains the AeroelasticAirplaneMovement and
-# the OperatingPointMovement. The delta_time and num_steps must be specified
-# explicitly. With a flapping period of 1.0s, 3 cycles at dt=0.03s gives 100 steps.
+# Define the AeroelasticMovement. This contains the AeroelasticAirplaneMovement and the
+# OperatingPointMovement. The delta_time and num_steps must be specified explicitly.
+# With a flapping period of 1.0 s, 3 cycles at dt = 0.03 s gives 100 steps.
 example_movement = ps.movements.aeroelastic_movement.AeroelasticMovement(
     airplane_movements=[example_airplane_movement],
     operating_point_movement=example_operating_point_movement,
@@ -321,11 +319,10 @@ example_movement = ps.movements.aeroelastic_movement.AeroelasticMovement(
     num_steps=100,
 )
 
-# Define the AeroelasticUnsteadyProblem.
-# The deformation parameters are set here.
-# The wing_density, spring_constant_rad, and damping_constant_rad are the
-# primary parameters you should expect to change. The step_discards parameter
-# is more for managing the UVLM solver's inconsistent startup effects.
+# Define the AeroelasticUnsteadyProblem. The deformation parameters are set here. The
+# wing_density, spring_constant_rad, and damping_constant_rad are the primary parameters
+# you should expect to change. The step_discards parameter is more for managing the UVLM
+# solver's inconsistent startup effects.
 example_problem = ps.problems.AeroelasticUnsteadyProblem(
     movement=example_movement,
     wing_density=6.0,

--- a/examples/aeroelastic_unsteady_first_order_deformation_mixed_wings.py
+++ b/examples/aeroelastic_unsteady_first_order_deformation_mixed_wings.py
@@ -11,8 +11,7 @@ airplane.
 
 import pterasoftware as ps
 
-# Initialize the WingCrossSection parameters.
-# Define the offsets for the spacing.
+# Initialize the WingCrossSection parameters. Define the offsets for the spacing.
 num_spanwise_panels = 2
 Lp_Wcsp_Lpp_Offsets = (0.1, 0.5, 0.0)
 cross_section_chords = [1.75, 1.75, 1.75, 1.75, 1.65, 1.55, 1.4, 1.2, 1.0]
@@ -64,12 +63,12 @@ wing_1 = ps.geometry.wing.Wing(
     chordwise_spacing="uniform",
 )
 
-# Actually generate the airplane. The V-tail is added as a second lifting surface but
-# is not split into deformation strips, because it follows prescribed rigid motion
-# rather than deforming. The solver deforms each wing from its own aerodynamic loads,
-# but only wings backed by an AeroelasticWingMovement; wings backed by a standard
-# WingMovement stay rigid. Leaving the tail rigid also keeps its movement definition
-# simpler, since it then needs no per-strip cross sections.
+# Actually generate the airplane. The V-tail is added as a second lifting surface but is
+# not split into deformation strips, because it follows prescribed rigid motion rather
+# than deforming. The solver deforms each wing from its own aerodynamic loads, but only
+# wings backed by an AeroelasticWingMovement. Wings backed by a standard WingMovement
+# stay rigid. Leaving the tail rigid also keeps its movement definition simpler, since
+# it then needs no per-strip wing cross sections.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         wing_1,
@@ -128,12 +127,12 @@ example_airplane = ps.geometry.airplane.Airplane(
 )
 
 # The main Wing was defined to have symmetric=True, mirror_only=False, and with a
-# symmetry plane offset non-coincident with the Wing's axes yz plane. Therefore,
-# that Wing had type 5 symmetry (see the Wing class documentation for more details on
-# symmetry types). Therefore, it was actually split into two Wings, the with the
-# second Wing being a reflected version of the first. Therefore, we need to define a
-# WingMovement for this reflected Wing. To start, we'll first define the reflected
-# main wing's root and tip WingCrossSections' WingCrossSectionMovements.
+# symmetry plane offset non-coincident with the Wing's axes yz plane. Therefore, that
+# Wing had type 5 symmetry (see the Wing class documentation for more details on
+# symmetry types). Therefore, it was actually split into two Wings, the with the second
+# Wing being a reflected version of the first. Therefore, we need to define a
+# WingMovement for this reflected Wing. To start, we'll first define the reflected main
+# wing's root and tip WingCrossSections' WingCrossSectionMovements.
 
 # Define the WingCrossSectionMovement parameters.
 dephase_x = 0.0
@@ -216,10 +215,10 @@ for i in range(len(example_airplane.wings[1].wing_cross_sections)):
     reflected_wcs_movements_list.append(reflected_wcs_movement)
 
 
-# Now define the v-tail's root and tip WingCrossSections' WingCrossSectionMovements.
-# The V-tail is not an aeroelastic surface, so we use standard WingCrossSectionMovements
-# and a standard WingMovement. This keeps the V-tail mesh consistent across all time
-# steps without applying any structural deformation.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements. The
+# V-tail is not an aeroelastic surface, so we use standard WingCrossSectionMovements and
+# a standard WingMovement. This keeps the V-tail mesh consistent across all time steps
+# without applying any structural deformation.
 v_tail_root_wcs_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[2].wing_cross_sections[0],
@@ -252,8 +251,8 @@ v_tail_tip_wcs_movement = (
 # This dephase parameter is used to make the Wing start in a flat position.
 dephase = 169.0
 
-# Now define the main wing's AeroelasticWingMovement, the reflected main wing's
-# standard WingMovement (no aeroelastic deformation), and the v-tail's WingMovement.
+# Now define the main Wing's AeroelasticWingMovement, the reflected main Wing's standard
+# WingMovement (no aeroelastic deformation), and the V-tail's WingMovement.
 main_wing_movement = ps.movements.aeroelastic_wing_movement.AeroelasticWingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=main_wcs_movements_list,
@@ -343,9 +342,9 @@ example_operating_point_movement = (
 # Delete the extraneous pointer.
 del example_operating_point
 
-# Define the AeroelasticMovement. This contains the AeroelasticAirplaneMovement and
-# the OperatingPointMovement. The delta_time and num_steps must be specified
-# explicitly. With a flapping period of 1.0s, 3 cycles at dt=0.03s gives 100 steps.
+# Define the AeroelasticMovement. This contains the AeroelasticAirplaneMovement and the
+# OperatingPointMovement. The delta_time and num_steps must be specified explicitly.
+# With a flapping period of 1.0 s, 3 cycles at dt = 0.03 s gives 100 steps.
 example_movement = ps.movements.aeroelastic_movement.AeroelasticMovement(
     airplane_movements=[example_airplane_movement],
     operating_point_movement=example_operating_point_movement,
@@ -353,11 +352,10 @@ example_movement = ps.movements.aeroelastic_movement.AeroelasticMovement(
     num_steps=100,
 )
 
-# Define the AeroelasticUnsteadyProblem.
-# The deformation parameters are set here.
-# The wing_density, spring_constant_rad, and damping_constant_rad are the
-# primary parameters you should expect to change. The step_discards parameter
-# is more for managing the UVLM solver's inconsistent startup effects.
+# Define the AeroelasticUnsteadyProblem. The deformation parameters are set here. The
+# wing_density, spring_constant_rad, and damping_constant_rad are the primary parameters
+# you should expect to change. The step_discards parameter is more for managing the UVLM
+# solver's inconsistent startup effects.
 example_problem = ps.problems.AeroelasticUnsteadyProblem(
     movement=example_movement,
     wing_density=6.0,

--- a/examples/aeroelastic_unsteady_first_order_plotting.py
+++ b/examples/aeroelastic_unsteady_first_order_plotting.py
@@ -26,8 +26,8 @@ FLAP_AMPLITUDE = 15.0
 FLAP_PERIOD = 1.0
 FLAP_PHASE = 169.0
 
-# Populate exactly ONE of these lists to sweep that parameter while holding the
-# others at their defaults. Leave the other two as empty lists.
+# Populate exactly ONE of these lists to sweep that parameter while holding the others
+# at their defaults. Leave the other two as empty lists.
 K_VALUES_RAD: list[float] = [100.0, 1000.0, 10000.0, 20000.0]
 B_VALUES_RAD: list[float] = []
 DENSITY_VALUES: list[float] = []
@@ -359,9 +359,9 @@ for val in sweep_values:
     deformationAnglesYRad_Wcsp_to_Wcs_ixyz, problem = run_aeroelastic(
         **{sweep_kwarg: val}
     )
-    # Extract the wing-tip torsional angle from every time series entry (the first
-    # entry is the pre-solve seed state, and each later entry is one time step's
-    # state), converting it from radians to degrees.
+    # Extract the wing-tip torsional angle from every time series entry (the first entry
+    # is the pre-solve seed state, and each later entry is one time step's state),
+    # converting it from radians to degrees.
     tip_twist = np.rad2deg(
         np.array(deformationAnglesYRad_Wcsp_to_Wcs_ixyz)[:, TIP_INDEX]
     ).tolist()

--- a/examples/analyze_steady_trim.py
+++ b/examples/analyze_steady_trim.py
@@ -70,10 +70,10 @@ trim_airplane = ps.geometry.airplane.Airplane(
     weight=250,
 )
 
-# Create an OperatingPoint. We must specify an external thrust because this Airplane
-# is not flapping, so it won't generate thrust via its Wings. Therefore, to balance
-# induced drag, we need an external thrust force which could be due to a propeller or
-# other type of engine.
+# Create an OperatingPoint. We must specify an external thrust because this Airplane is
+# not flapping, so it won't generate thrust via its Wings. Therefore, to balance induced
+# drag, we need an external thrust force which could be due to a propeller or other type
+# of engine.
 trim_operating_point = ps.operating_point.OperatingPoint(externalFX_W=5)
 
 # Construct a SteadyProblem containing the Airplane and OperatingPoint
@@ -81,9 +81,9 @@ trim_problem = ps.problems.SteadyProblem(
     airplanes=[trim_airplane], operating_point=trim_operating_point
 )
 
-# Call the analyze_steady_trim function to search for a trim condition (thrust
-# balances drag, weight balances lift, and all moments are close to zero) within a
-# certain set of bounds.
+# Call the analyze_steady_trim function to search for a trim condition (thrust balances
+# drag, weight balances lift, and all moments are close to zero) within a certain set of
+# bounds.
 trim_conditions = ps.trim.analyze_steady_trim(
     problem=trim_problem,
     solver_type="steady horseshoe vortex lattice method",

--- a/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.py
+++ b/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.py
@@ -20,19 +20,18 @@ import pterasoftware as ps
 # the console alongside progress bars instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_solver.log"))
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 #
 # This is a flapping-wing demonstration airframe: a cambered main wing that flaps
 # symmetrically (defined further below, a 15 degree amplitude at 1 Hz) plus a tail.
 # Unlike the glider example, this airframe is not tuned for static stability or trim. It
-# exists to exercise the strongly coupled free-flight solver under the large, oscillatory
-# loads that flapping produces, so the trajectory is a driven flapping flight rather than
-# a settled equilibrium.
+# exists to exercise the strongly coupled free-flight solver under the large,
+# oscillatory loads that flapping produces, so the trajectory is a driven flapping
+# flight rather than a settled equilibrium.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -163,12 +162,12 @@ main_wing_tip_wing_cross_section_movement = (
 )
 
 # The main Wing was defined to have symmetric=True, mirror_only=False, and with a
-# symmetry plane offset non coincident with the Wing's axes yz plane. Therefore,
-# that Wing had type 5 symmetry (see the Wing class documentation for more details on
-# symmetry types). Therefore, it was actually split into two Wings, the with the
-# second Wing being a reflected version of the first. Therefore, we need to define a
-# WingMovement for this reflected Wing. To start, we'll first define the reflected
-# main wing's root and tip WingCrossSections' WingCrossSectionMovements.
+# symmetry plane offset non coincident with the Wing's axes yz plane. Therefore, that
+# Wing had type 5 symmetry (see the Wing class documentation for more details on
+# symmetry types). Therefore, it was actually split into two Wings, the with the second
+# Wing being a reflected version of the first. Therefore, we need to define a
+# WingMovement for this reflected Wing. To start, we'll first define the reflected main
+# wing's root and tip WingCrossSections' WingCrossSectionMovements.
 reflected_main_wing_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[1].wing_cross_sections[0],
@@ -303,9 +302,9 @@ del v_tail_movement
 
 # Define a new OperatingPoint describing the initial flight condition. The initial body
 # orientation (angles_E_to_BP1_izyx) pitches the airplane nose up by the angle of attack
-# with zero sideslip, which places the initial velocity along the horizontal Earth x axis
-# at the start of free flight. No external thrust is applied (externalFX_W=0.0); in free
-# flight the dynamics never apply externalFX_W, and propulsion here comes from the
+# with zero sideslip, which places the initial velocity along the horizontal Earth x
+# axis at the start of free flight. No external thrust is applied (externalFX_W=0.0); in
+# free flight the dynamics never apply externalFX_W, and propulsion here comes from the
 # flapping motion rather than an external force. Standard gravity is set explicitly via
 # g_E (the default is no gravitational field), while the zero initial body rates
 # (omegas_BP1__E) are left at their default.
@@ -333,9 +332,9 @@ operating_point_movement = (
 del example_operating_point
 
 # Define the FreeFlightMovement. This contains the AirplaneMovement and the
-# FreeFlightOperatingPointMovement. The airplane first holds its initial flight condition
-# for prescribed_num_steps time steps so the wake can develop, then the solver releases
-# the rigid body dynamics for the remaining free_num_steps time steps.
+# FreeFlightOperatingPointMovement. The airplane first holds its initial flight
+# condition for prescribed_num_steps time steps so the wake can develop, then the solver
+# releases the rigid body dynamics for the remaining free_num_steps time steps.
 movement = ps.movements.free_flight_movement.FreeFlightMovement(
     airplane_movements=[airplane_movement],
     operating_point_movement=operating_point_movement,
@@ -349,15 +348,15 @@ del airplane_movement
 del operating_point_movement
 
 # Define the FreeFlightUnsteadyProblem. The inertia matrix holds representative mass
-# properties reused from the glider example; this airframe is a coupling demonstration and
-# is not separately tuned or verified for static stability. It is expressed in the first
-# Airplane's body axes relative to the first Airplane's center of gravity, which is at the
-# geometry origin. The off-diagonal terms are the body-axes products of inertia. The mass
-# equals the Airplane's weight (420.0 N) divided by the gravitational acceleration
-# magnitude (9.80665 m/s^2), which keeps the weight, mass, and gravity consistent; the
-# solver applies the gravitational force as mass * g_E. No external loads are applied
-# (external_loads_fn=None), so the airplane is driven only by its flapping aerodynamics,
-# gravity, and inertia.
+# properties reused from the glider example; this airframe is a coupling demonstration
+# and is not separately tuned or verified for static stability. It is expressed in the
+# first Airplane's body axes relative to the first Airplane's center of gravity, which
+# is at the geometry origin. The off-diagonal terms are the body-axes products of
+# inertia. The mass equals the Airplane's weight (420.0 N) divided by the gravitational
+# acceleration magnitude (9.80665 m/s^2), which keeps the weight, mass, and gravity
+# consistent; the solver applies the gravitational force as mass * g_E. No external
+# loads are applied (external_loads_fn=None), so the airplane is driven only by its
+# flapping aerodynamics, gravity, and inertia.
 example_problem = ps.problems.FreeFlightUnsteadyProblem(
     movement=movement,
     mass=420.0 / 9.80665,
@@ -403,8 +402,8 @@ ps.output.log_results(solver=loaded_solver)
 
 # Call the draw function on the loaded solver. For a free flight solver, the geometry is
 # drawn in Earth axes at the final time step's true flight pose, so the airplane appears
-# where and how it ended up after the final time step. Press any key to close the plotter
-# after it draws the output.
+# where and how it ended up after the final time step. Press any key to close the
+# plotter after it draws the output.
 ps.output.draw(
     solver=loaded_solver,
     scalar_type="lift",

--- a/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.py
+++ b/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_flapping.py
@@ -195,7 +195,7 @@ reflected_main_wing_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the v tail's root and tip WingCrossSections' WingCrossSectionMovements.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements.
 v_tail_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[2].wing_cross_sections[0],
@@ -224,7 +224,7 @@ v_tail_tip_wing_cross_section_movement = (
 )
 
 # Now define the main wing's WingMovement, the reflected main wing's WingMovement and
-# the v tail's WingMovement.
+# the V-tail's WingMovement.
 main_wing_movement = ps.movements.wing_movement.WingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=[

--- a/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.py
+++ b/examples/free_flight_unsteady_ring_vortex_lattice_method_solver_glider.py
@@ -20,12 +20,11 @@ import pterasoftware as ps
 # the console alongside progress bars instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_solver.log"))
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 #
 # This is a simple glider: a cambered main wing, a symmetric horizontal stabilizer set
 # at a negative incidence relative to the main wing, and a single vertical stabilizer.
@@ -182,9 +181,9 @@ example_airplane = ps.geometry.airplane.Airplane(
 # Now define each Wing's WingMovements (and the WingCrossSectionMovements they contain).
 # The main Wing was defined with symmetric=True, mirror_only=False, and a symmetry plane
 # coincident with its axes' xz-plane, giving it type 4 symmetry (see the Wing class
-# documentation for more details on symmetry types), so it stays a single Wing and is not
-# split into a separate reflected Wing. The Airplane therefore has exactly three Wings,
-# and we need one WingMovement per Wing.
+# documentation for more details on symmetry types), so it stays a single Wing and is
+# not split into a separate reflected Wing. The Airplane therefore has exactly three
+# Wings, and we need one WingMovement per Wing.
 #
 # This is a free flight of a rigid glider, so there is no prescribed flapping or
 # deformation: every prescribed-motion amplitude is left at its zero default. The only
@@ -220,8 +219,8 @@ del wing_movements
 # Define a new OperatingPoint describing the trimmed gliding condition. The speed and
 # angle of attack are the trimmed glide found for this airframe. The initial body
 # orientation (angles_E_to_BP1_izyx) pitches the airplane nose up by the angle of attack
-# with zero sideslip, which places the trim velocity along the horizontal Earth x axis at
-# the start of free flight. The glider flies an unpowered glide: externalFX_W must be
+# with zero sideslip, which places the trim velocity along the horizontal Earth x axis
+# at the start of free flight. The glider flies an unpowered glide: externalFX_W must be
 # zero in free flight (the dynamics never apply it), and thrust would instead be modeled
 # with FreeFlightUnsteadyProblem's external_loads_fn. Standard gravity is set explicitly
 # via g_E (the default is no gravitational field), while the zero initial body rates
@@ -271,9 +270,9 @@ del operating_point_movement
 # which is at the geometry origin. The off-diagonal terms are the body-axes products of
 # inertia. The mass equals the Airplane's weight (420.0 N) divided by the gravitational
 # acceleration magnitude (9.80665 m/s^2), which keeps the weight, mass, and gravity
-# consistent; the solver applies the gravitational force as mass * g_E. No external loads
-# are applied (external_loads_fn=None), so the glider flies an unpowered glide driven only
-# by its aerodynamics, gravity, and inertia.
+# consistent; the solver applies the gravitational force as mass * g_E. No external
+# loads are applied (external_loads_fn=None), so the glider flies an unpowered glide
+# driven only by its aerodynamics, gravity, and inertia.
 example_problem = ps.problems.FreeFlightUnsteadyProblem(
     movement=movement,
     mass=420.0 / 9.80665,

--- a/examples/steady_convergence.py
+++ b/examples/steady_convergence.py
@@ -13,8 +13,8 @@ import pterasoftware as ps
 # the console instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_convergence.log"))
 
-# Create two Airplanes. Read through the solver and formation examples for
-# more details on creating these Airplanes.
+# Create two Airplanes. Read through the solver and formation examples for more details
+# on creating these Airplanes.
 leading_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -162,8 +162,8 @@ del trailing_airplane
 del operating_point
 
 # Run the steady convergence analysis. This will run several simulations, modifying
-# average Panel aspect ratio and number of chordwise Panels with each iteration. Once
-# it detects that each load coefficient has stopped changing by more than the relative
+# average Panel aspect ratio and number of chordwise Panels with each iteration. Once it
+# detects that each load coefficient has stopped changing by more than the relative
 # tolerance (rtol) plus the absolute tolerance (atol) between successive meshes, it will
 # return the parameters it found to result in a converged solution. See the
 # analyze_steady_convergence function docstring for more details.

--- a/examples/steady_horseshoe_vortex_lattice_method_solver.py
+++ b/examples/steady_horseshoe_vortex_lattice_method_solver.py
@@ -15,12 +15,11 @@ import pterasoftware as ps
 # the console alongside progress bars instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_solver.log"))
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -140,8 +139,8 @@ del example_airplane
 del example_operating_point
 
 # Define a new solver. The available solver classes are
-# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver,
-# and UnsteadyRingVortexLatticeMethodSolver. We'll create a
+# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver, and
+# UnsteadyRingVortexLatticeMethodSolver. We'll create a
 # SteadyHorseshoeVortexLatticeMethodSolver, which requires a SteadyProblem.
 example_solver = (
     ps.steady_horseshoe_vortex_lattice_method.SteadyHorseshoeVortexLatticeMethodSolver(

--- a/examples/steady_ring_vortex_lattice_method_solver.py
+++ b/examples/steady_ring_vortex_lattice_method_solver.py
@@ -15,12 +15,11 @@ import pterasoftware as ps
 # the console alongside progress bars instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_solver.log"))
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -185,8 +184,8 @@ del example_airplane
 del example_operating_point
 
 # Define a new solver. The available solver classes are
-# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver,
-# and UnsteadyRingVortexLatticeMethodSolver. We'll create a
+# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver, and
+# UnsteadyRingVortexLatticeMethodSolver. We'll create a
 # SteadyRingVortexLatticeMethodSolver, which requires a SteadyProblem.
 example_solver = (
     ps.steady_ring_vortex_lattice_method.SteadyRingVortexLatticeMethodSolver(

--- a/examples/steady_ring_vortex_lattice_method_solver_non_trapezoidal.py
+++ b/examples/steady_ring_vortex_lattice_method_solver_non_trapezoidal.py
@@ -32,8 +32,8 @@ span = 6.0
 num_edge_samples = 100
 ys_Wn_Ler = np.linspace(0.0, span, num_edge_samples)
 
-# An elliptical chord distribution tapers smoothly from the root chord to a point at
-# the tip.
+# An elliptical chord distribution tapers smoothly from the root chord to a point at the
+# tip.
 chords = root_chord * np.sqrt(1.0 - (ys_Wn_Ler / span) ** 2)
 
 # Keep the quarter chord line straight along the span, which is what makes the planform
@@ -112,8 +112,8 @@ del example_airplane
 del example_operating_point
 
 # Define a new solver. The available solver classes are
-# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver,
-# and UnsteadyRingVortexLatticeMethodSolver. We'll create a
+# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver, and
+# UnsteadyRingVortexLatticeMethodSolver. We'll create a
 # SteadyRingVortexLatticeMethodSolver, which requires a SteadyProblem.
 example_solver = (
     ps.steady_ring_vortex_lattice_method.SteadyRingVortexLatticeMethodSolver(

--- a/examples/unsteady_ring_vortex_lattice_method_solver_static.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_static.py
@@ -149,7 +149,7 @@ main_wing_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the v tail's root and tip WingCrossSections' WingCrossSectionMovements.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements.
 v_tail_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[1].wing_cross_sections[0],
@@ -177,7 +177,7 @@ v_tail_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the main wing's WingMovement and the v tail's WingMovement.
+# Now define the main Wing's WingMovement and the V-tail's WingMovement.
 main_wing_movement = ps.movements.wing_movement.WingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=[

--- a/examples/unsteady_ring_vortex_lattice_method_solver_static.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_static.py
@@ -15,12 +15,11 @@ import pterasoftware as ps
 # the console alongside progress bars instead, omit the handler argument.
 ps.set_up_logging(level="Info", handler=logging.FileHandler("example_solver.log"))
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -270,8 +269,8 @@ example_problem = ps.problems.UnsteadyProblem(
 )
 
 # Define a new solver. The available solver classes are
-# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver,
-# and UnsteadyRingVortexLatticeMethodSolver. We'll create an
+# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver, and
+# UnsteadyRingVortexLatticeMethodSolver. We'll create an
 # UnsteadyRingVortexLatticeMethodSolver, which requires a UnsteadyProblem.
 example_solver = (
     ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(
@@ -309,9 +308,9 @@ ps.output.draw(
     save=True,
 )
 
-# Call the animate function on the loaded solver. This produces a GIF of the wake being shed.
-# The GIF is saved in the same directory as this script. Press any key, after orienting
-# the view, to begin the animation.
+# Call the animate function on the loaded solver. This produces a GIF of the wake being
+# shed. The GIF is saved in the same directory as this script. Press any key, after
+# orienting the view, to begin the animation.
 ps.output.animate(
     unsteady_solver=loaded_solver,
     scalar_type="lift",

--- a/examples/unsteady_ring_vortex_lattice_method_solver_static_ground_effect.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_static_ground_effect.py
@@ -149,7 +149,7 @@ main_wing_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the v tail's root and tip WingCrossSections' WingCrossSectionMovements.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements.
 v_tail_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[1].wing_cross_sections[0],
@@ -177,7 +177,7 @@ v_tail_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the main wing's WingMovement and the v tail's WingMovement.
+# Now define the main Wing's WingMovement and the V-tail's WingMovement.
 main_wing_movement = ps.movements.wing_movement.WingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=[

--- a/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
@@ -6,12 +6,11 @@ custom flapping-wing airplane."""
 # pterasoftware" in your terminal.
 import pterasoftware as ps
 
-# Create an Airplane with our custom geometry. I am going to declare every parameter
-# for Airplane, even though most of them have usable default values. This is for
-# educational purposes, but keep in mind that it makes the code much longer than it
-# needs to be. For details about each parameter, read the detailed class docstring.
-# The same caveats apply to the other classes, methods, and functions I call in this
-# script.
+# Create an Airplane with our custom geometry. I am going to declare every parameter for
+# Airplane, even though most of them have usable default values. This is for educational
+# purposes, but keep in mind that it makes the code much longer than it needs to be. For
+# details about each parameter, read the detailed class docstring. The same caveats
+# apply to the other classes, methods, and functions I call in this script.
 example_airplane = ps.geometry.airplane.Airplane(
     wings=[
         ps.geometry.wing.Wing(
@@ -142,12 +141,12 @@ main_wing_tip_wing_cross_section_movement = (
 )
 
 # The main Wing was defined to have symmetric=True, mirror_only=False, and with a
-# symmetry plane offset non coincident with the Wing's axes yz plane. Therefore,
-# that Wing had type 5 symmetry (see the Wing class documentation for more details on
-# symmetry types). Therefore, it was actually split into two Wings, the with the
-# second Wing being a reflected version of the first. Therefore, we need to define a
-# WingMovement for this reflected Wing. To start, we'll first define the reflected
-# main wing's root and tip WingCrossSections' WingCrossSectionMovements.
+# symmetry plane offset non coincident with the Wing's axes yz plane. Therefore, that
+# Wing had type 5 symmetry (see the Wing class documentation for more details on
+# symmetry types). Therefore, it was actually split into two Wings, the with the second
+# Wing being a reflected version of the first. Therefore, we need to define a
+# WingMovement for this reflected Wing. To start, we'll first define the reflected main
+# wing's root and tip WingCrossSections' WingCrossSectionMovements.
 reflected_main_wing_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[1].wing_cross_sections[0],
@@ -310,8 +309,8 @@ example_problem = ps.problems.UnsteadyProblem(
 )
 
 # Define a new solver. The available solver classes are
-# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver,
-# and UnsteadyRingVortexLatticeMethodSolver. We'll create an
+# SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver, and
+# UnsteadyRingVortexLatticeMethodSolver. We'll create an
 # UnsteadyRingVortexLatticeMethodSolver, which requires a UnsteadyProblem.
 example_solver = (
     ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver(

--- a/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_variable.py
@@ -174,7 +174,7 @@ reflected_main_wing_tip_wing_cross_section_movement = (
     )
 )
 
-# Now define the v tail's root and tip WingCrossSections' WingCrossSectionMovements.
+# Now define the V-tail's root and tip WingCrossSections' WingCrossSectionMovements.
 v_tail_root_wing_cross_section_movement = (
     ps.movements.wing_cross_section_movement.WingCrossSectionMovement(
         base_wing_cross_section=example_airplane.wings[2].wing_cross_sections[0],
@@ -203,7 +203,7 @@ v_tail_tip_wing_cross_section_movement = (
 )
 
 # Now define the main wing's WingMovement, the reflected main wing's WingMovement and
-# the v tail's WingMovement.
+# the V-tail's WingMovement.
 main_wing_movement = ps.movements.wing_movement.WingMovement(
     base_wing=example_airplane.wings[0],
     wing_cross_section_movements=[

--- a/examples/unsteady_ring_vortex_lattice_method_solver_variable_formation.py
+++ b/examples/unsteady_ring_vortex_lattice_method_solver_variable_formation.py
@@ -275,8 +275,8 @@ example_operating_point_movement = (
     )
 )
 
-# Delete the extraneous pointers to the Airplanes and the OperatingPoint, as these
-# are now accessible within their respective movement objects.
+# Delete the extraneous pointers to the Airplanes and the OperatingPoint, as these are
+# now accessible within their respective movement objects.
 del lead_airplane
 del trailing_right_airplane
 del trailing_left_airplane

--- a/examples/unsteady_static_convergence.py
+++ b/examples/unsteady_static_convergence.py
@@ -77,8 +77,7 @@ example_operating_point_movement = (
     )
 )
 
-# Create a Movement using the AirplaneMovement and OperatingPointMovement
-# objects.
+# Create a Movement using the AirplaneMovement and OperatingPointMovement objects.
 example_movement = ps.movements.movement.Movement(
     airplane_movements=[example_airplane_movement],
     operating_point_movement=example_operating_point_movement,

--- a/examples/unsteady_variable_convergence.py
+++ b/examples/unsteady_variable_convergence.py
@@ -101,8 +101,7 @@ example_operating_point_movement = (
     )
 )
 
-# Create a Movement using the AirplaneMovement and OperatingPointMovement
-# objects.
+# Create a Movement using the AirplaneMovement and OperatingPointMovement objects.
 example_movement = ps.movements.movement.Movement(
     airplane_movements=[example_airplane_movement],
     operating_point_movement=example_operating_point_movement,

--- a/pterasoftware/_aerodynamics_functions.py
+++ b/pterasoftware/_aerodynamics_functions.py
@@ -40,12 +40,12 @@ _four_lamb = 4.0 * _lamb
 
 # The smallest number of evaluations worth handing one thread of a parallel kernel
 # launch, where one evaluation is computing one line vortex's induced velocity at one
-# point. Sized so a thread's share of the work takes several times longer than the
-# cost of rallying the thread pool: waking its threads, splitting the work, and
-# waiting for the slowest member to finish. A launch too small to clear one grain
-# would spend more time rallying than computing, so it runs on a single thread. The
-# grain is expressed as work per thread rather than as a core count, so it transfers
-# across machines of different sizes without per-machine calibration.
+# point. Sized so a thread's share of the work takes several times longer than the cost
+# of rallying the thread pool: waking its threads, splitting the work, and waiting for
+# the slowest member to finish. A launch too small to clear one grain would spend more
+# time rallying than computing, so it runs on a single thread. The grain is expressed as
+# work per thread rather than as a core count, so it transfers across machines of
+# different sizes without per-machine calibration.
 _GRAIN = 10_000
 
 
@@ -91,12 +91,12 @@ def _threads_for_launch(num_points: int, num_vortices: int) -> int:
 
     # The kernels parallelize over points alone, summing each point's vortices in a
     # serial inner loop, so a launch can never use more threads than it has points.
-    # Handing it more would leave the surplus threads with no iteration to run while they
-    # still pay the parallel region's entry and its closing barrier, which is the very
-    # overhead this dispatch exists to avoid. The cap binds when a launch carries more
-    # than one grain of vortices and fewer points than the ceiling, as an unsteady run's
-    # wake influences do on a small mesh once the wake grows, and as streamline launches
-    # do generally.
+    # Handing it more would leave the surplus threads with no iteration to run while
+    # they still pay the parallel region's entry and its closing barrier, which is the
+    # very overhead this dispatch exists to avoid. The cap binds when a launch carries
+    # more than one grain of vortices and fewer points than the ceiling, as an unsteady
+    # run's wake influences do on a small mesh once the wake grows, and as streamline
+    # launches do generally.
     return min(max(evaluations // _GRAIN, 1), max(num_points, 1))
 
 
@@ -222,8 +222,8 @@ def collapsed_velocities_from_ring_vortices(
 
     stackVInd_GP1__E = np.zeros((stackP_GP1_CgP1.shape[0], 3), dtype=float)
 
-    # Read the current thread mask so the dispatch honors any cap the user has set,
-    # and restore it once the kernel launches finish.
+    # Read the current thread mask so the dispatch honors any cap the user has set, and
+    # restore it once the kernel launches finish.
     external_cap = numba.get_num_threads()
     numba.set_num_threads(
         min(
@@ -320,8 +320,8 @@ def collapsed_velocities_from_ring_vortices_chordwise_segments(
 
     stackVInd_GP1__E = np.zeros((stackP_GP1_CgP1.shape[0], 3), dtype=float)
 
-    # Read the current thread mask so the dispatch honors any cap the user has set,
-    # and restore it once the kernel launches finish.
+    # Read the current thread mask so the dispatch honors any cap the user has set, and
+    # restore it once the kernel launches finish.
     external_cap = numba.get_num_threads()
     numba.set_num_threads(
         min(
@@ -422,8 +422,8 @@ def expanded_velocities_from_ring_vortices(
         (stackP_GP1_CgP1.shape[0], strengths.shape[0], 3), dtype=float
     )
 
-    # Read the current thread mask so the dispatch honors any cap the user has set,
-    # and restore it once the kernel launches finish.
+    # Read the current thread mask so the dispatch honors any cap the user has set, and
+    # restore it once the kernel launches finish.
     external_cap = numba.get_num_threads()
     numba.set_num_threads(
         min(
@@ -518,8 +518,8 @@ def collapsed_velocities_from_horseshoe_vortices(
 
     stackVInd_GP1__E = np.zeros((stackP_GP1_CgP1.shape[0], 3), dtype=float)
 
-    # Read the current thread mask so the dispatch honors any cap the user has set,
-    # and restore it once the kernel launches finish.
+    # Read the current thread mask so the dispatch honors any cap the user has set, and
+    # restore it once the kernel launches finish.
     external_cap = numba.get_num_threads()
     numba.set_num_threads(
         min(
@@ -616,8 +616,8 @@ def expanded_velocities_from_horseshoe_vortices(
         (stackP_GP1_CgP1.shape[0], strengths.shape[0], 3), dtype=float
     )
 
-    # Read the current thread mask so the dispatch honors any cap the user has set,
-    # and restore it once the kernel launches finish.
+    # Read the current thread mask so the dispatch honors any cap the user has set, and
+    # restore it once the kernel launches finish.
     external_cap = numba.get_num_threads()
     numba.set_num_threads(
         min(
@@ -711,8 +711,8 @@ def _collapsed_velocities_from_line_vortices(
     num_vortices = stackSlvp_GP1_CgP1.shape[0]
     num_points = stackP_GP1_CgP1.shape[0]
 
-    # Initialize an empty array, which we will fill with the induced velocities (in
-    # the first Airplane's geometry axes, observed from the Earth frame).
+    # Initialize an empty array, which we will fill with the induced velocities (in the
+    # first Airplane's geometry axes, observed from the Earth frame).
     stackVInd_GP1__E = np.zeros((num_points, 3))
 
     # If the user didn't specify any ages, set the age of each line vortex to 0.0
@@ -756,8 +756,8 @@ def _collapsed_velocities_from_line_vortices(
         # Pre compute r0 * _tol outside the parallel loop.
         vortex_r0_times_tol[vortex_id] = r0 * _tol
 
-        # Calculate the radius of the line vortex's core squared. The initial core radius
-        # ensures nonzero regularization even for bound vortices with zero age.
+        # Calculate the radius of the line vortex's core squared. The initial core
+        # radius ensures nonzero regularization even for bound vortices with zero age.
         r_c_sq = r_c0**2.0 + _four_lamb * (nu + _squire * abs(strength)) * age
 
         vortex_c1[vortex_id] = strength / _four_pi
@@ -781,8 +781,8 @@ def _collapsed_velocities_from_line_vortices(
             Slvp_GP1_CgP1 = stackSlvp_GP1_CgP1[vortex_id]
             Elvp_GP1_CgP1 = stackElvp_GP1_CgP1[vortex_id]
 
-            # The r1_GP1 vector goes from P_GP1_CgP1 to the line vortex's start point (in
-            # the first Airplane's geometry axes).
+            # The r1_GP1 vector goes from P_GP1_CgP1 to the line vortex's start point
+            # (in the first Airplane's geometry axes).
             r1X_GP1 = Slvp_GP1_CgP1[0] - P_GP1_CgP1[0]
             r1Y_GP1 = Slvp_GP1_CgP1[1] - P_GP1_CgP1[1]
             r1Z_GP1 = Slvp_GP1_CgP1[2] - P_GP1_CgP1[2]
@@ -972,8 +972,8 @@ def _expanded_velocities_from_line_vortices(
         # Pre compute r0 * _tol outside the parallel loop.
         vortex_r0_times_tol[vortex_id] = r0 * _tol
 
-        # Calculate the radius of the line vortex's core squared. The initial core radius
-        # ensures nonzero regularization even for bound vortices with zero age.
+        # Calculate the radius of the line vortex's core squared. The initial core
+        # radius ensures nonzero regularization even for bound vortices with zero age.
         r_c_sq = r_c0**2.0 + _four_lamb * (nu + _squire * abs(strength)) * age
 
         vortex_c1[vortex_id] = strength / _four_pi
@@ -997,8 +997,8 @@ def _expanded_velocities_from_line_vortices(
             Slvp_GP1_CgP1 = stackSlvp_GP1_CgP1[vortex_id]
             Elvp_GP1_CgP1 = stackElvp_GP1_CgP1[vortex_id]
 
-            # The r1_GP1 vector goes from P_GP1_CgP1 to the line vortex's start point (in
-            # the first Airplane's geometry axes).
+            # The r1_GP1 vector goes from P_GP1_CgP1 to the line vortex's start point
+            # (in the first Airplane's geometry axes).
             r1X_GP1 = Slvp_GP1_CgP1[0] - P_GP1_CgP1[0]
             r1Y_GP1 = Slvp_GP1_CgP1[1] - P_GP1_CgP1[1]
             r1Z_GP1 = Slvp_GP1_CgP1[2] - P_GP1_CgP1[2]

--- a/pterasoftware/_convergence_meshing.py
+++ b/pterasoftware/_convergence_meshing.py
@@ -268,8 +268,8 @@ def build_unsteady_problem(
     # 5. Iterate over the WingMovements.
     #   5.1. Reference the WingMovement's base Wing.
     #   5.2. Reference the WingMovement's list of WingCrossSectionMovements.
-    #   5.3. Create an empty list for the WingCrossSectionMovements' base WingCrossSection
-    #        copies.
+    #   5.3. Create an empty list for the WingCrossSectionMovements' base
+    #        WingCrossSection copies.
     #   5.4. Create an empty list for the WingCrossSectionMovement copies.
     #   5.5. Iterate over the WingCrossSectionMovements.
     #     5.5.1. Reference the WingCrossSectionMovement's base WingCrossSection.
@@ -277,8 +277,8 @@ def build_unsteady_problem(
     #            combination of Panel aspect ratio and number of chordwise Panels.
     #     5.5.3. Create a copy of the base WingCrossSection.
     #     5.5.4. Create a copy of the WingCrossSectionMovement.
-    #     5.5.5. Append the base WingCrossSection copy to the list of base WingCrossSection
-    #            copies.
+    #     5.5.5. Append the base WingCrossSection copy to the list of base
+    #            WingCrossSection copies.
     #     5.5.6. Append the WingCrossSectionMovement copy to the list of
     #            WingCrossSectionMovement copies.
     #   5.6. Create a copy of the base Wing.

--- a/pterasoftware/_convergence_meshing.py
+++ b/pterasoftware/_convergence_meshing.py
@@ -53,9 +53,9 @@ def build_steady_problem(
     ref_airplanes = ref_problem.airplanes
     ref_operating_point = ref_problem.operating_point
 
-    # Initialize an empty list to hold this iteration's Airplanes. Then, fill the list by
-    # making new copies of each of the Airplanes with modified values for Panel aspect
-    # ratio and number of chordwise Panels.
+    # Initialize an empty list to hold this iteration's Airplanes. Then, fill the list
+    # by making new copies of each of the Airplanes with modified values for Panel
+    # aspect ratio and number of chordwise Panels.
     these_airplanes = []
     for ref_airplane_id, ref_airplane in enumerate(ref_airplanes):
         ref_wings = ref_airplane.wings
@@ -283,7 +283,7 @@ def build_unsteady_problem(
     #            WingCrossSectionMovement copies.
     #   5.6. Create a copy of the base Wing.
     #   5.7. Create a copy of the WingMovement.
-    #   5.8. Append the base Wing copy to the list  of base Wing copies.
+    #   5.8. Append the base Wing copy to the list of base Wing copies.
     #   5.9. Append the WingMovement copy to the list of WingMovement copies.
     # 6. Create a copy of the base Airplane.
     # 7. Create a copy of the AirplaneMovement.
@@ -312,11 +312,11 @@ def build_unsteady_problem(
 
             # An edge-defined Wing is refined by resampling its stored edge curves into
             # the number of WingCrossSections that achieves the desired Panel aspect
-            # ratio. Resampling changes the WingCrossSection count, so it cannot preserve
-            # per-WingCrossSection motion. Every WingCrossSectionMovement must therefore
-            # be static; the refined WingCrossSections are wrapped in motion free
-            # WingCrossSectionMovements and only the WingMovement's own motion is carried
-            # over.
+            # ratio. Resampling changes the WingCrossSection count, so it cannot
+            # preserve per-WingCrossSection motion. Every WingCrossSectionMovement must
+            # therefore be static; the refined WingCrossSections are wrapped in motion
+            # free WingCrossSectionMovements and only the WingMovement's own motion is
+            # carried over.
             if ref_base_wing.spanwise_mesh == "edge_defined":
                 for (
                     ref_wing_cross_section_movement_id,
@@ -466,7 +466,8 @@ def build_unsteady_problem(
 
                 # 5.5.4. Create a copy of the WingCrossSectionMovement.
                 this_wing_cross_section_movement = movements.wing_cross_section_movement.WingCrossSectionMovement(
-                    # These values are copied from the reference WingCrossSectionMovement.
+                    # These values are copied from the reference
+                    # WingCrossSectionMovement.
                     ampLp_Wcsp_Lpp=ref_wing_cross_section_movement.ampLp_Wcsp_Lpp,
                     periodLp_Wcsp_Lpp=ref_wing_cross_section_movement.periodLp_Wcsp_Lpp,
                     spacingLp_Wcsp_Lpp=ref_wing_cross_section_movement.spacingLp_Wcsp_Lpp,
@@ -582,8 +583,8 @@ def build_unsteady_problem(
         )
 
     # Cache the optimized delta_time on a miss so it is reused across the other
-    # wake-state and wake-length combinations at this mesh. Only a hit is logged,
-    # since on a miss the optimizer has just logged the value itself.
+    # wake-state and wake-length combinations at this mesh. Only a hit is logged, since
+    # on a miss the optimizer has just logged the value itself.
     if delta_time_key not in delta_time_cache:
         delta_time_cache[delta_time_key] = this_movement.delta_time
     else:
@@ -987,15 +988,15 @@ def _get_num_wing_cross_sections_for_panel_ar(
     lower_num = max(int(start_val), 2)
     lower_average_panel_aspect_ratio = average_panel_aspect_ratio_at(lower_num)
 
-    # If the starting count already meets the target, it is the smallest count that does,
-    # so return it.
+    # If the starting count already meets the target, it is the smallest count that
+    # does, so return it.
     if lower_average_panel_aspect_ratio <= desired_average_panel_aspect_ratio:
         return lower_num
 
-    # Proportionally jump to bracket the target from above. The average Panel aspect ratio
-    # scales roughly as 1 / (num_wing_cross_sections - 1), so this estimate lands near the
-    # crossing in a few steps. Each jump strictly increases the count, and the aspect
-    # ratio falls toward zero as the count grows, so the loop terminates.
+    # Proportionally jump to bracket the target from above. The average Panel aspect
+    # ratio scales roughly as 1.0 / (num_wing_cross_sections - 1), so this estimate
+    # lands near the crossing in a few steps. Each jump strictly increases the count,
+    # and the aspect ratio falls toward zero as the count grows, so the loop terminates.
     upper_num = lower_num
     upper_average_panel_aspect_ratio = lower_average_panel_aspect_ratio
     while upper_average_panel_aspect_ratio > desired_average_panel_aspect_ratio:
@@ -1019,8 +1020,9 @@ def _get_num_wing_cross_sections_for_panel_ar(
         else:
             upper_num = middle_num
 
-    # Return whichever of the two straddling counts gives the closer average Panel aspect
-    # ratio. On a tie, prefer the finer mesh (upper_num), matching the trapezoidal search.
+    # Return whichever of the two straddling counts gives the closer average Panel
+    # aspect ratio. On a tie, prefer the finer mesh (upper_num), matching the
+    # trapezoidal search.
     lower_difference = abs(
         average_panel_aspect_ratio_at(lower_num) - desired_average_panel_aspect_ratio
     )
@@ -1088,8 +1090,8 @@ def _resolve_num_wing_cross_sections(
     else:
         # Start the search from a conservative lower bound: the smallest number of
         # WingCrossSections already found for this Wing at an incrementally coarser mesh
-        # (in Panel aspect ratio, number of chordwise Panels, or both), since the current
-        # finer mesh must use at least that many. The floor is two, the fewest
+        # (in Panel aspect ratio, number of chordwise Panels, or both), since the
+        # current finer mesh must use at least that many. The floor is two, the fewest
         # WingCrossSections an edge-defined Wing can have.
         starting_num_wing_cross_sections = 2
         last_ar_key = (

--- a/pterasoftware/_core.py
+++ b/pterasoftware/_core.py
@@ -25,8 +25,8 @@ def lcm(a: float, b: float) -> float:
     """
     if a == 0.0 or b == 0.0:
         return 0.0
-    # Convert to integers (periods are typically whole multiples of delta_time).
-    # Use sufficiently large multiplier to preserve precision.
+    # Convert to integers (periods are typically whole multiples of delta_time). Use
+    # sufficiently large multiplier to preserve precision.
     multiplier = 1000000
     a_int = int(round(a * multiplier))
     b_int = int(round(b * multiplier))
@@ -127,8 +127,7 @@ class CoreOperatingPointMovement:
             raise ValueError("If ampVCg__E is 0.0, then phaseVCg__E must also be 0.0.")
         self._phaseVCg__E = phaseVCg__E
 
-        # Initialize the cache for the property derived from the immutable
-        # attributes.
+        # Initialize the cache for the property derived from the immutable attributes.
         self._max_period: float | None = None
 
     # --- Immutable: read only properties ---
@@ -333,8 +332,8 @@ class CoreWingCrossSectionMovement:
             angles_Wcsp_to_Wcs_ixyz oscillation in degrees.
         :return: None
         """
-        # Validate and store immutable attributes. Set those that are numpy
-        # arrays to be read only.
+        # Validate and store immutable attributes. Set those that are numpy arrays to be
+        # read only.
         if not isinstance(
             base_wing_cross_section,
             geometry.wing_cross_section.WingCrossSection,
@@ -479,15 +478,14 @@ class CoreWingCrossSectionMovement:
             avoid infinite recursion.
         :return: A new instance with copied attributes.
         """
-        # Create a new instance without calling __init__ to avoid redundant
-        # validation. Use type(self) so subclasses get the correct type.
+        # Create a new instance without calling __init__ to avoid redundant validation.
+        # Use type(self) so subclasses get the correct type.
         new_movement = object.__new__(type(self))
 
         # Store this instance in memo to handle potential circular references.
         memo[id(self)] = new_movement
 
-        # Deep copy the base WingCrossSection to ensure independence
-        # (immutable).
+        # Deep copy the base WingCrossSection to ensure independence (immutable).
         new_movement._base_wing_cross_section = copy.deepcopy(
             self._base_wing_cross_section, memo
         )
@@ -523,8 +521,7 @@ class CoreWingCrossSectionMovement:
             self._spacingAngles_Wcsp_to_Wcs_ixyz
         )
 
-        # Initialize cache variables to None (caches will be recomputed on
-        # access).
+        # Initialize cache variables to None (caches will be recomputed on access).
         new_movement._all_periods = None
         new_movement._max_period = None
 
@@ -663,8 +660,7 @@ class CoreWingCrossSectionMovement:
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Evaluate the oscillating value for each dimension of
-        # angles_Wcsp_to_Wcs_ixyz.
+        # Evaluate the oscillating value for each dimension of angles_Wcsp_to_Wcs_ixyz.
         theseAngles_Wcsp_to_Wcs_ixyz = np.zeros(3, dtype=float)
         for dim in range(3):
             this_spacing = self._spacingAngles_Wcsp_to_Wcs_ixyz[dim]
@@ -849,8 +845,8 @@ class CoreWingMovement:
             angular motion in meters.
         :return: None
         """
-        # Validate and store immutable attributes. Set those that are numpy
-        # arrays to be read only.
+        # Validate and store immutable attributes. Set those that are numpy arrays to be
+        # read only.
         if not isinstance(base_wing, geometry.wing.Wing):
             raise TypeError("base_wing must be a Wing.")
         self._base_wing = base_wing
@@ -1022,8 +1018,8 @@ class CoreWingMovement:
             avoid infinite recursion.
         :return: A new instance with copied attributes.
         """
-        # Create a new instance without calling __init__ to avoid redundant
-        # validation. Use type(self) so subclasses get the correct type.
+        # Create a new instance without calling __init__ to avoid redundant validation.
+        # Use type(self) so subclasses get the correct type.
         new_movement = object.__new__(type(self))
 
         # Store this instance in memo to handle potential circular references.
@@ -1068,8 +1064,7 @@ class CoreWingMovement:
         new_movement._spacingLer_Gs_Cgs = self._spacingLer_Gs_Cgs
         new_movement._spacingAngles_Gs_to_Wn_ixyz = self._spacingAngles_Gs_to_Wn_ixyz
 
-        # Initialize cache variables to None (caches will be recomputed on
-        # access).
+        # Initialize cache variables to None (caches will be recomputed on access).
         new_movement._all_periods = None
         new_movement._max_period = None
 
@@ -1230,8 +1225,7 @@ class CoreWingMovement:
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Evaluate the oscillating value for each dimension of
-        # angles_Gs_to_Wn_ixyz.
+        # Evaluate the oscillating value for each dimension of angles_Gs_to_Wn_ixyz.
         theseAngles_Gs_to_Wn_ixyz = np.zeros(3, dtype=float)
         for dim in range(3):
             this_spacing = self._spacingAngles_Gs_to_Wn_ixyz[dim]
@@ -1279,9 +1273,8 @@ class CoreWingMovement:
                 )
             )
 
-        # If there is a non zero rotation point offset, adjust the position
-        # to account for rotation about the offset point instead of the
-        # leading edge root.
+        # If there is a non zero rotation point offset, adjust the position to account
+        # for rotation about the offset point instead of the leading edge root.
         if not np.allclose(self._rotationPointOffset_Gs_Ler, np.zeros(3, dtype=float)):
             # Get the active rotation matrix for this step's angles.
             rot_T_act = _transformations.generate_rot_T(
@@ -1292,8 +1285,7 @@ class CoreWingMovement:
             )
             rot_R_act = rot_T_act[:3, :3]
 
-            # Compute the position adjustment due to the offset rotation
-            # point.
+            # Compute the position adjustment due to the offset rotation point.
             offsetRotationPointAdjustment_Gs = (
                 _transformations.compute_offset_rotation_adjustment(
                     rotation_matrix=rot_R_act,
@@ -1402,8 +1394,8 @@ class CoreAirplaneMovement:
             degrees.
         :return: None
         """
-        # Validate and store immutable attributes. Set those that are numpy
-        # arrays to be read only.
+        # Validate and store immutable attributes. Set those that are numpy arrays to be
+        # read only.
         if not isinstance(base_airplane, geometry.airplane.Airplane):
             raise TypeError("base_airplane must be an Airplane.")
         self._base_airplane = base_airplane
@@ -1489,8 +1481,8 @@ class CoreAirplaneMovement:
             avoid infinite recursion.
         :return: A new instance with copied attributes.
         """
-        # Create a new instance without calling __init__ to avoid redundant
-        # validation. Use type(self) so subclasses get the correct type.
+        # Create a new instance without calling __init__ to avoid redundant validation.
+        # Use type(self) so subclasses get the correct type.
         new_movement = object.__new__(type(self))
 
         # Store this instance in memo to handle potential circular references.
@@ -1517,8 +1509,7 @@ class CoreAirplaneMovement:
         # Copy tuple directly (it is immutable).
         new_movement._spacingCg_GP1_CgP1 = self._spacingCg_GP1_CgP1
 
-        # Initialize cache variables to None (caches will be recomputed on
-        # access).
+        # Initialize cache variables to None (caches will be recomputed on access).
         new_movement._all_periods = None
         new_movement._max_period = None
 
@@ -1779,8 +1770,7 @@ class CoreAirplaneMovement:
         # Step 1: Calculate geometry LCM period.
         geometry_lcm = self._geometry_lcm_period()
 
-        # Step 2: Pre-validation checks.
-        # Check if period aligns cleanly with delta_time.
+        # Step 2: Pre-validation checks. Check if period aligns cleanly with delta_time.
         steps_per_period_float = geometry_lcm / delta_time
         steps_per_period = int(round(steps_per_period_float))
 
@@ -1811,8 +1801,8 @@ class CoreAirplaneMovement:
             )
             wings[wing_movement_id, :] = this_wings_list_of_wings
 
-        # Step 4: Validate periodicity.
-        # Compare step 0 geometry to step steps_per_period.
+        # Step 4: Validate periodicity. Compare step 0 geometry to step
+        # steps_per_period.
         if not self._geometry_matches(
             wings_step_a=wings[:, 0],
             wings_step_b=wings[:, steps_per_period],
@@ -2057,8 +2047,8 @@ class CoreMovement:
         self._operating_point_movement = operating_point_movement
 
         # Initialize the caches for the properties derived from the immutable
-        # attributes. These are initialized early because static is accessed
-        # below during __init__ to validate max_wake_rows.
+        # attributes. These are initialized early because static is accessed below
+        # during __init__ to validate max_wake_rows.
         self._lcm_period: float | None = None
         self._max_period: float | None = None
         self._min_period: float | None = None
@@ -2153,16 +2143,15 @@ class CoreMovement:
             be 0.0.
         """
         if self._max_period is None:
-            # Iterate through the AirplaneMovements and find the one with the
-            # largest max period.
+            # Iterate through the AirplaneMovements and find the one with the largest
+            # max period.
             airplane_movement_max_periods = []
             for airplane_movement in self._airplane_movements:
                 airplane_movement_max_periods.append(airplane_movement.max_period)
             max_airplane_period = max(airplane_movement_max_periods)
 
-            # The global max period is the maximum of the max
-            # AirplaneMovement period and the OperatingPointMovement max
-            # period.
+            # The global max period is the maximum of the max AirplaneMovement period
+            # and the OperatingPointMovement max period.
             self._max_period = max(
                 max_airplane_period,
                 self._operating_point_movement.max_period,
@@ -2296,8 +2285,8 @@ class CoreUnsteadyProblem:
         # For CoreUnsteadyProblems with a static CoreMovement, we are typically
         # interested in the final time step's forces and moments, which, assuming
         # convergence, will be the most accurate. For CoreUnsteadyProblems with cyclic
-        # movement (e.g., flapping wings), we are typically interested in the forces
-        # and moments averaged over the last cycle simulated. Use the LCM of all motion
+        # movement (e.g., flapping wings), we are typically interested in the forces and
+        # moments averaged over the last cycle simulated. Use the LCM of all motion
         # periods to ensure we average over a complete cycle of all motions.
         self._first_averaging_step: int
         if lcm_period == 0:
@@ -2320,8 +2309,8 @@ class CoreUnsteadyProblem:
 
         # Initialize empty lists to hold the final loads and load coefficients each
         # Airplane experiences. These will only be populated if this
-        # CoreUnsteadyProblem's motion is static. These are mutable and populated by
-        # the solver.
+        # CoreUnsteadyProblem's motion is static. These are mutable and populated by the
+        # solver.
         self.finalForces_W: list[np.ndarray] = []
         self.finalForceCoefficients_W: list[np.ndarray] = []
         self.finalMoments_W_CgP1: list[np.ndarray] = []
@@ -2329,8 +2318,8 @@ class CoreUnsteadyProblem:
 
         # Initialize empty lists to hold the final cycle averaged loads and load
         # coefficients each Airplane experiences. These will only be populated if this
-        # CoreUnsteadyProblem's motion is cyclic. These are mutable and populated by
-        # the solver.
+        # CoreUnsteadyProblem's motion is cyclic. These are mutable and populated by the
+        # solver.
         self.finalMeanForces_W: list[np.ndarray] = []
         self.finalMeanForceCoefficients_W: list[np.ndarray] = []
         self.finalMeanMoments_W_CgP1: list[np.ndarray] = []

--- a/pterasoftware/_functions.py
+++ b/pterasoftware/_functions.py
@@ -187,16 +187,16 @@ def calculate_streamlines(
             -1, :, :
         ]
 
-        # Finds the fluid velocity (in the first Airplane's geometry axes, observed
-        # from the Earth frame) at each streamline point in the previous row due to
-        # the freestream velocity and the induced velocity from the vortices.
+        # Finds the fluid velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at each streamline point in the previous row due to the
+        # freestream velocity and the induced velocity from the vortices.
         stackVLastRowStreamlinePoints_GP1__E = solver.calculate_solution_velocity(
             stackP_GP1_CgP1=lastRowStackStreamlinePoints_GP1_CgP1,
             bound_singularity_counts=bound_singularity_counts,
         )
 
-        # Interpolate to find the new row of streamline points (in the first
-        # Airplane's geometry axes, relative to the first Airplane's CG).
+        # Interpolate to find the new row of streamline points (in the first Airplane's
+        # geometry axes, relative to the first Airplane's CG).
         newRowStackStreamlinePoints_GP1_CgP1 = (
             lastRowStackStreamlinePoints_GP1_CgP1
             + stackVLastRowStreamlinePoints_GP1__E * delta_time
@@ -316,8 +316,8 @@ def process_solver_loads(
     stackAirplaneForces_GP1 = np.zeros((solver.num_airplanes, 3), dtype=float)
     stackAirplaneMoments_GP1_CgP1 = np.zeros((solver.num_airplanes, 3), dtype=float)
 
-    # Iterate through each Airplane and find the total loads on each by summing up
-    # the contributions from its Panels.
+    # Iterate through each Airplane and find the total loads on each by summing up the
+    # contributions from its Panels.
     for airplane_num, airplane in enumerate(these_airplanes):
         for wing in airplane.wings:
             assert wing.panels is not None
@@ -412,8 +412,8 @@ def update_ring_vortex_solvers_panel_attributes(
     ring_vortex_solver.stackCpp_GP1_CgP1[global_panel_position, :] = panel.Cpp_GP1_CgP1
 
     # Bound ring vortex corner points. The right leg goes from the back right corner to
-    # the front right corner, the front leg from front right to front left, the left
-    # leg from front left to back left, and the back leg from back left to back right.
+    # the front right corner, the front leg from front right to front left, the left leg
+    # from front left to back left, and the back leg from back left to back right.
     assert ring_vortex_solver.stackBrbrvp_GP1_CgP1 is not None
     ring_vortex_solver.stackBrbrvp_GP1_CgP1[global_panel_position, :] = Brrvp_GP1_CgP1
     assert ring_vortex_solver.stackFrbrvp_GP1_CgP1 is not None
@@ -423,8 +423,8 @@ def update_ring_vortex_solvers_panel_attributes(
     assert ring_vortex_solver.stackBlbrvp_GP1_CgP1 is not None
     ring_vortex_solver.stackBlbrvp_GP1_CgP1[global_panel_position, :] = Blrvp_GP1_CgP1
 
-    # Bound line vortex leg center points and direction vectors, derived from the
-    # corner points.
+    # Bound line vortex leg center points and direction vectors, derived from the corner
+    # points.
     assert ring_vortex_solver.stackCblvpr_GP1_CgP1 is not None
     ring_vortex_solver.stackCblvpr_GP1_CgP1[global_panel_position, :] = 0.5 * (
         Brrvp_GP1_CgP1 + Frrvp_GP1_CgP1
@@ -471,9 +471,9 @@ def update_ring_vortex_solvers_panel_attributes(
     assert ring_vortex_solver.panel_is_left_edge is not None
     ring_vortex_solver.panel_is_left_edge[global_panel_position] = panel.is_left_edge
 
-    # Check if this Panel is on the trailing edge. If so, calculate its streamline
-    # seed point (in the first Airplane's geometry axes, relative to the first
-    # Airplane's CG) and add it to the solver's ndarray of streamline seed points.
+    # Check if this Panel is on the trailing edge. If so, calculate its streamline seed
+    # point (in the first Airplane's geometry axes, relative to the first Airplane's CG)
+    # and add it to the solver's ndarray of streamline seed points.
     if panel.is_trailing_edge:
         assert ring_vortex_solver.stackSeedPoints_GP1_CgP1 is not None
         assert panel.Brpp_GP1_CgP1 is not None
@@ -595,11 +595,11 @@ def interp_between_points(
     return gridInterpolatedPoints_A_a
 
 
-# The width to which format_duration left-pads its results when requested: the length
-# of the widest possible form, "-999 hr, 59 min, and 1.23E-305 s", built from the
-# widest possible components (a negative sign, three-digit hours, and a seconds
-# portion whose three-significant-figure form needs a three-digit exponent, the widest
-# a float can produce).
+# The width to which format_duration left-pads its results when requested: the length of
+# the widest possible form, "-999 hr, 59 min, and 1.23E-305 s", built from the widest
+# possible components (a negative sign, three-digit hours, and a seconds portion whose
+# three-significant-figure form needs a three-digit exponent, the widest a float can
+# produce).
 _DURATION_PAD_WIDTH: int = 32
 
 
@@ -635,8 +635,8 @@ def format_duration(total_seconds: float, left_pad: bool = False) -> str:
         num_minutes = int(magnitude_seconds % seconds_per_hour // seconds_per_minute)
         seconds_str = f"{magnitude_seconds % seconds_per_minute:#.3G}"
 
-        # Carry a seconds remainder that rounds to 60 at three significant figures
-        # into the minutes place, and a resulting 60 minutes into the hours place.
+        # Carry a seconds remainder that rounds to 60 at three significant figures into
+        # the minutes place, and a resulting 60 minutes into the hours place.
         if float(seconds_str) >= seconds_per_minute:
             seconds_str = f"{0.0:#.3G}"
             num_minutes += 1
@@ -661,25 +661,25 @@ def format_duration(total_seconds: float, left_pad: bool = False) -> str:
 
 
 # The Panel count at or above which letting the BLAS library multi-thread the linear
-# solves wins whole runs. Below it, a multi-threaded solve's post-work spin window
-# taxes the parallel kernel launches that follow it by more than the threaded solve
-# itself saves, so the solve runs single-threaded instead. Derived by timing whole
-# solver runs with the kernel thread dispatch in place, rather than the solve in
-# isolation, because an isolated timing cannot see the spin window's effect on the
-# launches around it and so puts the crossover well below its in-solver value. One
-# threshold serves both solver families.
+# solves wins whole runs. Below it, a multi-threaded solve's post-work spin window taxes
+# the parallel kernel launches that follow it by more than the threaded solve itself
+# saves, so the solve runs single-threaded instead. Derived by timing whole solver runs
+# with the kernel thread dispatch in place, rather than the solve in isolation, because
+# an isolated timing cannot see the spin window's effect on the launches around it and
+# so puts the crossover well below its in-solver value. One threshold serves both solver
+# families.
 _SOLVE_THREAD_THRESHOLD = 3_000
 
 # Guards the process-wide BLAS thread limit that a solve loop installs. A BLAS library
-# has one thread count per process, and threadpoolctl neither locks nor reference counts,
-# so two overlapping limits each record the other's width as the original to restore. An
-# out of order unwind then leaves the process pinned to a single BLAS thread for the rest
-# of its life, which is silent and slows everything that follows. Concurrent runs also
-# want conflicting widths, since a small run wants 1 thread and a large one wants the
-# full pool, and one process cannot hold both. Rather than corrupt the process quietly,
-# or serialize every run to accommodate a case that cannot pay off anyway (the compiled
-# kernels hold the GIL, so threads never speed the solvers up), a second concurrent solve
-# loop raises.
+# has one thread count per process, and threadpoolctl neither locks nor reference
+# counts, so two overlapping limits each record the other's width as the original to
+# restore. An out of order unwind then leaves the process pinned to a single BLAS thread
+# for the rest of its life, which is silent and slows everything that follows.
+# Concurrent runs also want conflicting widths, since a small run wants 1 thread and a
+# large one wants the full pool, and one process cannot hold both. Rather than corrupt
+# the process quietly, or serialize every run to accommodate a case that cannot pay off
+# anyway (the compiled kernels hold the GIL, so threads never speed the solvers up), a
+# second concurrent solve loop raises.
 _solve_loop_lock = threading.Lock()
 _solve_loop_owner: str | None = None
 _solve_loop_limiter: threadpoolctl.threadpool_limits | None = None

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -203,9 +203,9 @@ class MuJoCoModel:
         </mujoco>
         """
 
-        # Create the internal MuJoCo model object from the XML str. If mujoco_assets
-        # is provided, pass it so MuJoCo can resolve virtual filenames (e.g., STL
-        # meshes) without writing them to disk.
+        # Create the internal MuJoCo model object from the XML str. If mujoco_assets is
+        # provided, pass it so MuJoCo can resolve virtual filenames (e.g., STL meshes)
+        # without writing them to disk.
         # noinspection PyArgumentList
         if mujoco_assets is not None:
             self._model: mujoco.MjModel = mujoco.MjModel.from_xml_string(
@@ -237,9 +237,9 @@ class MuJoCoModel:
         # Set the internal model's state to the initial conditions.
         mujoco.mj_resetDataKeyframe(self._model, self._data, self._initial_key_frame_id)
 
-        # Run forward kinematics to compute derived quantities (xmat, xpos, etc.)
-        # from the initial qpos/qvel. Without this, xmat would be zeros until the
-        # first call to mj_step.
+        # Run forward kinematics to compute derived quantities (xmat, xpos, etc.) from
+        # the initial qpos/qvel. Without this, xmat would be zeros until the first call
+        # to mj_step.
         mujoco.mj_forward(self._model, self._data)
 
         # Store initial state for reset functionality.
@@ -351,8 +351,8 @@ class MuJoCoModel:
         # Airplane's body axes to Earth axes. To get R_pas_E_to_BP1, we take the
         # transpose.
         R_pas_BP1_to_E = self._data.xmat[self._body_id].reshape(3, 3)
-        # TODO: Consider creating an invert_R_pas function in _transformations.py
-        #  and calling it here.
+        # TODO: Consider creating an invert_R_pas function in _transformations.py and
+        #  calling it here.
         R_pas_E_to_BP1 = R_pas_BP1_to_E.T
 
         return {

--- a/pterasoftware/_oscillation.py
+++ b/pterasoftware/_oscillation.py
@@ -232,8 +232,8 @@ def _validate_custom_spacing_function(
             f"{start_value:#.3G}, but should be within {tolerance:#.3G} of 0.0."
         )
 
-    # Check that the function returns to 0.0 after one period.
-    # Find the index closest to 2.0 * pi.
+    # Check that the function returns to 0.0 after one period. Find the index closest to
+    # 2.0 * pi.
     end_period_idx = np.argmin(np.abs(test_times - 2.0 * np.pi))
     end_value = test_output[end_period_idx]
     if not np.isclose(end_value, 0.0, atol=tolerance):

--- a/pterasoftware/_panel.py
+++ b/pterasoftware/_panel.py
@@ -250,8 +250,8 @@ class Panel:
             avoid infinite recursion.
         :return: A new Panel with preserved mesh geometry and reset solver state.
         """
-        # Create a new Panel instance without calling __init__ to avoid redundant
-        # cache invalidation.
+        # Create a new Panel instance without calling __init__ to avoid redundant cache
+        # invalidation.
         new_panel = object.__new__(Panel)
 
         # Store this Panel in memo to handle potential circular references.
@@ -897,9 +897,9 @@ class Panel:
         projFirstDiagonalOnPlane_G = firstDiagonal_G - projFirstDiagonalOnNormal_G
         projSecondDiagonalOnPlane_G = secondDiagonal_G - projSecondDiagonalOnNormal_G
 
-        # The projected area is found by dividing the magnitude of cross product of
-        # the diagonal vectors (in geometry axes) by two. Read the area method for a
-        # more detailed explanation.
+        # The projected area is found by dividing the magnitude of cross product of the
+        # diagonal vectors (in geometry axes) by two. Read the area method for a more
+        # detailed explanation.
         projDiagonalsOnPlaneCross_G = np.cross(
             projFirstDiagonalOnPlane_G, projSecondDiagonalOnPlane_G
         )

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -16,9 +16,9 @@ import numpy as np
 
 from . import _logging
 
-# This module is inherently coupled to the internals of every class in the package
-# (it reads __slots__, knows class structure, and imports all classes into its
-# registry), so importing from a sibling private module is acceptable here.
+# This module is inherently coupled to the internals of every class in the package (it
+# reads __slots__, knows class structure, and imports all classes into its registry), so
+# importing from a sibling private module is acceptable here.
 # noinspection PyProtectedMember
 from ._mujoco_model import MuJoCoModel
 from ._oscillation import oscillating_lin_at_time, oscillating_sin_at_time
@@ -180,9 +180,9 @@ _UNSTEADY_SOLVER_SKIP_SLOTS: frozenset[str] = frozenset(
     {"current_airplanes", "current_operating_point", "panels"}
 )
 
-# Slots on Movement that are redundant when serialized inside an UnsteadyProblem.
-# The canonical data lives in the SteadyProblem objects; these are reconstructed
-# on deserialization to preserve object identity.
+# Slots on Movement that are redundant when serialized inside an UnsteadyProblem. The
+# canonical data lives in the SteadyProblem objects; these are reconstructed on
+# deserialization to preserve object identity.
 _MOVEMENT_SKIP_SLOTS: frozenset[str] = frozenset({"_airplanes", "_operating_points"})
 
 # Slots on MuJoCoModel that are serialized as null. _model and _data wrap native MuJoCo
@@ -240,8 +240,8 @@ def save(path: str | Path, obj: object) -> None:
     data = {**header, **data}
 
     if path.name.endswith(".json.gz"):
-        # Use compact format for gzip since readability does not matter and
-        # whitespace would increase the pre-compression size.
+        # Use compact format for gzip since readability does not matter and whitespace
+        # would increase the pre-compression size.
         json_bytes = json.dumps(data).encode("utf-8")
         with gzip.open(path, "wb") as f:
             f.write(json_bytes)
@@ -467,8 +467,8 @@ def _object_to_dict(
 
     _logger.debug(_logging.indent() + "Serializing %s", class_name)
 
-    # Solver skip slots always apply because the aliases are always redundant
-    # with solver._steady_problem or solver.unsteady_problem.
+    # Solver skip slots always apply because the aliases are always redundant with
+    # solver._steady_problem or solver.unsteady_problem.
     if isinstance(
         obj,
         (SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver),
@@ -480,11 +480,11 @@ def _object_to_dict(
     # The MuJoCoModel's native model and data objects cannot be serialized; they are
     # rebuilt from the XML string on deserialization.
     if isinstance(obj, MuJoCoModel):
-        # An asset-based model cannot survive that rebuild: the engine is recreated
-        # from the stored XML alone, whose asset references would be unresolvable.
-        # Refuse to save rather than produce a file that fails on load.
-        # This module is inherently coupled to class internals, so reading a private
-        # attribute directly is acceptable here.
+        # An asset-based model cannot survive that rebuild: the engine is recreated from
+        # the stored XML alone, whose asset references would be unresolvable. Refuse to
+        # save rather than produce a file that fails on load. This module is inherently
+        # coupled to class internals, so reading a private attribute directly is
+        # acceptable here.
         # noinspection PyProtectedMember
         if obj._mujoco_assets:
             raise ValueError(
@@ -500,8 +500,8 @@ def _object_to_dict(
         if slot_name in _skip_slots:
             result[slot_name] = None
         elif is_unsteady_problem and slot_name == "_movement":
-            # Pass _MOVEMENT_SKIP_SLOTS to the Movement child so that
-            # _airplanes and _operating_points are serialized as null.
+            # Pass _MOVEMENT_SKIP_SLOTS to the Movement child so that _airplanes and
+            # _operating_points are serialized as null.
             result[slot_name] = _object_to_dict(
                 getattr(obj, slot_name), _skip_slots=_MOVEMENT_SKIP_SLOTS
             )
@@ -547,10 +547,9 @@ def _reconstruct_shared_references(obj: object) -> None:
     :return: None
     """
     if isinstance(obj, MuJoCoModel):
-        # The native model and data objects were skipped during serialization; rebuild
-        # them from the deserialized XML string.
-        # This module is inherently coupled to class internals, so calling a private
-        # method directly is acceptable here.
+        # The native model and data objects were skipped during serialization. Rebuild
+        # them from the deserialized XML string. This module is inherently coupled to
+        # class internals, so calling a private method directly is acceptable here.
         # noinspection PyProtectedMember
         obj._rebuild_engine()
 
@@ -558,8 +557,8 @@ def _reconstruct_shared_references(obj: object) -> None:
         obj,
         (SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver),
     ):
-        # This module is inherently coupled to class internals (it reads __slots__
-        # and writes private backing stores for all classes), so accessing a private
+        # This module is inherently coupled to class internals (it reads __slots__ and
+        # writes private backing stores for all classes), so accessing a private
         # attribute directly is acceptable here.
         # noinspection PyProtectedMember
         problem = obj._steady_problem
@@ -569,8 +568,7 @@ def _reconstruct_shared_references(obj: object) -> None:
         object.__setattr__(obj, "vInf_GP1__E", problem.operating_point.vInf_GP1__E)
 
         if obj.ran:
-            # Reconstruct the flattened panels array (same order as
-            # _collapse_geometry).
+            # Reconstruct the flattened panels array (same order as _collapse_geometry).
             panels_list: list[Panel] = []
             for airplane in problem.airplanes:
                 for wing in airplane.wings:
@@ -578,8 +576,7 @@ def _reconstruct_shared_references(obj: object) -> None:
                     panels_list.extend(np.ravel(wing.panels))
             object.__setattr__(obj, "panels", np.array(panels_list, dtype=object))
         else:
-            # Pre run: panels is an uninitialized object array sized to
-            # num_panels.
+            # Pre run: panels is an uninitialized object array sized to num_panels.
             object.__setattr__(obj, "panels", np.empty(obj.num_panels, dtype=object))
 
     if isinstance(obj, UnsteadyProblem):
@@ -588,8 +585,8 @@ def _reconstruct_shared_references(obj: object) -> None:
         num_steps = len(steady_problems)
         num_airplane_movements = len(movement.airplane_movements)
 
-        # Reconstruct Movement._airplanes as a tuple[tuple[Airplane, ...], ...].
-        # Outer index = airplane movement, inner index = time step.
+        # Reconstruct Movement._airplanes as a tuple[tuple[Airplane, ...], ...]. The
+        # outer index is the AirplaneMovement, and the inner index is the time step.
         airplanes = tuple(
             tuple(
                 steady_problems[step].airplanes[airplane_movement_index]
@@ -599,8 +596,8 @@ def _reconstruct_shared_references(obj: object) -> None:
         )
         object.__setattr__(movement, "_airplanes", airplanes)
 
-        # Reconstruct Movement._operating_points: tuple[OperatingPoint, ...].
-        # Indexed by time step.
+        # Reconstruct Movement._operating_points: tuple[OperatingPoint, ...]. Indexed by
+        # time step.
         operating_points = tuple(
             steady_problems[step].operating_point for step in range(num_steps)
         )
@@ -609,8 +606,8 @@ def _reconstruct_shared_references(obj: object) -> None:
     if isinstance(obj, UnsteadyRingVortexLatticeMethodSolver):
         unsteady_problem = obj.unsteady_problem
 
-        # This module is inherently coupled to class internals (it reads __slots__
-        # and writes private backing stores for all classes), so accessing a private
+        # This module is inherently coupled to class internals (it reads __slots__ and
+        # writes private backing stores for all classes), so accessing a private
         # attribute directly is acceptable here.
         # noinspection PyProtectedMember
         current_step = obj._current_step
@@ -634,8 +631,8 @@ def _reconstruct_shared_references(obj: object) -> None:
                 obj, "panels", np.array(current_panels_list, dtype=object)
             )
         else:
-            # Pre run: current_airplanes is an empty tuple and panels is an
-            # empty object array.
+            # Pre run: current_airplanes is an empty tuple and panels is an empty object
+            # array.
             object.__setattr__(obj, "current_airplanes", ())
             object.__setattr__(obj, "panels", np.empty(0, dtype=object))
 

--- a/pterasoftware/_transformations.py
+++ b/pterasoftware/_transformations.py
@@ -11,8 +11,8 @@ import numpy as np
 # average error, and standard deviation.
 _QUAT_BRANCH_THRESHOLD = 0.0
 
-# Threshold above which |sin(angleY)| triggers the gimbal-lock fallback decomposition
-# in R_to_angles_izyx, equivalent to angleY within about 8.1e-5 degrees of the +/- 90
+# Threshold above which |sin(angleY)| triggers the gimbal-lock fallback decomposition in
+# R_to_angles_izyx, equivalent to angleY within about 8.1e-5 degrees of the +/- 90
 # degree pole. Picked to sit four orders of magnitude above float64 epsilon (1e-16): the
 # standard atan2 formula keeps cos(angleY) as a shared factor that cancels in the ratio,
 # so it works correctly until cos(angleY) approaches machine epsilon (cos at this
@@ -712,6 +712,7 @@ def alpha_and_beta_from_vInf_BP1(
 
     vInfX_BP1__E, vInfY_BP1__E, vInfZ_BP1__E = vInf_BP1__E
 
+    # octowrap: off
     # Invert the wind axes construction defined in docs/AXES_POINTS_AND_FRAMES.md and
     # implemented by OperatingPoint. In that convention the CG velocity in body axes (the
     # negated freestream, vCg_BP1__E = -vInf_BP1__E) has components
@@ -723,6 +724,7 @@ def alpha_and_beta_from_vInf_BP1(
     # textbook order that swaps which angle uses arcsin, keeps this function the exact
     # inverse of OperatingPoint. Deriving alpha and beta here and storing them back on an
     # OperatingPoint then reproduces the original freestream.
+    # octowrap: on
     sin_alpha = float(np.clip(-vInfZ_BP1__E / vCg__E, -1.0, 1.0))
     alpha = float(np.rad2deg(np.arcsin(sin_alpha)))
     beta = float(np.rad2deg(np.arctan2(-vInfY_BP1__E, -vInfX_BP1__E)))

--- a/pterasoftware/aeroelastic_unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/aeroelastic_unsteady_ring_vortex_lattice_method.py
@@ -90,19 +90,18 @@ class AeroelasticUnsteadyRingVortexLatticeMethodSolver(
 
         first_steady_problem: problems.SteadyProblem = self._get_steady_problem_at(0)
 
-        # Initialize SLEP (Strip Leading Edge Point) information. The SLEP is the
-        # leading edge point of the strip's outboard bounding WingCrossSection, the
-        # same WingCrossSection that receives the strip's torsional deformation, so
-        # each strip's moments and its deformation share one reference. The solver's flat panel
-        # stack is ordered chord-major within each wing (all spanwise positions of
-        # the first chordwise row, then all spanwise positions of the second
-        # chordwise row, and so on), with the wings stacked in order. For each
-        # panel, we record the flat index of the panel at the same wing and
-        # spanwise position in the first chordwise row, because that panel's
-        # outboard front point is the strip's leading edge point. Which grid corner
-        # is outboard depends on the meshing direction: the front-right point on a
-        # root-to-tip grid, and the front-left point on a mirror-meshed
-        # (tip-to-root) grid.
+        # Initialize SLEP (strip leading edge point) information. The SLEP is the
+        # leading edge point of the strip's outboard bounding WingCrossSection, the same
+        # WingCrossSection that receives the strip's torsional deformation, so each
+        # strip's moments and its deformation share one reference. The solver's flat
+        # Panel stack is ordered chord-major within each Wing (all spanwise positions of
+        # the first chordwise row, then all spanwise positions of the second chordwise
+        # row, and so on), with the Wings stacked in order. For each Panel, we record
+        # the flat index of the Panel at the same Wing and spanwise position in the
+        # first chordwise row, because that Panel's outboard front point is the strip's
+        # leading edge point. Which grid corner is outboard depends on the meshing
+        # direction: the front-right point on a root-to-tip grid, and the front-left
+        # point on a mirror-meshed (tip-to-root) grid.
         panel_count = 0
         slep_point_indices_list: list[int] = []
         slep_outboard_is_left_list: list[bool] = []
@@ -123,18 +122,18 @@ class AeroelasticUnsteadyRingVortexLatticeMethodSolver(
             slep_outboard_is_left_list, dtype=bool
         )
 
-        # The current time step's center bound LineVortex points for the right,
-        # front, left, and back legs (in the first Airplane's geometry axes,
-        # relative to the local strip leading edge point).
+        # The current time step's center bound LineVortex points for the right, front,
+        # left, and back legs (in the first Airplane's geometry axes, relative to the
+        # local strip leading edge point).
         self._stackCblvpr_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
         self._stackCblvpf_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
         self._stackCblvpl_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
         self._stackCblvpb_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
 
-        # The colocation panel points (in the first Airplane's geometry axes,
-        # relative to the local strip leading edge point), and each panel's own
-        # strip's leading edge point (in the first Airplane's geometry axes,
-        # relative to the first Airplane's CG).
+        # The collocation Panel points (in the first Airplane's geometry axes, relative
+        # to the local strip leading edge point), and each Panel's own strip's leading
+        # edge point (in the first Airplane's geometry axes, relative to the first
+        # Airplane's CG).
         self._stackCpp_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
         self.moments_GP1_Slep: np.ndarray = np.empty(0, dtype=float)
         self._stackSlep_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
@@ -250,9 +249,9 @@ class AeroelasticUnsteadyRingVortexLatticeMethodSolver(
 
         :return: None
         """
-        # Stage each panel's outboard front point. Only the first-chordwise-row
-        # entries are consumed by the gather below, since every strip's SLEP is a
-        # first-row panel's corner.
+        # Stage each Panel's outboard front point. Only the first-chordwise-row entries
+        # are consumed by the gather below, since every strip's SLEP is a first-row
+        # Panel's corner.
         outboardFrontPoints_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
         for panel_num, panel in enumerate(self.panels):
             if self._slep_outboard_is_left[panel_num]:

--- a/pterasoftware/convergence.py
+++ b/pterasoftware/convergence.py
@@ -245,8 +245,8 @@ def analyze_steady_convergence(
         range(num_chordwise_panels_bounds[0], num_chordwise_panels_bounds[1] + 1)
     )
 
-    # Initialize some empty ndarrays to hold variables related to each iteration.
-    # Going forward, an "iteration" refers to a SteadyProblem containing one of the
+    # Initialize some empty ndarrays to hold variables related to each iteration. Going
+    # forward, an "iteration" refers to a SteadyProblem containing one of the
     # combinations of Panel aspect ratio and number of chordwise Panels.
     iter_times = np.zeros(
         (len(panel_aspect_ratios_list), len(num_chordwise_panels_list)), dtype=float
@@ -271,19 +271,21 @@ def analyze_steady_convergence(
     # solve-cache and memo keys to this specific geometry, operating point, and motion.
     ref_problem_hash = _serialization.hash_object(ref_problem)
 
-    # Load the JSON solve cache, or start empty when caching is disabled or the file does
-    # not yet exist. Solved coefficients are looked up from and written through to it.
+    # Load the JSON solve cache, or start empty when caching is disabled or the file
+    # does not yet exist. Solved coefficients are looked up from and written through to
+    # it.
     solve_cache = _convergence_cache.load_solve_cache(cache_path)
 
-    # Pre-populate the in-loop memo caches from the cache file's memo section, translating
-    # each stored memo from its absolute mesh back onto this run's sweep indices. Memos
-    # outside this run's bounds or written for another reference problem are dropped. A
-    # cache with a populated memo section lets a warm run reuse these counts instead of
-    # re-resolving them. The number of spanwise Panels cache is keyed on a tuple of 5
-    # ints (ar_id, chord_id, ref_airplane_id, ref_wing_id, ref_wing_cross_section_id) for
-    # trapezoidal Wings, and the analogous number of WingCrossSections cache is keyed on a
-    # tuple of 4 ints (ar_id, chord_id, ref_airplane_id, ref_wing_id) for edge-defined
-    # Wings. A steady analysis has no delta_time, so that cache is discarded.
+    # Pre-populate the in-loop memo caches from the cache file's memo section,
+    # translating each stored memo from its absolute mesh back onto this run's sweep
+    # indices. Memos outside this run's bounds or written for another reference problem
+    # are dropped. A cache with a populated memo section lets a warm run reuse these
+    # counts instead of re-resolving them. The number of spanwise Panels cache is keyed
+    # on a tuple of 5 ints (ar_id, chord_id, ref_airplane_id, ref_wing_id,
+    # ref_wing_cross_section_id) for trapezoidal Wings, and the analogous number of
+    # WingCrossSections cache is keyed on a tuple of 4 ints (ar_id, chord_id,
+    # ref_airplane_id, ref_wing_id) for edge-defined Wings. A steady analysis has no
+    # delta_time, so that cache is discarded.
     num_spanwise_panels_cache, num_wing_cross_sections_cache, _ = (
         _convergence_cache.memos_from_disk(
             _convergence_cache.load_memo_cache(cache_path),
@@ -293,9 +295,9 @@ def analyze_steady_convergence(
         )
     )
 
-    # Persist the whole cache (solved coefficients and memos) to disk on each solve miss.
-    # The memo caches are translated back to their absolute mesh keys at write time. This
-    # is None when caching is disabled, in which case nothing is written.
+    # Persist the whole cache (solved coefficients and memos) to disk on each solve
+    # miss. The memo caches are translated back to their absolute mesh keys at write
+    # time. This is None when caching is disabled, in which case nothing is written.
     persist_cache: Callable[[], None] | None = None
     if cache_path is not None:
 
@@ -360,8 +362,8 @@ def analyze_steady_convergence(
                     num_wing_cross_sections_cache,
                 )
             ):
-                # The build's log messages nest at and one level under this
-                # iteration's messages.
+                # The build's log messages nest at and one level under this iteration's
+                # messages.
                 with _logging.nested(3):
                     this_problem = _convergence_meshing.build_steady_problem(
                         ar_id,
@@ -401,8 +403,8 @@ def analyze_steady_convergence(
                 with _logging.nested(4):
                     this_solver.run(calculate_streamlines=False)
 
-                # Create and fill an ndarray with each of this iteration's Airplanes' six
-                # load coefficients (cFX_W, cFY_W, cFZ_W, cMX_W_CgP1, cMY_W_CgP1,
+                # Create and fill an ndarray with each of this iteration's Airplanes'
+                # six load coefficients (cFX_W, cFY_W, cFZ_W, cMX_W_CgP1, cMY_W_CgP1,
                 # cMZ_W_CgP1).
                 solved_coefficients = np.zeros((len(these_airplanes), 6), dtype=float)
 
@@ -443,9 +445,9 @@ def analyze_steady_convergence(
                 )
 
             # Check per-coefficient convergence in each parameter direction against the
-            # incrementally coarser iteration. A direction cannot be checked on its first
-            # value, where there is no coarser iteration to compare against, so it starts
-            # as not converged.
+            # incrementally coarser iteration. A direction cannot be checked on its
+            # first value, where there is no coarser iteration to compare against, so it
+            # starts as not converged.
             ar_converged = False
             chord_converged = False
 
@@ -508,13 +510,13 @@ def analyze_steady_convergence(
             # degree of fineness.
             ar_saturated = panel_aspect_ratio == 1
 
-            # Check if only one value for either the Panel aspect ratio or the number
-            # of chordwise Panels were specified.
+            # Check if only one value for either the Panel aspect ratio or the number of
+            # chordwise Panels were specified.
             single_ar = len(panel_aspect_ratios_list) == 1
             single_chord = len(num_chordwise_panels_list) == 1
 
-            # Consider each convergence parameter to have "passed" if it is
-            # converged, single, or saturated.
+            # Consider each convergence parameter to have "passed" if it is converged,
+            # single, or saturated.
             ar_passed = ar_converged or single_ar or ar_saturated
             chord_passed = chord_converged or single_chord
 
@@ -578,8 +580,8 @@ def analyze_steady_convergence(
                         _logger.info(_logging.indent(3) + wing.name + ":")
 
                         # An edge-defined Wing is refined by its number of
-                        # WingCrossSections rather than its number of spanwise Panels, so
-                        # report that instead.
+                        # WingCrossSections rather than its number of spanwise Panels,
+                        # so report that instead.
                         if wing.spanwise_mesh == "edge_defined":
                             num_wing_cross_sections_key = (
                                 converged_ar_id,
@@ -627,10 +629,10 @@ def analyze_steady_convergence(
                                 + str(num_spanwise_panels)
                             )
 
-                # If requested, recreate and run the solver at the converged
-                # parameters so it can be returned. The converged parameters are
-                # frequently coarser than this iteration's, so the converged solver is
-                # rebuilt rather than reusing this iteration's finer solver.
+                # If requested, recreate and run the solver at the converged parameters
+                # so it can be returned. The converged parameters are frequently coarser
+                # than this iteration's, so the converged solver is rebuilt rather than
+                # reusing this iteration's finer solver.
                 converged_solver: (
                     steady_horseshoe_vortex_lattice_method.SteadyHorseshoeVortexLatticeMethodSolver
                     | steady_ring_vortex_lattice_method.SteadyRingVortexLatticeMethodSolver
@@ -642,8 +644,8 @@ def analyze_steady_convergence(
                         + "Recreating and running the converged solver"
                     )
 
-                    # The rebuild's and the solver's log messages nest under the
-                    # message above.
+                    # The rebuild's and the solver's log messages nest under the message
+                    # above.
                     with _logging.nested():
                         converged_problem = _convergence_meshing.build_steady_problem(
                             converged_ar_id,
@@ -676,9 +678,9 @@ def analyze_steady_convergence(
                     converged_solver,
                 )
 
-    # If all iterations have been checked and none of them resulted in both
-    # convergence parameters passing, then indicate that no converged case was found
-    # and return values of None for the converged parameters.
+    # If all iterations have been checked and none of them resulted in both convergence
+    # parameters passing, then indicate that no converged case was found and return
+    # values of None for the converged parameters.
     _logger.info(
         _logging.indent()
         + "The analysis did not find a converged case within the given bounds"
@@ -973,8 +975,8 @@ def analyze_unsteady_convergence(
         for ref_airplane_movement in ref_airplane_movements
     )
 
-    # Reject any Wing that cannot be refined (any spanwise mesh other than trapezoidal or
-    # edge-defined).
+    # Reject any Wing that cannot be refined (any spanwise mesh other than trapezoidal
+    # or edge-defined).
     _reject_unrefinable_wings(ref_base_airplanes, "analyze_unsteady_convergence")
 
     # Create the list of wake states to iterate over.
@@ -992,8 +994,8 @@ def analyze_unsteady_convergence(
         assert num_cycles_bounds is not None
         wake_lengths_list = list(range(num_cycles_bounds[0], num_cycles_bounds[1] + 1))
 
-    # Create the lists of Panel aspect ratios and number of chordwise Panels to
-    # iterate over.
+    # Create the lists of Panel aspect ratios and number of chordwise Panels to iterate
+    # over.
     panel_aspect_ratios_list = list(
         range(panel_aspect_ratio_bounds[0], panel_aspect_ratio_bounds[1] - 1, -1)
     )
@@ -1001,10 +1003,10 @@ def analyze_unsteady_convergence(
         range(num_chordwise_panels_bounds[0], num_chordwise_panels_bounds[1] + 1)
     )
 
-    # Initialize some empty ndarrays to hold variables regarding each iteration.
-    # Going forward, an "iteration" refers to an UnsteadyProblem containing one of
-    # the combinations of the wake state, wake length, Panel aspect ratio, and number
-    # of chordwise Panels.
+    # Initialize some empty ndarrays to hold variables regarding each iteration. Going
+    # forward, an "iteration" refers to an UnsteadyProblem containing one of the
+    # combinations of the wake state, wake length, Panel aspect ratio, and number of
+    # chordwise Panels.
     iter_times = np.zeros(
         (
             len(wake_list),
@@ -1041,22 +1043,24 @@ def analyze_unsteady_convergence(
     # solve-cache and memo keys to this specific geometry, operating point, and motion.
     ref_problem_hash = _serialization.hash_object(ref_problem)
 
-    # Load the JSON solve cache, or start empty when caching is disabled or the file does
-    # not yet exist. Solved coefficients are looked up from and written through to it.
+    # Load the JSON solve cache, or start empty when caching is disabled or the file
+    # does not yet exist. Solved coefficients are looked up from and written through to
+    # it.
     solve_cache = _convergence_cache.load_solve_cache(cache_path)
 
-    # Pre-populate the in-loop memo caches from the cache file's memo section, translating
-    # each stored memo from its absolute mesh back onto this run's sweep indices. Memos
-    # outside this run's bounds or written for another reference problem are dropped. A
-    # cache with a populated memo section lets a warm run reuse these values instead of
-    # re-resolving them, which for the delta_time cache skips the iterative optimizer. The
-    # number of spanwise Panels cache is keyed on a tuple of 5 ints (ar_id, chord_id,
-    # ref_base_airplane_id, ref_base_wing_id, ref_base_wing_cross_section_id) for
-    # trapezoidal Wings, the number of WingCrossSections cache is keyed on a tuple of 4
-    # ints (ar_id, chord_id, ref_base_airplane_id, ref_base_wing_id) for edge-defined
-    # Wings, and the delta_time cache is keyed on a tuple of 2 ints (ar_id, chord_id),
-    # since the optimum depends only on the mesh and is reused across every wake state and
-    # wake length at that mesh.
+    # Pre-populate the in-loop memo caches from the cache file's memo section,
+    # translating each stored memo from its absolute mesh back onto this run's sweep
+    # indices. Memos outside this run's bounds or written for another reference problem
+    # are dropped. A cache with a populated memo section lets a warm run reuse these
+    # values instead of re-resolving them, which for the delta_time cache skips the
+    # iterative optimizer. The number of spanwise Panels cache is keyed on a tuple of 5
+    # ints (ar_id, chord_id, ref_base_airplane_id, ref_base_wing_id,
+    # ref_base_wing_cross_section_id) for trapezoidal Wings, the number of
+    # WingCrossSections cache is keyed on a tuple of 4 ints (ar_id, chord_id,
+    # ref_base_airplane_id, ref_base_wing_id) for edge-defined Wings, and the delta_time
+    # cache is keyed on a tuple of 2 ints (ar_id, chord_id), since the optimum depends
+    # only on the mesh and is reused across every wake state and wake length at that
+    # mesh.
     (
         num_spanwise_panels_cache,
         num_wing_cross_sections_cache,
@@ -1068,9 +1072,9 @@ def analyze_unsteady_convergence(
         num_chordwise_panels_list,
     )
 
-    # Persist the whole cache (solved coefficients and memos) to disk on each solve miss.
-    # The memo caches are translated back to their absolute mesh keys at write time. This
-    # is None when caching is disabled, in which case nothing is written.
+    # Persist the whole cache (solved coefficients and memos) to disk on each solve
+    # miss. The memo caches are translated back to their absolute mesh keys at write
+    # time. This is None when caching is disabled, in which case nothing is written.
     persist_cache: Callable[[], None] | None = None
     if cache_path is not None:
 
@@ -1132,8 +1136,8 @@ def analyze_unsteady_convergence(
                     )
 
                     # Build this mesh's solve-cache key from the reference problem and
-                    # the wake state, wake length, and mesh parameters that determine the
-                    # solve.
+                    # the wake state, wake length, and mesh parameters that determine
+                    # the solve.
                     solve_cache_key = _convergence_cache.solve_cache_key(
                         ref_problem_hash,
                         wake,
@@ -1211,8 +1215,8 @@ def analyze_unsteady_convergence(
 
                         for airplane_id in range(len(ref_airplane_movements)):
                             # For static geometry, the final load coefficients are the
-                            # final time step's. For variable geometry, they are the mean
-                            # over the final cycle (the signed time-average).
+                            # final time step's. For variable geometry, they are the
+                            # mean over the final cycle (the signed time-average).
                             if static:
                                 solved_coefficients[airplane_id, 0:3] = (
                                     this_problem.finalForceCoefficients_W[airplane_id]
@@ -1390,9 +1394,9 @@ def analyze_unsteady_convergence(
 
                     # Consider the Panel aspect ratio value to be saturated if it is
                     # equal to 1. This is because a Panel aspect ratio of 1 is
-                    # considered the maximum degree of fineness. Consider the wake
-                    # state to be saturated if it False (which corresponds to a free
-                    # wake), as this is considered to be the most accurate wake state.
+                    # considered the maximum degree of fineness. Consider the wake state
+                    # to be saturated if it is False (which corresponds to a free wake),
+                    # as this is considered to be the most accurate wake state.
                     wake_saturated = not wake
                     ar_saturated = panel_aspect_ratio == 1
 
@@ -1410,9 +1414,9 @@ def analyze_unsteady_convergence(
                     ar_passed = ar_converged or single_ar or ar_saturated
                     chord_passed = chord_converged or single_chord
 
-                    # If all four convergence parameters have passed, then a
-                    # converged or semi-converged combination of parameters has been
-                    # found and will be returned.
+                    # If all four convergence parameters have passed, then a converged
+                    # or semi-converged combination of parameters has been found and
+                    # will be returned.
                     if wake_passed and length_passed and ar_passed and chord_passed:
                         converged_wake_id = _converged_parameter_id(
                             wake_id, single_wake, wake_converged
@@ -1554,8 +1558,8 @@ def analyze_unsteady_convergence(
                                         )
                                         - 1
                                     ):
-                                        # Not the last WingCrossSection, retrieve
-                                        # from cache.
+                                        # Not the last WingCrossSection, retrieve from
+                                        # cache.
                                         num_spanwise_panels_key = (
                                             converged_ar_id,
                                             converged_chord_id,
@@ -1592,8 +1596,8 @@ def analyze_unsteady_convergence(
                                 + "Recreating and running the converged solver"
                             )
 
-                            # The rebuild's and the solver's log messages nest under
-                            # the message above.
+                            # The rebuild's and the solver's log messages nest under the
+                            # message above.
                             with _logging.nested():
                                 converged_problem = (
                                     _convergence_meshing.build_unsteady_problem(
@@ -1631,9 +1635,9 @@ def analyze_unsteady_convergence(
                             converged_solver,
                         )
 
-    # If all iterations have been checked and none of them resulted in all
-    # convergence parameters passing, then indicate that no converged solution was
-    # found and return values of None for the converged parameters.
+    # If all iterations have been checked and none of them resulted in all convergence
+    # parameters passing, then indicate that no converged solution was found and return
+    # values of None for the converged parameters.
     _logger.info(
         _logging.indent()
         + "The analysis did not find a converged case within the given bounds"
@@ -1805,8 +1809,8 @@ def _check_coefficient_convergence(
 
     all_converged = bool(np.all(converged[:, coefficient_mask]))
 
-    # The metric is 100.0 for a converged coefficient (including one with zero error) and
-    # falls toward 0.0 as the error grows past its tolerance.
+    # The metric is 100.0 for a converged coefficient (including one with zero error)
+    # and falls toward 0.0 as the error grows past its tolerance.
     with np.errstate(divide="ignore", invalid="ignore"):
         metrics = np.where(
             errors == 0.0,
@@ -1814,8 +1818,9 @@ def _check_coefficient_convergence(
             100.0 * np.minimum(1.0, tolerances / errors),
         )
 
-    # Exclude the masked-out coefficients from the limiting-coefficient search by setting
-    # their metrics to infinity. The mask has shape (6,) and broadcasts across Airplanes.
+    # Exclude the masked-out coefficients from the limiting-coefficient search by
+    # setting their metrics to infinity. The mask has shape (6,) and broadcasts across
+    # Airplanes.
     masked_metrics = np.where(coefficient_mask, metrics, np.inf)
     min_metric = float(np.min(masked_metrics))
     limiting_coefficient_id = int(np.argmin(masked_metrics) % 6)

--- a/pterasoftware/free_flight_unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/free_flight_unsteady_ring_vortex_lattice_method.py
@@ -25,8 +25,8 @@ from ._coupled_unsteady_ring_vortex_lattice_method import (
 )
 
 # Body and geometry axes differ by a 180-degree rotation about y, so transforming a free
-# vector (such as an angular velocity) from the first Airplane's body axes to its geometry
-# axes negates the x and z components.
+# vector (such as an angular velocity) from the first Airplane's body axes to its
+# geometry axes negates the x and z components.
 _BP1_TO_GP1_FLIP = np.array([-1.0, 1.0, -1.0], dtype=float)
 _BP1_TO_GP1_FLIP.flags.writeable = False
 
@@ -89,15 +89,15 @@ class FreeFlightUnsteadyRingVortexLatticeMethodSolver(
 
         # Transient working state for the strongly coupled sub-iteration, established by
         # freeze_substep and cleared by restore_substep. Each is None between substeps.
-        # The next step and its transient SteadyProblem and trial OperatingPoint redirect
-        # the inherited geometry and wake reads to a scratch copy of the next Airplane and
-        # the current trial state, since the canonical next-step SteadyProblem is not
-        # committed until the solve accepts. The frozen induced velocities are the
-        # iterate-independent part of the wake transport; the two strength snapshots are
-        # the current and previous steps' solved bound ring vortex strengths. These are
-        # initialized before the inherited constructor runs, because it calls
-        # _get_steady_problem_at, which this solver's override consults for the substep
-        # state.
+        # The next step and its transient SteadyProblem and trial OperatingPoint
+        # redirect the inherited geometry and wake reads to a scratch copy of the next
+        # Airplane and the current trial state, since the canonical next-step
+        # SteadyProblem is not committed until the solve accepts. The frozen induced
+        # velocities are the iterate-independent part of the wake transport. The two
+        # strength snapshots are the current and previous steps' solved bound ring
+        # vortex strengths. These are initialized before the inherited constructor runs,
+        # because it calls _get_steady_problem_at, which this solver's override consults
+        # for the substep state.
         self._substep_next_step: int | None = None
         self._substep_next_steady_problem: problems.SteadyProblem | None = None
         self._substep_next_operating_point: operating_point.OperatingPoint | None = None
@@ -280,10 +280,10 @@ class FreeFlightUnsteadyRingVortexLatticeMethodSolver(
         self._initialize_panel_vortices_at(next_step)
 
         # P: age the current step's wake into the next step. The wake builder reads the
-        # current step as the reference step, the next step's trial OperatingPoint for the
-        # frame terms, and the snapshot bound strengths for the newly shed row, so set the
-        # current step's context and restore the snapshot strengths first. The induced
-        # transport is the frozen precompute from freeze_substep.
+        # current step as the reference step, the next step's trial OperatingPoint for
+        # the frame terms, and the snapshot bound strengths for the newly shed row, so
+        # set the current step's context and restore the snapshot strengths first. The
+        # induced transport is the frozen precompute from freeze_substep.
         current_problem = self._get_steady_problem_at(step)
         self._current_step = step
         self.current_airplanes = current_problem.airplanes
@@ -297,8 +297,8 @@ class FreeFlightUnsteadyRingVortexLatticeMethodSolver(
 
         # C and L: solve the circulation and loads at the next step against the trial
         # geometry and the freshly aged wake. The current Airplanes are the scratch copy
-        # and the current OperatingPoint is the trial. The unsteady load term differences
-        # the solved strengths against the snapshot strengths.
+        # and the current OperatingPoint is the trial. The unsteady load term
+        # differences the solved strengths against the snapshot strengths.
         self._current_step = next_step
         self.current_airplanes = self._get_steady_problem_at(next_step).airplanes
         self.current_operating_point = trial_operating_point

--- a/pterasoftware/geometry/_meshing.py
+++ b/pterasoftware/geometry/_meshing.py
@@ -49,8 +49,8 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
     num_wing_cross_sections = len(wing_cross_sections)
     num_wing_sections = num_wing_cross_sections - 1
 
-    # Initialize an empty array that will hold the Panels of this Wing. It currently
-    # has 0 columns and M rows, where M is the number of the Wing's chordwise Panels.
+    # Initialize an empty array that will hold the Panels of this Wing. It currently has
+    # 0 columns and M rows, where M is the number of the Wing's chordwise Panels.
     wing_panels: np.ndarray = np.empty((num_chordwise_panels, 0), dtype=object)
 
     # The type 4 mirrored half is reflected about the wing's symmetry plane. Re-express
@@ -84,9 +84,9 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
         inner_wing_cross_section = wing_cross_sections[inner_wing_cross_section_num]
         outer_wing_cross_section = wing_cross_sections[inner_wing_cross_section_num + 1]
 
-        # Get the homogeneous passive transformation matrices from the inner and
-        # outer WingCrossSection's axes relative to their respective leading points
-        # to wing axes relative to the leading edge root point.
+        # Get the homogeneous passive transformation matrices from the inner and outer
+        # WingCrossSection's axes relative to their respective leading points to wing
+        # axes relative to the leading edge root point.
         T_pas_Wcsi_Lpi_to_Wn_Ler = children_T_pas_Wcs_Lp_to_Wn_Ler[
             inner_wing_cross_section_num
         ]
@@ -125,8 +125,8 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
         else:
             spanwise_coordinates = _functions.cosspace(0, 1, num_spanwise_coordinates)
 
-        # Get this wing section's MCS points (in wing axes, relative to the leading
-        # edge root point).
+        # Get this wing section's MCS points (in wing axes, relative to the leading edge
+        # root point).
         [
             Fipp_Wn_Ler,
             Fopp_Wn_Ler,
@@ -159,9 +159,9 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
             T_pas_Wn_Ler_to_G_Cg, Bopp_Wn_Ler, is_position=True
         )
 
-        # Compute a matrix that is (M,N), where M and N are the number of chordwise
-        # and spanwise Panels. The values are either 1 if the Panel at that location
-        # is a trailing edge, or 0 if not.
+        # Compute a matrix that is (M,N), where M and N are the number of chordwise and
+        # spanwise Panels. The values are either 1 if the Panel at that location is a
+        # trailing edge, or 0 if not.
         wing_section_is_trailing_edge = np.vstack(
             [
                 np.zeros((num_chordwise_panels - 1, num_spanwise_panels), dtype=bool),
@@ -169,9 +169,9 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
             ]
         )
 
-        # Compute a matrix that is (M,N), where M and N are the number of chordwise
-        # and spanwise Panels. The values are either 1 if the Panel at that location
-        # is a leading edge, or 0 if not.
+        # Compute a matrix that is (M,N), where M and N are the number of chordwise and
+        # spanwise Panels. The values are either 1 if the Panel at that location is a
+        # leading edge, or 0 if not.
         wing_section_is_leading_edge = np.vstack(
             [
                 np.ones((1, num_spanwise_panels), dtype=bool),
@@ -265,9 +265,9 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
                 spanwise_coordinates,
             )
 
-            # Compute a matrix that is (M,N), where M and N are the number of
-            # chordwise and spanwise Panels. The values are either 1 if the Panel at
-            # that location is a trailing edge, or 0 if not.
+            # Compute a matrix that is (M,N), where M and N are the number of chordwise
+            # and spanwise Panels. The values are either 1 if the Panel at that location
+            # is a trailing edge, or 0 if not.
             wing_section_is_trailing_edge = np.vstack(
                 [
                     np.zeros(
@@ -277,9 +277,9 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
                 ]
             )
 
-            # Compute a matrix that is (M,N), where M and N are the number of
-            # chordwise and spanwise Panels. The values are either 1 if the Panel at
-            # that location is a leading edge, or 0 if not.
+            # Compute a matrix that is (M,N), where M and N are the number of chordwise
+            # and spanwise Panels. The values are either 1 if the Panel at that location
+            # is a leading edge, or 0 if not.
             wing_section_is_leading_edge = np.vstack(
                 [
                     np.ones((1, num_spanwise_panels), dtype=bool),
@@ -305,13 +305,13 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
             # wing's attributes.
 
             # A reflection is an improper transformation (determinant -1) that flips
-            # handedness/chirality. A rotation or translation is a proper
-            # transformation (determinant +1) that preserves handedness. If we derived
-            # the mirrored wing's points using only a passive transformation, we would
-            # get a right-handed copy of the original wing just relocated. That means
-            # camber would carry the wrong geometric sign on the opposite side.
-            # Reflection is the only linear operation that genuinely inverts handedness
-            # to turn a right wing into a left wing.
+            # handedness/chirality. A rotation or translation is a proper transformation
+            # (determinant +1) that preserves handedness. If we derived the mirrored
+            # wing's points using only a passive transformation, we would get a
+            # right-handed copy of the original wing just relocated. That means camber
+            # would carry the wrong geometric sign on the opposite side. Reflection is
+            # the only linear operation that genuinely inverts handedness to turn a
+            # right wing into a left wing.
 
             assert reflect_T_act is not None
 
@@ -331,8 +331,8 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
                 reflect_T_act, Bopp_Wn_Ler, is_position=True
             )
 
-            # Step 2 (passive transformation): Re-express the now-reflected points
-            # from local wing axes into geometry axes relative to the CG.
+            # Step 2 (passive transformation): Re-express the now-reflected points from
+            # local wing axes into geometry axes relative to the CG.
             reflected_Fipp_G_Cg = _transformations.apply_T_to_vectors(
                 T_pas_Wn_Ler_to_G_Cg, reflected_Fipp_Wn_Ler, is_position=True
             )
@@ -356,8 +356,8 @@ def mesh_wing(wing: wing_mod.Wing) -> None:
                 is_leading_edge=wing_section_is_leading_edge,
             )
 
-            # This wing section's Panels array is stacked horizontally, to the left
-            # of the Wing's Panel array.
+            # This wing section's Panels array is stacked horizontally, to the left of
+            # the Wing's Panel array.
             wing_panels = np.hstack([np.flip(wing_section_panels, axis=1), wing_panels])
 
     # Iterate through the Panels and populate their local position attributes.
@@ -402,30 +402,30 @@ def _get_mcl_points(
         components, and (4) the outer Airfoil's MCL points' x components. The values are
         normalized from 0.0 to 1.0 and are unitless.
     """
-    # Make the MCLs for each Airfoil. First index is point number, second index is
-    # the coordinates of that point on the MCL (in each Airfoil's axes, relative to
-    # each Airfoil's leading point).
+    # Make the MCLs for each Airfoil. First index is point number, second index is the
+    # coordinates of that point on the MCL (in each Airfoil's axes, relative to each
+    # Airfoil's leading point).
     inner_mcl_points_Ai_lpAi = inner_airfoil.get_resampled_mcl(chordwise_coordinates)
     outer_mcl_points_Ao_lpAo = outer_airfoil.get_resampled_mcl(chordwise_coordinates)
 
-    # Extract the y components of the inner Airfoil's MCL points (in the inner
-    # Airfoil's axes, relative to the inner Airfoil's leading point) and put them in
-    # a column vector.
+    # Extract the y components of the inner Airfoil's MCL points (in the inner Airfoil's
+    # axes, relative to the inner Airfoil's leading point) and put them in a column
+    # vector.
     inner_mcl_pointsY_Ai_lpAi = np.expand_dims(inner_mcl_points_Ai_lpAi[:, 1], 1)
 
-    # Extract the x components of the inner Airfoil's MCL points (in the inner
-    # Airfoil's axes, relative to the inner Airfoil's leading point) and put them in
-    # a column vector.
+    # Extract the x components of the inner Airfoil's MCL points (in the inner Airfoil's
+    # axes, relative to the inner Airfoil's leading point) and put them in a column
+    # vector.
     inner_mcl_pointsX_Ai_lpAi = np.expand_dims(inner_mcl_points_Ai_lpAi[:, 0], 1)
 
-    # Extract the y components of the outer Airfoil's MCL points (in the outer
-    # Airfoil's axes, relative to the outer Airfoil's leading point) and put them in
-    # a column vector.
+    # Extract the y components of the outer Airfoil's MCL points (in the outer Airfoil's
+    # axes, relative to the outer Airfoil's leading point) and put them in a column
+    # vector.
     outer_mcl_pointsY_Ao_lpAo = np.expand_dims(outer_mcl_points_Ao_lpAo[:, 1], 1)
 
-    # Extract the x components of the outer Airfoil's MCL points (in the outer
-    # Airfoil's axes, relative to the outer Airfoil's leading point) and put them in
-    # a column vector.
+    # Extract the x components of the outer Airfoil's MCL points (in the outer Airfoil's
+    # axes, relative to the outer Airfoil's leading point) and put them in a column
+    # vector.
     outer_mcl_pointsX_Ao_lpAo = np.expand_dims(outer_mcl_points_Ao_lpAo[:, 0], 1)
 
     return [
@@ -528,8 +528,8 @@ def _get_mcs_points(
     )
 
     # Find the vertices of the points on this wing section's (MCS) (in wing axes,
-    # relative to the leading edge root point) with interpolation. This returns an (
-    # M,N,3) array, where M and N are the number of chordwise points and spanwise
+    # relative to the leading edge root point) with interpolation. This returns an
+    # (M,N,3) array, where M and N are the number of chordwise points and spanwise
     # points.
     wing_section_mcl_vertices = _functions.interp_between_points(
         inner_mcl_points_Wn_Ler, outer_mcl_points_Wn_Ler, spanwise_coordinates
@@ -585,8 +585,8 @@ def _get_panels(
     num_chordwise_panels = Flpp_G_Cg.shape[0]
     num_spanwise_panels = Flpp_G_Cg.shape[1]
 
-    # Initialize an empty ndarray to hold the wing section's Panels. The ndarray is
-    # size (M,N), where M and N are the number of chordwise and spanwise Panels.
+    # Initialize an empty ndarray to hold the wing section's Panels. The ndarray is size
+    # (M,N), where M and N are the number of chordwise and spanwise Panels.
     panels = np.empty((num_chordwise_panels, num_spanwise_panels), dtype=object)
 
     # Loop through the empty Panels array and create a new Panel in each position.

--- a/pterasoftware/geometry/airfoil.py
+++ b/pterasoftware/geometry/airfoil.py
@@ -140,8 +140,8 @@ class Airfoil:
         if self._resample:
             self._resample_outline(self._n_points_per_side)
 
-        # Initialize an attribute for an array of points along the MCL (in airfoil
-        # axes, relative to the leading point). It will be set by _populate_mcl.
+        # Initialize an attribute for an array of points along the MCL (in airfoil axes,
+        # relative to the leading point). It will be set by _populate_mcl.
         self._mcl_A_lp: np.ndarray | None = None
         self._populate_mcl()
 
@@ -205,14 +205,13 @@ class Airfoil:
         return self._mcl_A_lp
 
     # --- Other methods ---
-    # TODO: In the future, if adding control surfaces becomes more important,
-    #  we may want to rework this method. Using this method we need to artificially
-    #  limit the maximum deflection to 5.0 degrees because higher values may cause
-    #  the upper and lower outlines to intersect. This is because they each rotate
-    #  about points on their respective outlines. Instead, it would be better to have
-    #  everything rotate about the MCL's hinge point, however, this causes
-    #  self intersections for the upper and lower outlines, so we'd need to write some
-    #  logic to remove those.
+    # TODO: In the future, if adding control surfaces becomes more important, we may
+    #  want to rework this method. Using this method we need to artificially limit the
+    #  maximum deflection to 5.0 degrees because higher values may cause the upper and
+    #  lower outlines to intersect. This is because they each rotate about points on
+    #  their respective outlines. Instead, it would be better to have everything rotate
+    #  about the MCL's hinge point, however, this causes self intersections for the
+    #  upper and lower outlines, so we'd need to write some logic to remove those.
     def add_control_surface(
         self, deflection: float | int, hinge_point: float | int
     ) -> Airfoil:
@@ -354,9 +353,9 @@ class Airfoil:
         )
 
         # Return the new flapped Airfoil, with the _TRUST token so that we don't
-        # re-validate the outline, which would fail because the validation requires
-        # the trailing edge points be roughly at y=0.0 (in airfoil axes, relative to
-        # the leading point).
+        # re-validate the outline, which would fail because the validation requires the
+        # trailing edge points be roughly at y=0.0 (in airfoil axes, relative to the
+        # leading point).
         return Airfoil(
             name=self.name + " flapped",
             outline_A_lp=flappedOutline_A_lp,
@@ -501,8 +500,8 @@ class Airfoil:
             + np.power(mclY_A_lp[:-1] - mclY_A_lp[1:], 2)
         )
 
-        # Create a horizontal 1D array that contains the distance along the MCL of
-        # each point on the MCL.
+        # Create a horizontal 1D array that contains the distance along the MCL of each
+        # point on the MCL.
         mcl_distances_cumulative = np.hstack(
             (0, np.cumsum(mcl_distances_between_points))
         )
@@ -592,9 +591,8 @@ class Airfoil:
                             "supported."
                         )
 
-                    # Reject inconsistent camber parameters. The first two digits
-                    # must either both be zero (symmetric) or both be non zero
-                    # (cambered).
+                    # Reject inconsistent camber parameters. The first two digits must
+                    # either both be zero (symmetric) or both be non zero (cambered).
                     if (max_camber > 0) != (camber_loc > 0):
                         raise ValueError(
                             "NACA 4 series airfoils must have consistent camber "
@@ -639,8 +637,8 @@ class Airfoil:
                     if camber_loc == 0:
                         camber_loc = 0.5
 
-                    # Get the y components of the MCL (in airfoil axes, relative to
-                    # the leading point).
+                    # Get the y components of the MCL (in airfoil axes, relative to the
+                    # leading point).
                     mclY1_A_lp = (
                         max_camber
                         / camber_loc**2
@@ -675,14 +673,14 @@ class Airfoil:
                     )
                     mclSlope_A = np.hstack((mclSlope1_A, mclSlope2_A))
 
-                    # Convert the slope of the MCL to the angle between the airfoil
-                    # x axis and the MCL tangent line.
+                    # Convert the slope of the MCL to the angle between the airfoil x
+                    # axis and the MCL tangent line.
                     thetaSlopeRad_Ax_to_MCL = np.arctan(mclSlope_A)
 
                     # Find the upper and lower points of the Airfoil's outline (in
-                    # airfoil axes, relative to the leading point) using the MCL
-                    # points, the perpendicular half-thickness, and the angle between
-                    # the x axis and the MCL tangent line.
+                    # airfoil axes, relative to the leading point) using the MCL points,
+                    # the perpendicular half-thickness, and the angle between the x axis
+                    # and the MCL tangent line.
                     upperOutlineX_A_lp = mclX_A_lp - halfThickness_A * np.sin(
                         thetaSlopeRad_Ax_to_MCL
                     )
@@ -791,8 +789,8 @@ class Airfoil:
                 outline_A_lp, "outline_A_lp"
             )
         )
-        # Make a copy to ensure the Airfoil owns its own data. This is important
-        # because the input might be a read only array from another Airfoil.
+        # Make a copy to ensure the Airfoil owns its own data. This is important because
+        # the input might be a read only array from another Airfoil.
         validated_outline_A_lp = validated_outline_A_lp.copy()
 
         n_outline_points = validated_outline_A_lp.shape[0]
@@ -873,8 +871,8 @@ class Airfoil:
                     f"outline data appears to be in an unexpected orientation."
                 )
 
-            # Create an active rotation matrix to rotate the chord onto x axis.
-            # Convert the angle to degrees to match the _transformations.py standard.
+            # Create an active rotation matrix to rotate the chord onto x axis. Convert
+            # the angle to degrees to match the _transformations.py standard.
             rot_R_act = _transformations.generate_2D_rot_R(
                 angle=np.rad2deg(-chord_angle_rad), passive=False
             )
@@ -926,9 +924,9 @@ class Airfoil:
                 y_at_1 = y0 + (y1 - y0) * (1.0 - x0) / (x1 - x0)
                 self._outline_A_lp[-1, :] = [1.0, y_at_1]
 
-        # Remove duplicate interior points while preserving first and last points.
-        # For closed trailing edges, the upper and lower TE points may be identical,
-        # but both must be kept to maintain proper outline topology.
+        # Remove duplicate interior points while preserving first and last points. For
+        # closed trailing edges, the upper and lower TE points may be identical, but
+        # both must be kept to maintain proper outline topology.
         interior = self._outline_A_lp[1:-1]
         _, unique_indices = np.unique(interior, axis=0, return_index=True)
         unique_indices = np.sort(unique_indices)
@@ -938,11 +936,11 @@ class Airfoil:
         )
 
         # Correct small trailing edge inversions. After normalization, floating-point
-        # precision or minor data quality issues may cause the upper TE y to be
-        # slightly below the lower TE y. If the inversion is small (<=0.1% chord),
-        # correct it by averaging the y values to create a closed trailing edge.
-        # Larger inversions indicate genuinely malformed data and are left for
-        # _validate_outline_final() to catch.
+        # precision or minor data quality issues may cause the upper TE y to be slightly
+        # below the lower TE y. If the inversion is small (<=0.1% chord), correct it by
+        # averaging the y values to create a closed trailing edge. Larger inversions
+        # indicate genuinely malformed data and are left for _validate_outline_final()
+        # to catch.
         upperTpY_A_lp = self._outline_A_lp[0, 1]
         lowerTpY_A_lp = self._outline_A_lp[-1, 1]
         if lowerTpY_A_lp > upperTpY_A_lp:
@@ -1012,9 +1010,9 @@ class Airfoil:
         upperOutlineDiffX_A = np.diff(upperOutline_A_lp[:, 0])
         lowerOutlineDiffX_A = np.diff(lowerOutline_A_lp[:, 0])
 
-        # Check that the upper outline is non increasing in x and that the lower
-        # outline is non decreasing in x (in airfoil axes). Adjacent points may have
-        # the same x value.
+        # Check that the upper outline is non increasing in x and that the lower outline
+        # is non decreasing in x (in airfoil axes). Adjacent points may have the same x
+        # value.
         if not np.all(upperOutlineDiffX_A <= 0.0):
             raise ValueError(
                 "Every point in the Airfoil's outline's upper portion must have "
@@ -1105,8 +1103,8 @@ class Airfoil:
             )
         )
 
-        # Create a horizontal 1D array that contains the cumulative distance along
-        # the upper flipped original outline of each point.
+        # Create a horizontal 1D array that contains the cumulative distance along the
+        # upper flipped original outline of each point.
         flippedUpperOutline_distances_cumulative = np.hstack(
             (0, np.cumsum(flippedUpperOutline_distances_between_points))
         )
@@ -1135,8 +1133,8 @@ class Airfoil:
             )
         )
 
-        # Create a horizontal 1D array that contains the cumulative distance along
-        # the lower original outline of each point.
+        # Create a horizontal 1D array that contains the cumulative distance along the
+        # lower original outline of each point.
         lowerOutline_distances_cumulative = np.hstack(
             (0, np.cumsum(lowerOutline_distances_between_points))
         )
@@ -1151,8 +1149,8 @@ class Airfoil:
             0.0, 1.0, n_points_per_side
         )
 
-        # Use linear interpolation to find the x and y components of the upper and
-        # lower outline points at each of the resampled cosine spaced distances.
+        # Use linear interpolation to find the x and y components of the upper and lower
+        # outline points at each of the resampled cosine spaced distances.
         upperResampledOutlineX_A_lp = np.flipud(
             np.interp(
                 cosine_spaced_normalized_distances,
@@ -1206,8 +1204,8 @@ class Airfoil:
             0.0, 1.0, self._n_points_per_side
         )
 
-        # Use linear interpolation to find the y values of the upper and lower
-        # outlines at the cosine spaced x positions.
+        # Use linear interpolation to find the y values of the upper and lower outlines
+        # at the cosine spaced x positions.
         flippedUpperOutlineY_A_lp = np.interp(
             cosine_spaced_chord_fractions,
             flippedUpperOutline_A_lp[:, 0],
@@ -1219,8 +1217,8 @@ class Airfoil:
             lowerOutline_A_lp[:, 1],
         )
 
-        # Calculate the approximate MCL points (in airfoil axes, relative to the
-        # leading point) and set the class attribute.
+        # Calculate the approximate MCL points (in airfoil axes, relative to the leading
+        # point) and set the class attribute.
         self._mcl_A_lp = np.column_stack(
             [
                 cosine_spaced_chord_fractions,

--- a/pterasoftware/geometry/airplane.py
+++ b/pterasoftware/geometry/airplane.py
@@ -220,8 +220,8 @@ class Airplane:
         self._num_panels: int | None = None
         self._T_pas_G_Cg_to_GP1_CgP1: np.ndarray | None = None
 
-        # Initialize mutable attributes to hold the forces, moments, force
-        # coefficients, and moment coefficients this Airplane experiences.
+        # Initialize mutable attributes to hold the loads and load coefficients this
+        # Airplane experiences.
         self.forces_W: np.ndarray | None = None
         self.forceCoefficients_W: np.ndarray | None = None
         self.moments_W_CgP1: np.ndarray | None = None
@@ -329,8 +329,8 @@ class Airplane:
         new_airplane._c_ref = self._c_ref
         new_airplane._b_ref = self._b_ref
 
-        # Copy _num_panels cache (depends only on Wings, not position).
-        # Reset _T_pas_G_Cg_to_GP1_CgP1 to None (depends on Cg_GP1_CgP1).
+        # Copy _num_panels cache (depends only on Wings, not position). Reset
+        # _T_pas_G_Cg_to_GP1_CgP1 to None (depends on Cg_GP1_CgP1).
         new_airplane._num_panels = self._num_panels
         new_airplane._T_pas_G_Cg_to_GP1_CgP1 = None
 
@@ -401,8 +401,8 @@ class Airplane:
             Airplane's geometry axes, relative to its CG.
         """
         if self._T_pas_G_Cg_to_GP1_CgP1 is None:
-            # generate_trans_T with passive=True expects the `translations` parameter
-            # to be the position of the target reference point (CgP1) relative to the
+            # generate_trans_T with passive=True expects the `translations` parameter to
+            # be the position of the target reference point (CgP1) relative to the
             # source reference point (Cg). Using the notation from
             # AXES_POINTS_AND_FRAMES.md: translations=CgP1_G_Cg. However, we have
             # Cg_GP1_CgP1 (position of Cg, in GP1 axes, relative to CgP1). Since
@@ -448,8 +448,8 @@ class Airplane:
         panel_vertices = np.empty((0, 3), dtype=float)
         panel_faces = np.empty(0, dtype=int)
 
-        # Initialize a variable to keep track of how many Panels' data has been added
-        # to the ndarrays.
+        # Initialize a variable to keep track of how many Panels' data has been added to
+        # the ndarrays.
         panel_num = 0
 
         # Iterate through this Airplane's Wings.
@@ -478,8 +478,8 @@ class Airplane:
                     ]
                 )
 
-                # Stack this Panel's vertices and faces with the array of all
-                # vertices and faces.
+                # Stack this Panel's vertices and faces with the array of all vertices
+                # and faces.
                 panel_vertices = np.vstack((panel_vertices, panel_vertices_to_add))
                 panel_faces = np.hstack((panel_faces, panel_face_to_add))
 
@@ -719,8 +719,8 @@ class Airplane:
                 panel_vertices = np.empty((0, 3), dtype=float)
                 panel_faces = np.empty(0, dtype=int)
 
-                # Initialize a variable to keep track of how many Panels' data has
-                # been added to the arrays
+                # Initialize a variable to keep track of how many Panels' data has been
+                # added to the arrays
                 panel_num = 0
 
                 # Unravel the Wing's Panel matrix and iterate through it
@@ -802,24 +802,23 @@ class Airplane:
             followed by the new reflected Wing. Before returning them, it also calls
             each Wing's generate_mesh method, preparing them for use simulation.
         """
-        # Determine if the symmetry plane is coincident with the wing axes' xz plane.
-        # If symmetryNormal_G or symmetryPoint_G_Cg is None, then there is no
-        # symmetry and the symmetry plane doesn't exist. Otherwise, the symmetry
-        # plane is coincident to the wing axes' xz plane if Ler_Gs_Cgs lies on the
-        # symmetry plane, and if symmetryNormal_G is parallel with WnY_G. We don't
-        # need to check types, values, or normalize because this is done in Wing's
-        # init method.
+        # Determine if the symmetry plane is coincident with the wing axes' xz plane. If
+        # symmetryNormal_G or symmetryPoint_G_Cg is None, then there is no symmetry and
+        # the symmetry plane doesn't exist. Otherwise, the symmetry plane is coincident
+        # to the wing axes' xz plane if Ler_Gs_Cgs lies on the symmetry plane, and if
+        # symmetryNormal_G is parallel with WnY_G. We don't need to check types, values,
+        # or normalize because this is done in Wing's init method.
         coincident_symmetry_plane = True
         if wing.symmetryPoint_G_Cg is None or wing.symmetryNormal_G is None:
             coincident_symmetry_plane = False
         else:
-            # If the symmetry plane exists, we first need to check if its normal
-            # vector is parallel with the wing axes' y axis vector.
+            # If the symmetry plane exists, we first need to check if its normal vector
+            # is parallel with the wing axes' y axis vector.
 
-            # Actively transform geometry axes' second basis vector (in geometry
-            # axes) to this Wing's axes' second basis vector (in geometry axes). We
-            # can skip the translation step (step 2) as we are only transforming a
-            # direction vector, not a position vector.
+            # Actively transform geometry axes' second basis vector (in geometry axes)
+            # to this Wing's axes' second basis vector (in geometry axes). We can skip
+            # the translation step (step 2) as we are only transforming a direction
+            # vector, not a position vector.
             GY_G = np.array([0.0, 1.0, 0.0], dtype=float)
             GsY_G = _transformations.apply_T_to_vectors(
                 _transformations.generate_reflect_T(
@@ -851,21 +850,20 @@ class Airplane:
             if not is_parallel:
                 coincident_symmetry_plane = False
             else:
-                # If the symmetry plane's normal vector and the wing axes y axis
-                # vector are parallel, then the last check for a coincident symmetry
-                # plane is to check if the Ler is on the symmetry plane.
+                # If the symmetry plane's normal vector and the wing axes' y axis vector
+                # are parallel, then the last check for a coincident symmetry plane is
+                # to check if the Ler is on the symmetry plane.
 
                 # To do this, we first find the symmetry plane's normal vector (in
-                # geometry axes after accounting for symmetry) and the symmetry
-                # plane's point (in geometry axes after accounting for symmetry,
-                # relative to the CG after accounting for symmetry). As the symmetry
-                # plane is defined using these quantities, they don't change after
-                # reflection.
+                # geometry axes after accounting for symmetry) and the symmetry plane's
+                # point (in geometry axes after accounting for symmetry, relative to the
+                # CG after accounting for symmetry). As the symmetry plane is defined
+                # using these quantities, they don't change after reflection.
                 symmetryPoint_Gs_Cgs = wing.symmetryPoint_G_Cg
                 symmetryNormal_Gs_Cgs = wing.symmetryNormal_G
 
-                # The leading edge root point is on the symmetry plane if the
-                # distance between it and the symmetry plane is zero.
+                # The leading edge root point is on the symmetry plane if the distance
+                # between it and the symmetry plane is zero.
                 Ler_on_plane = np.allclose(
                     np.dot(
                         symmetryNormal_Gs_Cgs, (wing.Ler_Gs_Cgs - symmetryPoint_Gs_Cgs)
@@ -876,8 +874,8 @@ class Airplane:
                 if not Ler_on_plane:
                     coincident_symmetry_plane = False
 
-        # See the Wing class docstring for the interpretation of the different
-        # symmetry types.
+        # See the Wing class docstring for the interpretation of the different symmetry
+        # types.
         if not wing.symmetric:
             if not wing.mirror_only:
                 # Type 1 Symmetry:
@@ -902,9 +900,9 @@ class Airplane:
                 # symmetric=True, coincident_symmetry_plane=False
                 symmetry_type = 5
 
-        # Based on the determined symmetry type, validate the Wing's
-        # WingCrossSections' control_surface_symmetry types. From the validation done
-        # during each WingCrossSection's initialization method, we already know that
+        # Based on the determined symmetry type, validate the Wing's WingCrossSections'
+        # control_surface_symmetry types. From the validation done during each
+        # WingCrossSection's initialization method, we already know that
         # control_surface_symmetry type is None or a valid string.
         for wing_cross_section in wing.wing_cross_sections:
             control_surface_symmetry_type = (

--- a/pterasoftware/geometry/wing.py
+++ b/pterasoftware/geometry/wing.py
@@ -339,13 +339,13 @@ class Wing:
         # refine.
         self._spanwise_mesh: str = "exploded" if explode_into_strips else "trapezoidal"
 
-        # The original, full resolution leading edge and trailing edge curves a Wing
-        # was built from. These are populated only by from_edge_points, which sets the
+        # The original, full resolution leading edge and trailing edge curves a Wing was
+        # built from. These are populated only by from_edge_points, which sets the
         # spanwise mesh marker to "edge_defined" and stores the curves (together with
         # the tip trim fraction applied while resampling them) so a future non
         # trapezoidal convergence tool can resample them to a different number of
-        # WingCrossSections. A Wing built any other way carries no such curves and a None
-        # tip trim fraction.
+        # WingCrossSections. A Wing built any other way carries no such curves and a
+        # None tip trim fraction.
         self._leadingEdgePoints_Wn_Ler: np.ndarray | None = None
         self._trailingEdgePoints_Wn_Ler: np.ndarray | None = None
         self._tip_trim_fraction: float | None = None
@@ -455,8 +455,8 @@ class Wing:
         self._children_T_pas_G_Cg_to_Wcs_Lp: list[np.ndarray] | None = None
         self._children_T_pas_Wcs_Lp_to_G_Cg: list[np.ndarray] | None = None
 
-        # Caches for properties derived from set once attributes. These are populated
-        # on first access and reset to None in deepcopy.
+        # Caches for properties derived from set once attributes. These are populated on
+        # first access and reset to None in deepcopy.
         self._projected_area: float | None = None
         self._wetted_area: float | None = None
         self._average_panel_aspect_ratio: float | None = None
@@ -595,8 +595,7 @@ class Wing:
         # the spanwise (y) direction, from the root (y of 0) to the trimmed tip. Without
         # trimming the trimmed tip is the shared maximum y. The tip_trim_fraction pulls
         # it inboard so a planform that tapers to a point at the tip ends at a finite
-        # chord.
-        # The z component is zero at every point in this planar version.
+        # chord. The z component is zero at every point in this planar version.
         yTip_Wn_Ler = float(leadingEdgePoints_Wn_Ler[-1, 1])
         yTrimmedTip_Wn_Ler = (1.0 - tip_trim_fraction) * yTip_Wn_Ler
         ys_Wn_Ler = np.linspace(0.0, yTrimmedTip_Wn_Ler, num_wing_cross_sections)
@@ -623,18 +622,19 @@ class Wing:
                     "value at every WingCrossSection."
                 )
 
-        # A symmetric Wing always resolves to symmetry type 4 or 5, both of which require
-        # every WingCrossSection to carry a non None control_surface_symmetry_type, while
-        # a non symmetric Wing (types 1 through 3) requires None. These Wings build no
-        # control surfaces, so "symmetric" with the default zero deflection adds no
-        # geometry. It is just the value that lets a symmetric Wing mesh.
+        # A symmetric Wing always resolves to symmetry type 4 or 5, both of which
+        # require every WingCrossSection to carry a non None
+        # control_surface_symmetry_type, while a non symmetric Wing (types 1 through 3)
+        # requires None. These Wings build no control surfaces, so "symmetric" with the
+        # default zero deflection adds no geometry. It is just the value that lets a
+        # symmetric Wing mesh.
         control_surface_symmetry_type = "symmetric" if symmetric else None
 
-        # Stage 3: build one single-panel WingCrossSection from each resampled point. The
-        # parent relative leading point offset is the difference of consecutive resampled
-        # leading edge points taken directly in wing axes, which is valid only because
-        # every angle vector is zero, so the wing cross section parent axes coincide with
-        # the wing axes. The root offset is the zero vector.
+        # Stage 3: build one single-panel WingCrossSection from each resampled point.
+        # The parent relative leading point offset is the difference of consecutive
+        # resampled leading edge points taken directly in wing axes, which is valid only
+        # because every angle vector is zero, so the wing cross section parent axes
+        # coincide with the wing axes. The root offset is the zero vector.
         wing_cross_sections = []
         for wing_cross_section_id in range(num_wing_cross_sections):
             is_tip = wing_cross_section_id == num_wing_cross_sections - 1
@@ -759,8 +759,8 @@ class Wing:
             else None
         )
 
-        # Copy set once mesh metadata directly to private attributes (bypassing
-        # setters) since we're copying, not setting for the first time.
+        # Copy set once mesh metadata directly to private attributes (bypassing setters)
+        # since we're copying, not setting for the first time.
         new_wing._symmetry_type = self._symmetry_type
         new_wing._num_spanwise_panels = self._num_spanwise_panels
         new_wing._num_panels = self._num_panels
@@ -782,8 +782,8 @@ class Wing:
         else:
             new_wing.gridWrvp_GP1_CgP1 = None
 
-        # Preserve caches for properties derived from immutable attributes.
-        # Copy numpy arrays and make them read-only.
+        # Preserve caches for properties derived from immutable attributes. Copy numpy
+        # arrays and make them read-only.
         if self._T_pas_G_Cg_to_Wn_Ler is not None:
             new_wing._T_pas_G_Cg_to_Wn_Ler = self._T_pas_G_Cg_to_Wn_Ler.copy()
             new_wing._T_pas_G_Cg_to_Wn_Ler.flags.writeable = False
@@ -982,17 +982,17 @@ class Wing:
             T_reflect_pas_G_Cg_to_Gs_Cgs = np.eye(4, dtype=float)
 
         # Step 2: Create T_trans_pas_Gs_Cgs_to_Gs_Ler, which maps in homogeneous
-        # coordinates from geometry axes (after accounting for symmetry) relative to
-        # the CG (after accounting for symmetry) to geometry axes (after accounting
-        # for symmetry) relative to the leading edge root point. This is the
-        # translation step.
+        # coordinates from geometry axes (after accounting for symmetry) relative to the
+        # CG (after accounting for symmetry) to geometry axes (after accounting for
+        # symmetry) relative to the leading edge root point. This is the translation
+        # step.
         T_trans_pas_Gs_Cgs_to_Gs_Ler = _transformations.generate_trans_T(
             self.Ler_Gs_Cgs, passive=True
         )
 
-        # Step 3: Create T_rot_pas_Gs_to_Wn, which maps in homogeneous coordinates
-        # from geometry axes (after accounting for symmetry) to wing axes. This is
-        # the rotation step.
+        # Step 3: Create T_rot_pas_Gs_to_Wn, which maps in homogeneous coordinates from
+        # geometry axes (after accounting for symmetry) to wing axes. This is the
+        # rotation step.
         T_rot_pas_Gs_to_Wn = _transformations.generate_rot_T(
             self.angles_Gs_to_Wn_ixyz, passive=True, intrinsic=True, order="xyz"
         )
@@ -1310,8 +1310,8 @@ class Wing:
         WnZ_G = self.WnZ_G
         assert WnZ_G is not None
 
-        # Iterate through the chordwise and spanwise indices of the Panels and add
-        # their area to the total projected area.
+        # Iterate through the chordwise and spanwise indices of the Panels and add their
+        # area to the total projected area.
         assert self._num_spanwise_panels is not None
         for chordwise_location in range(self._num_chordwise_panels):
             for spanwise_location in range(self._num_spanwise_panels):
@@ -1346,8 +1346,8 @@ class Wing:
 
         wetted_area = 0.0
 
-        # Iterate through the chordwise and spanwise indices of the panels and add
-        # their area to the total wetted area.
+        # Iterate through the chordwise and spanwise indices of the panels and add their
+        # area to the total wetted area.
         assert self._num_spanwise_panels is not None
         for chordwise_location in range(self._num_chordwise_panels):
             for spanwise_location in range(self._num_spanwise_panels):
@@ -1377,8 +1377,8 @@ class Wing:
 
         aspect_ratio_sum = 0.0
 
-        # Iterate through the chordwise and spanwise indices of the Panels and sum
-        # all the Panels' aspect ratios.
+        # Iterate through the chordwise and spanwise indices of the Panels and sum all
+        # the Panels' aspect ratios.
         assert self._num_spanwise_panels is not None
         for chordwise_location in range(self._num_chordwise_panels):
             for spanwise_location in range(self._num_spanwise_panels):
@@ -1489,11 +1489,11 @@ class Wing:
         if self._mean_aerodynamic_chord is not None:
             return self._mean_aerodynamic_chord
 
-        # This method is based on the equation for the mean aerodynamic chord of a
-        # wing, which can be found here: https://en.wikipedia.org/wiki/Chord_(
-        # aeronautics)#Mean_aerodynamic_chord. This equation integrates the squared
-        # chord from the Wing's center to the Wing's tip. We will perform this
-        # integral piecewise for each section of the Wing.
+        # This method is based on the equation for the mean aerodynamic chord of a wing,
+        # which can be found here:
+        # https://en.wikipedia.org/wiki/Chord_(aeronautics)#Mean_aerodynamic_chord. This
+        # equation integrates the squared chord from the Wing's center to the Wing's
+        # tip. We will perform this integral piecewise for each section of the Wing.
         integral = 0.0
 
         # Iterate through the WingCrossSections to add the contribution of their
@@ -1533,7 +1533,8 @@ class Wing:
                 T_pas_nextWcs_nextLp_to_Wn_Ler, nextLp_nextWcs_nextLp, is_position=True
             )
 
-            # Find the section vector and project it onto spanwise direction (wing axes y direction)
+            # Find the section vector and project it onto spanwise direction (wing axes
+            # y direction)
             nextLp_Wn_Lp = nextLp_Wn_Ler - Lp_Wn_Ler
 
             nextLpProj_Wn_Lp = np.dot(
@@ -1542,10 +1543,9 @@ class Wing:
 
             section_span = float(np.linalg.norm(nextLpProj_Wn_Lp))
 
-            # Each Wing section is, by definition, trapezoidal (at least when
-            # projected on to the wing axes' xy plane). For a trapezoid,
-            # the integral from the cited equation can be shown to evaluate to the
-            # following.
+            # Each Wing section is, by definition, trapezoidal (at least when projected
+            # on to the wing axes' xy plane). For a trapezoid, the integral from the
+            # cited equation can be shown to evaluate to the following.
             integral += (
                 section_span * (chord**2 + chord * next_chord + next_chord**2) / 3
             )
@@ -1571,10 +1571,10 @@ class Wing:
             class docstring for details on how to interpret the symmetry types.
         :return: None
         """
-        # Validate and apply symmetry_type. 5 isn't a valid symmetry type, because
-        # the parent Airplane should have modified a Wing that initially had type 5
-        # symmetry to have type 1 symmetry, and then made a new reflected Wing with
-        # type 3 symmetry.
+        # Validate and apply symmetry_type. 5 isn't a valid symmetry type, because the
+        # parent Airplane should have modified a Wing that initially had type 5 symmetry
+        # to have type 1 symmetry, and then made a new reflected Wing with type 3
+        # symmetry.
         validated_symmetry_type = _parameter_validation.int_in_range_return_int(
             symmetry_type,
             "symmetry_type",
@@ -1589,10 +1589,10 @@ class Wing:
         for wing_cross_section in self.wing_cross_sections:
             wing_cross_section.symmetry_type = validated_symmetry_type
 
-        # Find the number of spanwise panels on the wing by adding each cross
-        # section's number of spanwise panels. Exclude the last cross section's
-        # number of spanwise panels as this is irrelevant. If the wing has type 4
-        # symmetry multiply the summation by two.
+        # Find the number of spanwise Panels on this Wing by adding each
+        # WingCrossSection's number of spanwise Panels. Exclude the last
+        # WingCrossSection's number of spanwise Panels as this is irrelevant. If this
+        # Wing has type 4 symmetry multiply the summation by two.
         computed_num_spanwise_panels = 0
         for wing_cross_section in self.wing_cross_sections[:-1]:
             assert wing_cross_section.num_spanwise_panels is not None
@@ -1820,8 +1820,8 @@ class Wing:
                     ]
                 )
 
-                # Stack this Panel's vertices and faces with the array of all
-                # vertices and faces.
+                # Stack this Panel's vertices and faces with the array of all vertices
+                # and faces.
                 panel_vertices = np.vstack((panel_vertices, panel_vertices_to_add))
                 panel_faces = np.hstack((panel_faces, panel_face_to_add))
 
@@ -1985,9 +1985,10 @@ class Wing:
             chord = (1 - t) * wcs1.chord + t * wcs2.chord
             # Lp_Wcsp_Lpp and angles_Wcsp_to_Wcs_ixyz are parent-relative deltas (see
             # WingCrossSection's constructor docstring), so each of the N intermediates
-            # carries 1/N of wcs2's delta and the chain composes back to wcs2's offset
-            # and twist. This is exact only when the intermediates are uniformly
-            # spaced, which _explode_wing enforces by validating the input.
+            # carries 1.0 / N of the second WingCrossSection's delta and the chain
+            # composes back to the second WingCrossSection's offset and twist. This is
+            # exact only when the intermediates are uniformly spaced, which
+            # _explode_wing enforces by validating the input.
             Lp_Wcsp_Lpp = tuple(np.array(wcs2.Lp_Wcsp_Lpp) / N)
             angles_Wcsp_to_Wcs_ixyz = wcs2.angles_Wcsp_to_Wcs_ixyz / N
             is_final_section = wcs2.num_spanwise_panels is None and i == N - 1

--- a/pterasoftware/geometry/wing_cross_section.py
+++ b/pterasoftware/geometry/wing_cross_section.py
@@ -187,8 +187,8 @@ class WingCrossSection:
         self._airfoil = airfoil
 
         # Perform a preliminary validation for num_spanwise_panels (immutable). The
-        # parent Wing will later check that this is None if this WingCrossSection is
-        # a tip WingCrossSection.
+        # parent Wing will later check that this is None if this WingCrossSection is a
+        # tip WingCrossSection.
         if num_spanwise_panels is not None:
             num_spanwise_panels = _parameter_validation.int_in_range_return_int(
                 num_spanwise_panels,
@@ -203,9 +203,9 @@ class WingCrossSection:
             chord, "chord", min_val=0.0, min_inclusive=False
         )
 
-        # Perform a preliminary validation for Lp_Wcsp_Lpp (immutable). The parent
-        # Wing will later check that this is a zero vector if this WingCrossSection
-        # is a root WingCrossSection.
+        # Perform a preliminary validation for Lp_Wcsp_Lpp (immutable). The parent Wing
+        # will later check that this is a zero vector if this WingCrossSection is a root
+        # WingCrossSection.
         Lp_Wcsp_Lpp = _parameter_validation.threeD_number_vectorLike_return_float(
             Lp_Wcsp_Lpp, "Lp_Wcsp_Lpp"
         )
@@ -215,8 +215,8 @@ class WingCrossSection:
         self._Lp_Wcsp_Lpp = Lp_Wcsp_Lpp
         self._Lp_Wcsp_Lpp.flags.writeable = False
 
-        # Perform a preliminary validation for angles_Wcsp_to_Wcs_ixyz (immutable).
-        # The parent Wing will later check that this is a zero vector if this
+        # Perform a preliminary validation for angles_Wcsp_to_Wcs_ixyz (immutable). The
+        # parent Wing will later check that this is a zero vector if this
         # WingCrossSection is a root WingCrossSection.
         angles_Wcsp_to_Wcs_ixyz = (
             _parameter_validation.threeD_number_vectorLike_return_float(
@@ -277,9 +277,9 @@ class WingCrossSection:
             )
         )
 
-        # Perform a preliminary validation for spanwise_spacing (immutable). The
-        # parent Wing will later check that this is None if this WingCrossSection is
-        # a tip WingCrossSection.
+        # Perform a preliminary validation for spanwise_spacing (immutable). The parent
+        # Wing will later check that this is None if this WingCrossSection is a tip
+        # WingCrossSection.
         if spanwise_spacing is not None:
             spanwise_spacing = _parameter_validation.str_return_str(
                 spanwise_spacing, "spanwise_spacing"
@@ -292,14 +292,14 @@ class WingCrossSection:
                 )
         self._spanwise_spacing = spanwise_spacing
 
-        # Define a flag for if this WingCrossSection has been fully validated
-        # (set once). This will be set by the parent Wing after calling its
-        # additional validation methods.
+        # Define a flag for if this WingCrossSection has been fully validated (set
+        # once). This will be set by the parent Wing after calling its additional
+        # validation methods.
         self._validated: bool = False
 
-        # Define a flag for this WingCrossSection's parent Wing's symmetry type
-        # (set once). This will be set by its parent Wing immediately after it has
-        # its own symmetry_type parameter set by its parent Airplane.
+        # Define a flag for this WingCrossSection's parent Wing's symmetry type (set
+        # once). This will be set by its parent Wing immediately after it has its own
+        # symmetry_type parameter set by its parent Airplane.
         self._symmetry_type: int | None = None
 
         # Initialize the caches for the properties derived from the immutable

--- a/pterasoftware/movements/aeroelastic_airplane_movement.py
+++ b/pterasoftware/movements/aeroelastic_airplane_movement.py
@@ -118,9 +118,9 @@ class AeroelasticAirplaneMovement(_core.CoreAirplaneMovement):
             0.0).
         :return: None
         """
-        # Validate that every element is an AeroelasticWingMovement or a
-        # WingMovement. CoreAirplaneMovement.__init__() validates at the Core level,
-        # but AeroelasticAirplaneMovement enforces this stricter requirement.
+        # Validate that every element is an AeroelasticWingMovement or a WingMovement.
+        # CoreAirplaneMovement.__init__() validates at the Core level, but
+        # AeroelasticAirplaneMovement enforces this stricter requirement.
         for wing_movement in wing_movements:
             if not isinstance(
                 wing_movement,
@@ -134,16 +134,16 @@ class AeroelasticAirplaneMovement(_core.CoreAirplaneMovement):
                     "AeroelasticWingMovement or a WingMovement."
                 )
 
-            # Reject an AeroelasticWingMovement whose base Wing has type 4
-            # symmetry. A type 4 symmetric Wing's mirrored half has Panels but no
-            # WingCrossSections, so its strips cannot deform. The check lives at
-            # this level rather than in AeroelasticWingMovement.__init__() because
-            # a base Wing may not have been meshed yet (and so had no symmetry
-            # type) when its AeroelasticWingMovement was constructed, while a base
-            # Wing shared with the base Airplane has been meshed in place by the
-            # base Airplane's constructor by the time this check runs. A base Wing
-            # that is unmeshed and not shared with the base Airplane still passes
-            # this check, but such a Wing fails loudly in the structural solve.
+            # Reject an AeroelasticWingMovement whose base Wing has type 4 symmetry. A
+            # type 4 symmetric Wing's mirrored half has Panels but no WingCrossSections,
+            # so its strips cannot deform. The check lives at this level rather than in
+            # AeroelasticWingMovement.__init__() because a base Wing may not have been
+            # meshed yet (and so had no symmetry type) when its AeroelasticWingMovement
+            # was constructed, while a base Wing shared with the base Airplane has been
+            # meshed in place by the base Airplane's constructor by the time this check
+            # runs. A base Wing that is unmeshed and not shared with the base Airplane
+            # still passes this check, but such a Wing fails loudly in the structural
+            # solve.
             if (
                 isinstance(
                     wing_movement,
@@ -249,9 +249,9 @@ class AeroelasticAirplaneMovement(_core.CoreAirplaneMovement):
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Generate the Wings for this time step, threading deformation to
-        # each AeroelasticWingMovement child. WingMovement children are advanced
-        # without deformation.
+        # Generate the Wings for this time step, threading deformation to each
+        # AeroelasticWingMovement child. WingMovement children are advanced without
+        # deformation.
         these_wings = []
         for i, wing_movement in enumerate(self.wing_movements):
             # Extract this Wing's deformation, or None.

--- a/pterasoftware/movements/aeroelastic_movement.py
+++ b/pterasoftware/movements/aeroelastic_movement.py
@@ -98,8 +98,8 @@ class AeroelasticMovement(_core.CoreMovement):
                 )
 
         # Validate that operating_point_movement is an OperatingPointMovement.
-        # CoreMovement.__init__() validates at the Core level, but
-        # AeroelasticMovement enforces the concrete type.
+        # CoreMovement.__init__() validates at the Core level, but AeroelasticMovement
+        # enforces the concrete type.
         if not isinstance(
             operating_point_movement,
             operating_point_movement_mod.OperatingPointMovement,

--- a/pterasoftware/movements/aeroelastic_movement.py
+++ b/pterasoftware/movements/aeroelastic_movement.py
@@ -84,9 +84,9 @@ class AeroelasticMovement(_core.CoreMovement):
             Wing. Must be a positive int if set. The default is None (no truncation).
         :return: None
         """
-        # Validate that every element is an AeroelasticAirplaneMovement, not
-        # just a CoreAirplaneMovement. CoreMovement.__init__() validates at
-        # the Core level, but AeroelasticMovement enforces the stricter type.
+        # Validate that every element is an AeroelasticAirplaneMovement, not just a
+        # CoreAirplaneMovement. CoreMovement.__init__() validates at the Core level, but
+        # AeroelasticMovement enforces the stricter type.
         for airplane_movement in airplane_movements:
             if not isinstance(
                 airplane_movement,
@@ -118,8 +118,8 @@ class AeroelasticMovement(_core.CoreMovement):
         )
 
         # --- Batch generate OperatingPoints ---
-        # OperatingPoints are prescribed in aeroelastic simulations, so
-        # generate them all upfront.
+        # OperatingPoints are prescribed in aeroelastic simulations, so generate them
+        # all upfront.
         operating_points_list = operating_point_movement.generate_operating_points(
             num_steps=self._num_steps, delta_time=self._delta_time
         )

--- a/pterasoftware/movements/aeroelastic_wing_cross_section_movement.py
+++ b/pterasoftware/movements/aeroelastic_wing_cross_section_movement.py
@@ -235,8 +235,7 @@ class AeroelasticWingCrossSectionMovement(_core.CoreWingCrossSectionMovement):
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Evaluate the oscillating value for each dimension of
-        # angles_Wcsp_to_Wcs_ixyz.
+        # Evaluate the oscillating value for each dimension of angles_Wcsp_to_Wcs_ixyz.
         theseAngles_Wcsp_to_Wcs_ixyz = np.zeros(3, dtype=float)
         for dim in range(3):
             this_spacing = self._spacingAngles_Wcsp_to_Wcs_ixyz[dim]
@@ -279,9 +278,9 @@ class AeroelasticWingCrossSectionMovement(_core.CoreWingCrossSectionMovement):
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Apply structural deformation if provided. The deformation angles
-        # are added to the prescribed angles, representing the structural
-        # response computed by the aeroelastic solver.
+        # Apply structural deformation if provided. The deformation angles are added to
+        # the prescribed angles, representing the structural response computed by the
+        # aeroelastic solver.
         if deformationAngles_Wcsp_to_Wcs_ixyz is not None:
             theseAngles_Wcsp_to_Wcs_ixyz = (
                 theseAngles_Wcsp_to_Wcs_ixyz + deformationAngles_Wcsp_to_Wcs_ixyz

--- a/pterasoftware/movements/aeroelastic_wing_movement.py
+++ b/pterasoftware/movements/aeroelastic_wing_movement.py
@@ -217,10 +217,9 @@ class AeroelasticWingMovement(_core.CoreWingMovement):
             default is None.
         :return: None
         """
-        # Validate that every element is an AeroelasticWingCrossSectionMovement,
-        # not just a CoreWingCrossSectionMovement. CoreWingMovement.__init__()
-        # validates at the Core level, but AeroelasticWingMovement enforces the
-        # stricter type.
+        # Validate that every element is an AeroelasticWingCrossSectionMovement, not
+        # just a CoreWingCrossSectionMovement. CoreWingMovement.__init__() validates at
+        # the Core level, but AeroelasticWingMovement enforces the stricter type.
         for wing_cross_section_movement in wing_cross_section_movements:
             if not isinstance(
                 wing_cross_section_movement,
@@ -384,8 +383,7 @@ class AeroelasticWingMovement(_core.CoreWingMovement):
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Evaluate the oscillating value for each dimension of
-        # angles_Gs_to_Wn_ixyz.
+        # Evaluate the oscillating value for each dimension of angles_Gs_to_Wn_ixyz.
         theseAngles_Gs_to_Wn_ixyz = np.zeros(3, dtype=float)
         for dim in range(3):
             this_spacing = self._spacingAngles_Gs_to_Wn_ixyz[dim]
@@ -424,8 +422,8 @@ class AeroelasticWingMovement(_core.CoreWingMovement):
             else:
                 raise ValueError(f"Invalid spacing value: {this_spacing}")
 
-        # Generate the WingCrossSections for this time step, threading
-        # deformation to each AeroelasticWingCrossSectionMovement child.
+        # Generate the WingCrossSections for this time step, threading deformation to
+        # each AeroelasticWingCrossSectionMovement child.
         these_wing_cross_sections = []
         for i, wing_cross_section_movement in enumerate(
             self._wing_cross_section_movements
@@ -450,9 +448,8 @@ class AeroelasticWingMovement(_core.CoreWingMovement):
                 )
             )
 
-        # If there is a non zero rotation point offset, adjust the position
-        # to account for rotation about the offset point instead of the
-        # leading edge root.
+        # If there is a non zero rotation point offset, adjust the position to account
+        # for rotation about the offset point instead of the leading edge root.
         if not np.allclose(self._rotationPointOffset_Gs_Ler, np.zeros(3, dtype=float)):
             rot_T_act = _transformations.generate_rot_T(
                 theseAngles_Gs_to_Wn_ixyz,

--- a/pterasoftware/movements/airplane_movement.py
+++ b/pterasoftware/movements/airplane_movement.py
@@ -98,9 +98,9 @@ class AirplaneMovement(_core.CoreAirplaneMovement):
             0.0).
         :return: None
         """
-        # Validate that every element is a WingMovement, not just a
-        # CoreWingMovement. CoreAirplaneMovement.__init__() validates at the Core
-        # level, but AirplaneMovement enforces the stricter type.
+        # Validate that every element is a WingMovement, not just a CoreWingMovement.
+        # CoreAirplaneMovement.__init__() validates at the Core level, but
+        # AirplaneMovement enforces the stricter type.
         for wing_movement in wing_movements:
             if not isinstance(wing_movement, wing_movement_mod.WingMovement):
                 raise TypeError(

--- a/pterasoftware/movements/free_flight_movement.py
+++ b/pterasoftware/movements/free_flight_movement.py
@@ -101,8 +101,7 @@ class FreeFlightMovement(_core.CoreMovement):
                     "AirplaneMovement."
                 )
 
-        # Validate that operating_point_movement is a
-        # FreeFlightOperatingPointMovement.
+        # Validate that operating_point_movement is a FreeFlightOperatingPointMovement.
         if not isinstance(
             operating_point_movement,
             free_flight_operating_point_movement_mod.FreeFlightOperatingPointMovement,
@@ -142,9 +141,8 @@ class FreeFlightMovement(_core.CoreMovement):
 
         # --- Batch generate Airplanes ---
         # Generate a list of lists of Airplanes that are the steps through each
-        # AirplaneMovement. The first index identifies the
-        # AirplaneMovement, and the second index identifies the time
-        # step.
+        # AirplaneMovement. The first index identifies the AirplaneMovement, and the
+        # second index identifies the time step.
         airplanes_temp: list[list[geometry.airplane.Airplane]] = []
         for airplane_movement in self.airplane_movements:
             airplanes_temp.append(
@@ -153,8 +151,7 @@ class FreeFlightMovement(_core.CoreMovement):
                 )
             )
 
-        # Validate that all Wings maintain their symmetry type across all time
-        # steps.
+        # Validate that all Wings maintain their symmetry type across all time steps.
         for airplane_movement_id, airplane_list in enumerate(airplanes_temp):
             # Get the base Airplane (first time step).
             base_airplane = airplane_list[0]

--- a/pterasoftware/movements/free_flight_movement.py
+++ b/pterasoftware/movements/free_flight_movement.py
@@ -88,9 +88,9 @@ class FreeFlightMovement(_core.CoreMovement):
             Wing. Must be a positive int if set. The default is None (no truncation).
         :return: None
         """
-        # Validate that every element is an AirplaneMovement.
-        # CoreMovement.__init__() validates at the Core level, but
-        # FreeFlightMovement enforces the concrete type.
+        # Validate that every element is an AirplaneMovement. CoreMovement.__init__()
+        # validates at the Core level, but FreeFlightMovement enforces the concrete
+        # type.
         for airplane_movement in airplane_movements:
             if not isinstance(
                 airplane_movement,

--- a/pterasoftware/movements/free_flight_operating_point_movement.py
+++ b/pterasoftware/movements/free_flight_operating_point_movement.py
@@ -51,9 +51,9 @@ class FreeFlightOperatingPointMovement(_core.CoreOperatingPointMovement):
         """
         super().__init__(base_operating_point=base_operating_point)
 
-        # Mutable list of OperatingPoints. The solver appends new
-        # OperatingPoints from dynamics integration at each time step. Starts
-        # with the base OperatingPoint at step 0.
+        # Mutable list of OperatingPoints. The solver appends new OperatingPoints from
+        # dynamics integration at each time step. Starts with the base OperatingPoint at
+        # step 0.
         self.operating_points: list[operating_point_mod.OperatingPoint] = [
             base_operating_point
         ]

--- a/pterasoftware/movements/movement.py
+++ b/pterasoftware/movements/movement.py
@@ -26,12 +26,12 @@ from . import operating_point_movement as operating_point_movement_mod
 
 _logger = _logging.get_logger("movements.movement")
 
-# The minimum number of time steps per LCM period that the default delta_time
-# estimate must provide. The analytical estimate matches the wake ring vortex
-# and bound ring vortex chord lengths, which does not by itself guarantee that
-# the motion is resolved in time: a coarse chordwise discretization or a slow
-# motion can produce a delta_time too large to sample the motion adequately.
-# The estimate is clamped to this temporal resolution to guard against that.
+# The minimum number of time steps per LCM period that the default delta_time estimate
+# must provide. The analytical estimate matches the wake ring vortex and bound ring
+# vortex chord lengths, which does not by itself guarantee that the motion is resolved
+# in time: a coarse chordwise discretization or a slow motion can produce a delta_time
+# too large to sample the motion adequately. The estimate is clamped to this temporal
+# resolution to guard against that.
 _MIN_TIME_STEPS_PER_LCM_PERIOD: int = 30
 
 
@@ -135,9 +135,9 @@ class Movement(_core.CoreMovement):
         """
         # --- Validate types early ---
         # CoreMovement.__init__() validates these, but Movement needs to use
-        # the parameters before calling super().__init__() (for delta_time
-        # estimation and period computation). Validate here so that bad types
-        # produce clear TypeErrors rather than AttributeErrors.
+        # the parameters before calling super().__init__() (for delta_time estimation
+        # and period computation). Validate here so that bad types produce clear
+        # TypeErrors rather than AttributeErrors.
         if not isinstance(airplane_movements, list):
             raise TypeError("airplane_movements must be a list.")
         if len(airplane_movements) < 1:
@@ -159,10 +159,9 @@ class Movement(_core.CoreMovement):
             )
 
         # --- Compute period properties locally ---
-        # These are needed for the delta_time estimate clamp and for the
-        # num_steps and max_wake calculations before super().__init__() is
-        # called. The same values will be lazily cached by CoreMovement when
-        # accessed via properties.
+        # These are needed for the delta_time estimate clamp and for the num_steps and
+        # max_wake calculations before super().__init__() is called. The same values
+        # will be lazily cached by CoreMovement when accessed via properties.
         _airplane_movement_max_periods = []
         for airplane_movement in airplane_movements:
             _airplane_movement_max_periods.append(airplane_movement.max_period)
@@ -198,9 +197,9 @@ class Movement(_core.CoreMovement):
                 delta_time, "delta_time", min_val=0.0, min_inclusive=False
             )
         else:
-            # Calculate a fast initial delta_time estimate based on freestream
-            # velocity. This is used as a fallback for static movements and as
-            # a starting point for the analytical optimization.
+            # Calculate a fast initial delta_time estimate based on freestream velocity.
+            # This is used as a fallback for static Movements and as a starting point
+            # for the analytical optimization.
             delta_times = []
             for airplane_movement in airplane_movements:
                 # TODO: Consider making this also average across each Airplane's Wings.
@@ -213,8 +212,8 @@ class Movement(_core.CoreMovement):
                 )
             fast_estimate = sum(delta_times) / len(delta_times)
 
-            # Run analytical optimization to get a better delta_time that accounts
-            # for both freestream and geometry motion velocities.
+            # Run analytical optimization to get a better delta_time that accounts for
+            # both freestream and geometry motion velocities.
             delta_time = _analytically_optimize_delta_time(
                 airplane_movements=list(airplane_movements),
                 operating_point_movement=operating_point_movement,
@@ -222,15 +221,15 @@ class Movement(_core.CoreMovement):
             )
 
             # Clamp the estimate so that there are at least
-            # _MIN_TIME_STEPS_PER_LCM_PERIOD time steps per LCM period, which
-            # the wake sizing criterion alone does not guarantee.
+            # _MIN_TIME_STEPS_PER_LCM_PERIOD time steps per LCM period, which the wake
+            # sizing criterion alone does not guarantee.
             if _lcm_period > 0.0:
                 delta_time = min(
                     delta_time, _lcm_period / _MIN_TIME_STEPS_PER_LCM_PERIOD
                 )
 
-        # Run iterative optimization if requested, using the analytical result
-        # as the initial guess.
+        # Run iterative optimization if requested, using the analytical result as the
+        # initial guess.
         if _should_iteratively_optimize_delta_time:
             delta_time = _optimize_delta_time(
                 airplane_movements=list(airplane_movements),
@@ -296,8 +295,8 @@ class Movement(_core.CoreMovement):
             )
         else:
             if _static:
-                # Find the value of the largest reference chord length of all the
-                # base Airplanes.
+                # Find the value of the largest reference chord length of all the base
+                # Airplanes.
                 c_refs = []
                 for airplane_movement in airplane_movements:
                     c_ref = airplane_movement.base_airplane.c_ref
@@ -305,8 +304,8 @@ class Movement(_core.CoreMovement):
                     c_refs.append(c_ref)
                 max_c_ref = max(c_refs)
 
-                # Set the number of time steps such that the wake extends back by
-                # some number of reference chord lengths.
+                # Set the number of time steps such that the wake extends back by some
+                # number of reference chord lengths.
                 assert num_chords is not None
                 wake_length = num_chords * max_c_ref
                 distance_per_time_step = (
@@ -314,9 +313,9 @@ class Movement(_core.CoreMovement):
                 )
                 num_steps = math.ceil(wake_length / distance_per_time_step)
             else:
-                # Set the number of time steps such that the simulation runs for
-                # some number of cycles of all motions. Use the LCM of all periods
-                # to ensure each motion completes an integer number of cycles.
+                # Set the number of time steps such that the simulation runs for some
+                # number of cycles of all motions. Use the LCM of all periods to ensure
+                # each motion completes an integer number of cycles.
                 assert num_cycles is not None
                 num_steps = math.ceil(num_cycles * _lcm_period / delta_time)
 
@@ -353,8 +352,8 @@ class Movement(_core.CoreMovement):
                 min_inclusive=True,
             )
 
-        # Convert max_wake_chords to max_wake_rows using the same formula as
-        # num_chords to num_steps.
+        # Convert max_wake_chords to max_wake_rows using the same formula as num_chords
+        # to num_steps.
         if max_wake_chords is not None:
             c_refs = []
             for airplane_movement in airplane_movements:
@@ -370,8 +369,8 @@ class Movement(_core.CoreMovement):
                 max_wake_chords * max_c_ref / distance_per_time_step
             )
 
-        # Convert max_wake_cycles to max_wake_rows using the same formula as
-        # num_cycles to num_steps.
+        # Convert max_wake_cycles to max_wake_rows using the same formula as num_cycles
+        # to num_steps.
         if max_wake_cycles is not None:
             max_wake_rows = math.ceil(max_wake_cycles * _lcm_period / delta_time)
 
@@ -384,11 +383,10 @@ class Movement(_core.CoreMovement):
             max_wake_rows=max_wake_rows,
         )
 
-        # Pre-populate the lazy caches with values already computed above so
-        # that accessing the inherited properties does not redundantly
-        # recompute them. _max_period, _lcm_period, and _static are set here
-        # because they are always needed during __init__ (via the static
-        # check). _min_period remains lazy.
+        # Pre-populate the lazy caches with values already computed above so that
+        # accessing the inherited properties does not redundantly recompute them.
+        # _max_period, _lcm_period, and _static are set here because they are always
+        # needed during __init__ (via the static check). _min_period remains lazy.
         self._max_period = _max_period
         self._lcm_period = _lcm_period
         self._static = _static
@@ -498,11 +496,10 @@ class Movement(_core.CoreMovement):
         return self._operating_points
 
 
-# Oversampling factor for the non static cached path. The high resolution
-# Movement is built with _NON_STATIC_CACHE_OVERSAMPLE * max_num_steps
-# intervals (and therefore one more snapshot) so the maximum and half maximum
-# candidates have integer strides and other candidates stay within roughly
-# half a high resolution step of the nominal time.
+# Oversampling factor for the non static cached path. The high resolution Movement is
+# built with _NON_STATIC_CACHE_OVERSAMPLE * max_num_steps intervals (and therefore one
+# more snapshot) so the maximum and half maximum candidates have integer strides and
+# other candidates stay within roughly half a high resolution step of the nominal time.
 _NON_STATIC_CACHE_OVERSAMPLE: int = 2
 
 
@@ -719,17 +716,17 @@ def _compute_wake_area_mismatch(
                 )
 
                 # Wake first row area depends on how the solver's wake populator
-                # constructs the back vertices. At step 1 (first wake population, run
-                # at solver step 0), there is no preexisting wake grid: the populator
-                # sets row 0 to the bound TE back vertices at step 1 and row 1 to
-                # row 0 + vInf(0) * dt. The area collapses to
-                # dt * |cross(Brrvp_curr - Blrvp_curr, vInf_prev)|. At step k >= 2,
-                # the populator copies the previous step's wake grid forward, advects
-                # it by vInf(k - 1) * dt, then prepends a new front row from bound TE
-                # back vertices at step k. The first wake row's back vertices are
-                # therefore Blrvp_prev + vInf_prev * dt and Brrvp_prev +
-                # vInf_prev * dt, where Blrvp_prev and Brrvp_prev are the previous
-                # step's bound TE back vertices already computed above.
+                # constructs the back vertices. At step 1 (first wake population, run at
+                # solver step 0), there is no preexisting wake grid: the populator sets
+                # row 0 to the bound TE back vertices at step 1 and row 1 to row 0 +
+                # vInf(0) * dt. The area collapses to dt * |cross(Brrvp_curr -
+                # Blrvp_curr, vInf_prev)|. At step k >= 2, the populator copies the
+                # previous step's wake grid forward, advects it by vInf(k - 1) * dt,
+                # then prepends a new front row from bound TE back vertices at step k.
+                # The first wake row's back vertices are therefore Blrvp_prev +
+                # vInf_prev * dt and Brrvp_prev + vInf_prev * dt, where Blrvp_prev and
+                # Brrvp_prev are the previous step's bound TE back vertices already
+                # computed above.
                 if step == 1:
                     span_vec = Brrvp_curr - Blrvp_curr
                     wake_areas = delta_time * np.linalg.norm(
@@ -798,8 +795,8 @@ def _compute_wake_area_mismatches_cached_non_static(
     max_candidate = max(num_steps_candidates)
     high_res_num_intervals = _NON_STATIC_CACHE_OVERSAMPLE * max_candidate
     high_res_dt = lcm_period / high_res_num_intervals
-    # The Movement covers high_res_num_intervals + 1 snapshots so that one full
-    # LCM period worth of intervals can be sampled.
+    # The Movement covers high_res_num_intervals + 1 snapshots so that one full LCM
+    # period worth of intervals can be sampled.
     high_res_num_steps = high_res_num_intervals + 1
 
     airplane_movements_copy = copy.deepcopy(airplane_movements)
@@ -815,10 +812,9 @@ def _compute_wake_area_mismatches_cached_non_static(
 
     first_problem = temp_problem.steady_problems[0]
 
-    # Per (airplane, wing) cache of TE panel corners. Each stored array has
-    # shape (high_res_num_steps, num_spanwise_panels, 3) so that strided
-    # advanced indexing produces (N + 1, num_spanwise_panels, 3) views per
-    # candidate.
+    # Per (Airplane, Wing) cache of TE Panel corners. Each stored array has shape
+    # (high_res_num_steps, num_spanwise_panels, 3) so that strided advanced indexing
+    # produces (N + 1, num_spanwise_panels, 3) views per candidate.
     cache_per_wing: list[dict] = []
     for airplane_id, airplane in enumerate(first_problem.airplanes):
         for wing_id, wing in enumerate(airplane.wings):
@@ -923,18 +919,18 @@ def _evaluate_cached_wake_area_mismatch(
 
     delta_time = lcm_period / num_steps
 
-    # Linear interpolation mapping from candidate steps to high resolution
-    # samples. The floor index gives the lower bracketing sample; the fractional
-    # part is the interpolation weight on the next sample. Only num_steps
-    # candidate samples are generated since the comparison loop reads indices
-    # [0, num_steps - 1]; the t = lcm_period sample would be dead.
+    # Linear interpolation mapping from candidate steps to high resolution samples. The
+    # floor index gives the lower bracketing sample; the fractional part is the
+    # interpolation weight on the next sample. Only num_steps candidate samples are
+    # generated since the comparison loop reads indices [0, num_steps - 1]; the t =
+    # lcm_period sample would be dead.
     fractional_indices = np.arange(num_steps) * high_res_num_intervals / num_steps
     floor_indices = np.floor(fractional_indices).astype(int)
     weights_next = fractional_indices - floor_indices
     next_indices = floor_indices + 1
     weights_floor = 1.0 - weights_next
-    # Reshape weights for broadcasting against (num_samples, num_spanwise, 3)
-    # panel arrays.
+    # Reshape weights for broadcasting against (num_samples, num_spanwise, 3) Panel
+    # arrays.
     weights_floor_b = weights_floor[:, None, None]
     weights_next_b = weights_next[:, None, None]
     # Reshape weights for broadcasting against (num_samples, 3) vInf arrays.
@@ -945,9 +941,9 @@ def _evaluate_cached_wake_area_mismatch(
     num_comparisons = 0
 
     for cache in cache_per_wing:
-        # Sample and linearly interpolate the cached panel attribute arrays at
-        # the candidate step times. Each result has shape (num_steps,
-        # num_spanwise_panels, 3); v_inf has shape (num_steps, 3).
+        # Sample and linearly interpolate the cached Panel attribute arrays at the
+        # candidate step times. Each result has shape (num_steps, num_spanwise_panels,
+        # 3). v_inf has shape (num_steps, 3).
         Flpp = (
             weights_floor_b * cache["Flpp"][floor_indices]
             + weights_next_b * cache["Flpp"][next_indices]
@@ -982,17 +978,17 @@ def _evaluate_cached_wake_area_mismatch(
         v_inf_prev_arr = v_inf[: num_steps - 1, None, :]
         v_inf_curr_arr = v_inf[1:num_steps, None, :]
 
-        # Bound RingVortex front vertices at the previous step (panel quarter
-        # chord, no derivative term).
+        # Bound RingVortex front vertices at the previous step (Panel quarter chord, no
+        # derivative term).
         Flrvp_prev = 0.75 * Flpp_prev_arr + 0.25 * Blpp_prev_arr
         Frrvp_prev = 0.75 * Frpp_prev_arr + 0.25 * Brpp_prev_arr
 
-        # Bound RingVortex back vertices at the previous step. For comparison
-        # index 0 (prev_step == 0) there is no panel at step - 2; substituting
-        # the step - 1 panel makes the derivative formula collapse to the
-        # solver's no-derivative form 0.75*Blpp + 0.25*Blpp + 0.25*vInf*dt =
-        # Blpp + 0.25*vInf*dt, so we get the correct value for both i == 0 and
-        # i >= 1 from a single vectorized expression.
+        # Bound RingVortex back vertices at the previous step. For comparison index 0
+        # (prev_step == 0) there is no Panel at step - 2. Substituting the step - 1
+        # Panel makes the derivative formula collapse to the solver's no-derivative form
+        # 0.75 * Blpp + 0.25 * Blpp + 0.25 * vInf * dt = Blpp + 0.25 * vInf * dt, so we
+        # get the correct value for both i == 0 and i >= 1 from a single vectorized
+        # expression.
         Blpp_prev_prev_arr = np.concatenate(
             [Blpp_prev_arr[:1], Blpp_prev_arr[:-1]], axis=0
         )
@@ -1016,8 +1012,8 @@ def _evaluate_cached_wake_area_mismatch(
         bound_diag2 = Flrvp_prev - Brrvp_prev
         bound_areas = 0.5 * np.linalg.norm(np.cross(bound_diag1, bound_diag2), axis=-1)
 
-        # Bound RingVortex back vertices at the current step. These are the
-        # front vertices of the wake first row at the current step.
+        # Bound RingVortex back vertices at the current step. These are the front
+        # vertices of the wake first row at the current step.
         Blrvp_curr = (
             0.75 * Blpp_curr_arr
             + 0.25 * Blpp_prev_arr
@@ -1029,12 +1025,12 @@ def _evaluate_cached_wake_area_mismatch(
             + 0.25 * v_inf_curr_arr * delta_time
         )
 
-        # Wake first row back vertices. At comparison index 0 (step == 1, first
-        # wake population) the solver sets row 1 = row 0 + vInf * dt, so the
-        # wake's back row is the bound TE back at the *current* step advected.
-        # At i >= 1 the wake's back row is the bound TE back at the *previous*
-        # step advected. Substituting Blrvp_curr[0] for index 0 of the previous
-        # step array makes a single vectorized expression cover both cases.
+        # The following computes the wake first row back vertices. At comparison index 0
+        # (step == 1, first wake population) the solver sets row 1 = row 0 + vInf * dt,
+        # so the wake's back row is the bound TE back at the current step advected. At i
+        # >= 1 the wake's back row is the bound TE back at the previous step advected.
+        # Substituting Blrvp_curr[0] for index 0 of the previous step array makes a
+        # single vectorized expression cover both cases.
         Blrvp_prev_for_wake = np.concatenate([Blrvp_curr[:1], Blrvp_prev[1:]], axis=0)
         Brrvp_prev_for_wake = np.concatenate([Brrvp_curr[:1], Brrvp_prev[1:]], axis=0)
         Flwrvp = Blrvp_curr
@@ -1266,10 +1262,10 @@ def _optimize_delta_time_non_static(
 
     candidates = list(range(min_num_steps, max_num_steps + 1))
 
-    # Build one high resolution Movement and score every integer candidate against it
-    # by linearly interpolating the cached panel corners. This collapses the per
-    # candidate Movement and UnsteadyProblem cost into a single up front build for
-    # the entire bracket.
+    # Build one high resolution Movement and score every integer candidate against it by
+    # linearly interpolating the cached panel corners. This collapses the per candidate
+    # Movement and UnsteadyProblem cost into a single up front build for the entire
+    # bracket.
     cached_mismatches = _compute_wake_area_mismatches_cached_non_static(
         airplane_movements=airplane_movements,
         operating_point_movement=operating_point_movement,
@@ -1441,11 +1437,11 @@ def _analytically_optimize_delta_time(
             assert _panels is not None
             num_spanwise = _panels.shape[1]
 
-            # Compute the mean chordwise width of trailing edge Panels. This is
-            # the target chord length for wake ring vortices. We use the trailing
-            # edge Panel chord directly (rather than standard_mean_chord /
-            # num_chordwise) because non uniform chordwise spacing can cause
-            # trailing edge Panels to have different chords than average.
+            # Compute the mean chordwise width of trailing edge Panels. This is the
+            # target chord length for wake ring vortices. We use the trailing edge Panel
+            # chord directly (rather than standard_mean_chord / num_chordwise) because
+            # non uniform chordwise spacing can cause trailing edge Panels to have
+            # different chords than average.
             total_te_panel_chord = 0.0
             for spanwise_id in range(num_spanwise):
                 te_panel = _panels[num_chordwise - 1, spanwise_id]
@@ -1461,8 +1457,8 @@ def _analytically_optimize_delta_time(
                 total_te_panel_chord += panel_chord
             mean_te_panel_chord = total_te_panel_chord / num_spanwise
 
-            # Accumulate displacement distance across all trailing edge Panels
-            # across all consecutive time step pairs.
+            # Accumulate displacement distance across all trailing edge Panels across
+            # all consecutive time step pairs.
             total_distance = 0.0
             num_measurements = 0
 
@@ -1528,8 +1524,8 @@ def _analytically_optimize_delta_time(
 
             # Average distance over one LCM period per spanwise Panel.
             average_distance = total_distance / num_measurements
-            # The desired number of steps per LCM period is such that each wake
-            # ring vortex chord equals the trailing edge bound Panel chord.
+            # The desired number of steps per LCM period is such that each wake ring
+            # vortex chord equals the trailing edge bound Panel chord.
             wing_num_steps_per_lcm = average_distance / mean_te_panel_chord
             wing_num_steps_values.append(wing_num_steps_per_lcm)
             wing_num_spanwise_panels_values.append(num_spanwise)

--- a/pterasoftware/movements/movement.py
+++ b/pterasoftware/movements/movement.py
@@ -134,10 +134,10 @@ class Movement(_core.CoreMovement):
         :return: None
         """
         # --- Validate types early ---
-        # CoreMovement.__init__() validates these, but Movement needs to use
-        # the parameters before calling super().__init__() (for delta_time estimation
-        # and period computation). Validate here so that bad types produce clear
-        # TypeErrors rather than AttributeErrors.
+        # CoreMovement.__init__() validates these, but Movement needs to use the
+        # parameters before calling super().__init__() (for delta_time estimation and
+        # period computation). Validate here so that bad types produce clear TypeErrors
+        # rather than AttributeErrors.
         if not isinstance(airplane_movements, list):
             raise TypeError("airplane_movements must be a list.")
         if len(airplane_movements) < 1:
@@ -965,10 +965,9 @@ def _evaluate_cached_wake_area_mismatch(
             + weights_next_v * v_inf_high_res[next_indices]
         )
 
-        # Comparison axis: index i in [0, num_steps - 2] maps to
-        # step = i + 1, prev_step = i. Slice the panel arrays accordingly so
-        # bound and wake area calculations can run as one vectorized batch
-        # rather than a Python step loop.
+        # Comparison axis: index i in [0, num_steps - 2] maps to step = i + 1, prev_step
+        # = i. Slice the panel arrays accordingly so bound and wake area calculations
+        # can run as one vectorized batch rather than a Python step loop.
         Flpp_prev_arr = Flpp[: num_steps - 1]
         Frpp_prev_arr = Frpp[: num_steps - 1]
         Blpp_prev_arr = Blpp[: num_steps - 1]

--- a/pterasoftware/operating_point.py
+++ b/pterasoftware/operating_point.py
@@ -380,12 +380,13 @@ class OperatingPoint:
         else:
             new_operating_point._surfacePoint_E_Eo = None
 
-        # Copy the scalar dynamic pressure cache directly, preserving None when it has not
-        # been computed.
+        # Copy the scalar dynamic pressure cache directly, preserving None when it has
+        # not been computed.
         new_operating_point._qInf__E = self._qInf__E
 
         # Copy each cached transformation matrix into a new read only array, or keep it
-        # None. These are all derived from immutable attributes, so the copies stay valid.
+        # None. These are all derived from immutable attributes, so the copies stay
+        # valid.
         if self._T_pas_GP1_CgP1_to_BP1_CgP1 is not None:
             new_operating_point._T_pas_GP1_CgP1_to_BP1_CgP1 = (
                 self._T_pas_GP1_CgP1_to_BP1_CgP1.copy()
@@ -471,8 +472,8 @@ class OperatingPoint:
         else:
             new_operating_point._T_pas_E_CgP1_to_W_CgP1 = None
 
-        # Copy each remaining cached derived array into a new read only array, or keep it
-        # None. These are also derived from immutable attributes.
+        # Copy each remaining cached derived array into a new read only array, or keep
+        # it None. These are also derived from immutable attributes.
         if self._surfaceNormal_GP1 is not None:
             new_operating_point._surfaceNormal_GP1 = self._surfaceNormal_GP1.copy()
             new_operating_point._surfaceNormal_GP1.flags.writeable = False

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -113,8 +113,8 @@ _text_min_position = (0.85, 0.050)
 _text_speed_position = (0.05, 0.075)
 _text_font_size = 11
 
-# Set the line widths for the results plots. Lines are drawn from thickest to
-# thinnest so that all remain visible even when they overlap.
+# Set the line widths for the results plots. Lines are drawn from thickest to thinnest
+# so that all remain visible even when they overlap.
 _max_line_width = 3.5
 _min_line_width = 1.5
 _legend_line_width = (_max_line_width + _min_line_width) / 2
@@ -251,9 +251,9 @@ def draw(
 
     # For a free flight solver, geometry is rendered in its true Earth-frame pose so the
     # body flies through the scene. T_pas_GP1_CgP1_to_E_Eo holds the passive
-    # transformation from the first Airplane's geometry axes (relative to its CG) to Earth
-    # axes (relative to the Earth origin) for the drawn time step, and stays None for the
-    # standard body-fixed rendering in geometry axes.
+    # transformation from the first Airplane's geometry axes (relative to its CG) to
+    # Earth axes (relative to the Earth origin) for the drawn time step, and stays None
+    # for the standard body-fixed rendering in geometry axes.
     is_free_flight = isinstance(
         solver,
         free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
@@ -349,9 +349,9 @@ def draw(
     image_surface_mesh = None
 
     # For free flight, the active reflection is represented in geometry axes, but the
-    # geometry has been mapped into Earth axes. Re-expressing the reflection in Earth axes
-    # (a change of basis by the same passive transformation) lets the reflected-geometry
-    # code below operate entirely in Earth axes.
+    # geometry has been mapped into Earth axes. Re-expressing the reflection in Earth
+    # axes (a change of basis by the same passive transformation) lets the
+    # reflected-geometry code below operate entirely in Earth axes.
     if T_pas_GP1_CgP1_to_E_Eo is not None and T_reflect is not None:
         T_reflect = (
             T_pas_GP1_CgP1_to_E_Eo
@@ -359,8 +359,8 @@ def draw(
             @ _transformations.invert_T_pas(T_pas_GP1_CgP1_to_E_Eo)
         )
 
-    # If an image surface is defined, add reflected geometry. The image surface plane
-    # is added later, after the geometry bounds are captured.
+    # If an image surface is defined, add reflected geometry. The image surface plane is
+    # added later, after the geometry bounds are captured.
     if T_reflect is not None:
         mute = _image_reflection_mute_factor
         muted_edge_color = _mute_color("black", mute)
@@ -410,8 +410,8 @@ def draw(
             # Iterate through the streamline points at this spanwise position.
             for point_index in range(stackStreamlinePoints_GP1_CgP1.shape[0]):
 
-                # Skip the first point because it has no previous point with which
-                # to make a line.
+                # Skip the first point because it has no previous point with which to
+                # make a line.
                 if point_index != 0:
                     # Get the current and last point.
                     point = stackStreamlinePoints_GP1_CgP1[point_index, :]
@@ -462,18 +462,18 @@ def draw(
                             smooth_shading=False,
                         )
 
-    # If an image surface is defined, save the geometry bounds (which now include
-    # the reflected geometry but not the image surface plane), add the image surface
-    # plane, then fit the camera to the saved bounds so the view is not dominated by
-    # the much larger image surface plane. When an image surface is present, cpos is
-    # not passed to show() because that would trigger an auto-fit to all actors
-    # (including the image surface).
+    # If an image surface is defined, save the geometry bounds (which now include the
+    # reflected geometry but not the image surface plane), add the image surface plane,
+    # then fit the camera to the saved bounds so the view is not dominated by the much
+    # larger image surface plane. When an image surface is present, cpos is not passed
+    # to show() because that would trigger an auto-fit to all actors (including the
+    # image surface).
     if T_reflect is not None:
         geometry_bounds = plotter.bounds
         if T_pas_GP1_CgP1_to_E_Eo is not None:
-            # The image surface helper builds the plane from geometry-axis quantities, so
-            # it needs geometry-axis bounds. Build the plane there, then map it into Earth
-            # axes to match the rendered geometry.
+            # The image surface helper builds the plane from geometry-axis quantities,
+            # so it needs geometry-axis bounds. Build the plane there, then map it into
+            # Earth axes to match the rendered geometry.
             geometry_axis_bounds = _get_panel_surfaces(airplanes).bounds
             image_surface_result = _get_image_surface_mesh_and_texture(
                 draw_operating_point, geometry_axis_bounds
@@ -505,10 +505,11 @@ def draw(
             plotter.camera.up = (0, 0, 1)
             plotter.reset_camera(bounds=geometry_bounds)  # type: ignore[call-arg]
 
-    # Choose the camera position. Free flight frames the body in Earth axes with physical
-    # up as Earth -z. The standard rendering views geometry axes from (-1, -1, 1), unless
-    # an image surface is present, in which case the camera was already fitted above and
-    # cpos is left None so show() does not auto-fit to the large image surface plane.
+    # Choose the camera position. Free flight frames the body in Earth axes with
+    # physical up as Earth -z. The standard rendering views geometry axes from (-1, -1,
+    # 1), unless an image surface is present, in which case the camera was already
+    # fitted above and cpos is left None so show() does not auto-fit to the large image
+    # surface plane.
     draw_cpos: tuple | None
     if is_free_flight:
         # Aim the camera along the Earth-axes view direction with physical up, then fit
@@ -535,9 +536,9 @@ def draw(
     # Set the Plotter's background color.
     plotter.set_background(color=_plotter_background_color)  # type: ignore[call-arg]
     if not testing:
-        # Show the Plotter so the user can adjust the camera position and window.
-        # When the user closes the window, the Plotter still exists. Therefore,
-        # it can later be saved as an image if desired.
+        # Show the Plotter so the user can adjust the camera position and window. When
+        # the user closes the window, the Plotter still exists. Therefore, it can later
+        # be saved as an image if desired.
         plotter.show(
             title="Orient the view, then press any key to continue.",
             cpos=draw_cpos,
@@ -545,8 +546,8 @@ def draw(
             auto_close=False,
         )
     else:
-        # Show the Plotter for 1 second, then proceed automatically. This is useful
-        # for testing.
+        # Show the Plotter for 1 second, then proceed automatically. This is useful for
+        # testing.
         plotter.show(
             cpos=draw_cpos,
             full_screen=False,
@@ -645,18 +646,18 @@ def animate(
 
     first_results_step = unsteady_solver.first_results_step
 
-    # Get the solver's SteadyProblems' Airplanes. This will become a list of lists,
-    # with the first index being the time step and the second index identifying each
-    # Airplane at that time step.
+    # Get the solver's SteadyProblems' Airplanes. This will become a list of lists, with
+    # the first index being the time step and the second index identifying each Airplane
+    # at that time step.
     step_airplanes = []
     for steady_problem in unsteady_solver.steady_problems:
         step_airplanes.append(steady_problem.airplanes)
 
-    # For a free flight solver, each time step's geometry is rendered in its true Earth-
-    # frame pose so the body flies through the scene. step_transforms holds, per time
-    # step, the passive transformation from the first Airplane's geometry axes (relative
-    # to its CG) to Earth axes (relative to the Earth origin). It stays empty for the
-    # standard body-fixed rendering in geometry axes.
+    # For a free flight solver, each time step's geometry is rendered in its true
+    # Earth-frame pose so the body flies through the scene. step_transforms holds, per
+    # time step, the passive transformation from the first Airplane's geometry axes
+    # (relative to its CG) to Earth axes (relative to the Earth origin). It stays empty
+    # for the standard body-fixed rendering in geometry axes.
     is_free_flight = isinstance(
         unsteady_solver,
         free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
@@ -668,8 +669,8 @@ def animate(
             for steady_problem in unsteady_solver.steady_problems
         ]
 
-    # Scale down the true-speed frames per second to at most 50 fps. This is the
-    # maximum speed at which some programs can render WebPs.
+    # Scale down the true-speed frames per second to at most 50 fps. This is the maximum
+    # speed at which some programs can render WebPs.
     requested_fps = 1.0 / unsteady_solver.delta_time
     speed = 1.0
     if requested_fps > 50.0:
@@ -724,12 +725,12 @@ def animate(
         min_scalar = float(min(all_scalars))
         max_scalar = float(max(all_scalars))
 
-    # Pre-compute the image surface mesh and reflection matrix from the last time
-    # step's geometry so that the plane is large enough to encompass the fully
-    # developed wake. The mesh, texture, and reflection matrix are static and reused
-    # for every frame. The last step's geometry bounds (including reflected geometry
-    # but not the image surface plane) are also saved so the camera can be fitted to
-    # the geometry rather than the larger image surface.
+    # Pre-compute the image surface mesh and reflection matrix from the last time step's
+    # geometry so that the plane is large enough to encompass the fully developed wake.
+    # The mesh, texture, and reflection matrix are static and reused for every frame.
+    # The last step's geometry bounds (including reflected geometry but not the image
+    # surface plane) are also saved so the camera can be fitted to the geometry rather
+    # than the larger image surface.
     last_step = len(step_airplanes) - 1
     last_step_operating_point = unsteady_solver.steady_problems[
         last_step
@@ -740,10 +741,10 @@ def animate(
     if is_free_flight:
         if T_reflect is not None:
             # The image surface is fixed in the world, so build its plane once from the
-            # last step's geometry-axis quantities, then map it into Earth axes. Re-
-            # expressing the reflection in Earth axes (a change of basis by the same
+            # last step's quantities in geometry axes, then map it into Earth axes.
+            # Re-expressing the reflection in Earth axes (a change of basis by the same
             # passive transformation) lets the reflected geometry be built from the
-            # Earth-axes panels each frame.
+            # panels in Earth axes each frame.
             T_pas_last = step_transforms[last_step]
             geometry_axis_bounds = _get_panel_surfaces(step_airplanes[last_step]).bounds
             image_surface_result = _get_image_surface_mesh_and_texture(
@@ -791,10 +792,11 @@ def animate(
         image_surface_texture = None
 
     # For free flight, compute a fixed camera that frames the whole trajectory. The body
-    # moves through the scene, so the camera is centered on the trajectory's midpoint and
-    # the parallel scale is fit to the projected extent of the trajectory's geometry so
-    # the whole glide stays in view. The clipping range is sized later, after the user has
-    # oriented the view, so it tracks the user's chosen camera rather than the default.
+    # moves through the scene, so the camera is centered on the trajectory's midpoint
+    # and the parallel scale is fit to the projected extent of the trajectory's geometry
+    # so the whole glide stays in view. The clipping range is sized later, after the
+    # user has oriented the view, so it tracks the user's chosen camera rather than the
+    # default.
     free_flight_cpos: list | None = None
     free_flight_parallel_scale = 0.0
     free_flight_clip_meshes: list = []
@@ -808,8 +810,8 @@ def animate(
             np.linalg.norm(finalPosition_E_Eo - initialPosition_E_Eo)
         )
 
-        # Map the first and last frames' Panel surfaces into Earth axes. These two frames
-        # bound the trajectory, so their combined extent frames the whole glide.
+        # Map the first and last frames' Panel surfaces into Earth axes. These two
+        # frames bound the trajectory, so their combined extent frames the whole glide.
         first_step_panel_surfaces = _transform_mesh(
             _get_panel_surfaces(step_airplanes[0]), step_transforms[0]
         )
@@ -822,8 +824,9 @@ def animate(
             np.linalg.norm(airplane_bounds[1::2] - airplane_bounds[::2])
         )
 
-        # Aim the camera along the Earth-axes view direction with physical up, centered on
-        # the trajectory's midpoint and far enough back to clear the geometry at both ends.
+        # Aim the camera along the Earth-axes view direction with physical up, centered
+        # on the trajectory's midpoint and far enough back to clear the geometry at both
+        # ends.
         padding = max(2.0 * airplane_diagonal, 0.5 * trajectory_extent)
         camera_distance = trajectory_extent + padding
         cameraPosition_E_Eo = (
@@ -835,9 +838,9 @@ def animate(
             _free_flight_view_up_E,
         ]
 
-        # Collect the geometry that frames the trajectory: the body at both ends, plus the
-        # last frame's wake (the largest) if it is shown. The last frame's surfaces are
-        # reused below to size the clipping range after the user orients the view.
+        # Collect the geometry that frames the trajectory: the body at both ends, plus
+        # the last frame's wake (the largest) if it is shown. The last frame's surfaces
+        # are reused below to size the clipping range after the user orients the view.
         framing_meshes = [first_step_panel_surfaces, last_step_panel_surfaces]
         free_flight_clip_meshes = [last_step_panel_surfaces]
         if show_wake_vortices:
@@ -850,9 +853,9 @@ def animate(
                 free_flight_clip_meshes.append(last_step_wake_surfaces)
 
         # Fit the parallel scale (half the viewport height in world units, since the
-        # projection is parallel) to the projected extent of that geometry about the focal
-        # point. This frames the glide snugly; the user can rescale interactively before
-        # the animation is captured.
+        # projection is parallel) to the projected extent of that geometry about the
+        # focal point. This frames the glide snugly. The user can rescale interactively
+        # before the animation is captured.
         free_flight_parallel_scale = _free_flight_fit_parallel_scale(
             framing_meshes,
             trajectoryMidpoint_E_Eo,
@@ -876,8 +879,8 @@ def animate(
     if is_free_flight:
         panel_surfaces = _transform_mesh(panel_surfaces, step_transforms[0])
 
-    # Plot the first time step's Airplanes' Panels either with scalar coloring or
-    # with a uniform color.
+    # Plot the first time step's Airplanes' Panels either with scalar coloring or with a
+    # uniform color.
     if scalar_type is not None and first_results_step == 0:
         these_scalars = _get_scalars(
             step_airplanes[0],
@@ -908,8 +911,8 @@ def animate(
     # If an image surface is defined, add reflected geometry, plot the pre-computed
     # plane, set the camera direction, and fit the camera to the last time step's
     # geometry bounds so the view is not dominated by the much larger image surface
-    # plane. When an image surface is present, cpos is not passed to show() because
-    # that would trigger an auto-fit to all actors (including the image surface).
+    # plane. When an image surface is present, cpos is not passed to show() because that
+    # would trigger an auto-fit to all actors (including the image surface).
     if T_reflect is not None:
         assert image_surface_mesh is not None
         mute = _image_reflection_mute_factor
@@ -964,10 +967,10 @@ def animate(
     # explicitly (rather than through show()'s cpos) so it survives the mesh additions
     # above and becomes the default for the held first frame; cpos is then left None so
     # show() does not reset it, which lets the user's interactive reorientation and
-    # rescaling carry through to the animation. The standard rendering views geometry axes
-    # from (-1, -1, 1), unless an image surface is present, in which case the camera was
-    # already fitted above and cpos is left None so show() does not auto-fit to the large
-    # image surface plane.
+    # rescaling carry through to the animation. The standard rendering views geometry
+    # axes from (-1, -1, 1), unless an image surface is present, in which case the
+    # camera was already fitted above and cpos is left None so show() does not auto-fit
+    # to the large image surface plane.
     animate_cpos: tuple | list | None
     if is_free_flight:
         assert free_flight_cpos is not None
@@ -982,10 +985,10 @@ def animate(
     # Set the Plotter's background color.
     plotter.set_background(color=_plotter_background_color)  # type: ignore[call-arg]
 
-    # If not testing, show the Plotter with the first time step so the user can
-    # orient the view. When the user presses any key, set the title back to the
-    # animation title and proceed. If testing, show the Plotter with the first time
-    # step for 1 second, and start the animation with the current window view.
+    # If not testing, show the Plotter with the first time step so the user can orient
+    # the view. When the user presses any key, set the title back to the animation title
+    # and proceed. If testing, show the Plotter with the first time step for 1 second,
+    # and start the animation with the current window view.
     if not testing:
         plotter.show(
             title="Orient the view, then press any key to produce the animation.",
@@ -1006,10 +1009,11 @@ def animate(
         time.sleep(1)
 
     # The user may have reoriented or rescaled the view during the held first frame.
-    # Preserve that camera and only size the clipping range so every frame stays visible:
-    # temporarily add the last frame's geometry (the first frame's is already present), fit
-    # the clipping range to both, then remove the temporary actors. The body moves through
-    # the scene, so a clipping range fit to the first frame alone would clip later frames.
+    # Preserve that camera and only size the clipping range so every frame stays
+    # visible: temporarily add the last frame's geometry (the first frame's is already
+    # present), fit the clipping range to both, then remove the temporary actors. The
+    # body moves through the scene, so a clipping range fit to the first frame alone
+    # would clip later frames.
     if is_free_flight:
         temporary_actors = [
             plotter.add_mesh(clip_mesh) for clip_mesh in free_flight_clip_meshes
@@ -1042,8 +1046,8 @@ def animate(
         # Clear the Plotter.
         plotter.clear()
 
-        # Get the Panel surfaces of this time step's Airplane(s), mapping them into Earth
-        # axes for free flight.
+        # Get the Panel surfaces of this time step's Airplane(s), mapping them into
+        # Earth axes for free flight.
         panel_surfaces = _get_panel_surfaces(airplanes)
         if is_free_flight:
             panel_surfaces = _transform_mesh(
@@ -1076,8 +1080,8 @@ def animate(
                 color=_wake_vortex_color,
             )
 
-        # Plot the Panels either with a uniform color or, if the current time step
-        # has results, with scalar coloring.
+        # Plot the Panels either with a uniform color or, if the current time step has
+        # results, with scalar coloring.
         if scalar_type is not None and first_results_step <= current_step:
             these_scalars = _get_scalars(
                 airplanes,
@@ -1154,15 +1158,15 @@ def animate(
 
         # If an image surface is present, force VTK to recalculate the scalar bar
         # layout. Adding the image surface mesh with opacity causes VTK's
-        # UnconstrainedFontSize layout to misposition the left label (PyVista
-        # issue #7516).
+        # UnconstrainedFontSize layout to misposition the left label (PyVista issue
+        # #7516).
         if T_reflect is not None:
             for scalar_bar_actor in plotter.scalar_bars.values():
                 scalar_bar_actor.Modified()
             plotter.render()
 
-        # If saving, append a WebP Image of this frame to the list of Images. To do
-        # so, take a screenshot, convert it to a ndarray, and convert that to an Image.
+        # If saving, append a WebP Image of this frame to the list of Images. To do so,
+        # take a screenshot, convert it to a ndarray, and convert that to an Image.
         if save:
             images.append(
                 webp.Image.fromarray(
@@ -1234,8 +1238,8 @@ def plot_results_versus_time(
 
     first_results_step = unsteady_solver.first_results_step
 
-    # Get the time step characteristics. Note that the first time step (time step
-    # 0), occurs at 0 seconds.
+    # Get the time step characteristics. Note that the first time step (time step 0),
+    # occurs at 0 seconds.
     num_steps = unsteady_solver.num_steps
     delta_time = unsteady_solver.delta_time
     num_airplanes = unsteady_solver.num_airplanes
@@ -1342,8 +1346,8 @@ def plot_results_versus_time(
         moment_coefficients_figure.patch.set_facecolor(_figure_background_color)
         moment_coefficients_axes.set_facecolor(_figure_background_color)
 
-        # Populate the plots. Lines are drawn from thickest to thinnest so that
-        # all three remain visible even when the curves overlap.
+        # Populate the plots. Lines are drawn from thickest to thinnest so that all
+        # three remain visible even when the curves overlap.
         _widths_3 = np.linspace(_max_line_width, _min_line_width, 3)
         force_axes.plot(
             times,
@@ -1456,9 +1460,9 @@ def plot_results_versus_time(
             "(in Wind Axes, Relative to the First Airplane's CG)"
         )
 
-        # Name the plots' axis labels, titles, and subtitles. The main title
-        # uses suptitle at the default size, and the subtitle uses set_title at
-        # a smaller size so the two render at different scales.
+        # Name the plots' axis labels, titles, and subtitles. The main title uses
+        # suptitle at the default size, and the subtitle uses set_title at a smaller
+        # size so the two render at different scales.
         force_axes.set_xlabel("Time (s)", color=_text_color_normalized)
         force_axes.set_ylabel("Force (N)", color=_text_color_normalized)
         force_figure.suptitle(force_title, color=_text_color_normalized)
@@ -1496,8 +1500,8 @@ def plot_results_versus_time(
             fontsize="small",
         )
 
-        # Format the plots' legends. The handler map normalizes legend line
-        # widths so the thickness staggering does not appear in the legend.
+        # Format the plots' legends. The handler map normalizes legend line widths so
+        # the thickness staggering does not appear in the legend.
         _legend_handler_map = {
             plt.Line2D: matplotlib.legend_handler.HandlerLine2D(
                 update_func=lambda h, orig: (
@@ -1660,8 +1664,8 @@ def plot_results_versus_time(
             airplane_name_snake + "_aerodynamic_angles.png",
         )
 
-    # If the user wants to show the plots, do so. This is done outside the loop so
-    # that plt.show() is only called once after all figures are created.
+    # If the user wants to show the plots, do so. This is done outside the loop so that
+    # plt.show() is only called once after all figures are created.
     if show:
         plt.show()
     else:
@@ -1960,11 +1964,11 @@ def log_results(
             _logging.indent() + "The First Airplane's Free Flight State History:"
         )
 
-        # Each vector state quantity is broken into one row per component, mirroring
-        # the per-component force and moment rows above, and each component row is
-        # labeled with its variable-convention name. The four group headers are logged
-        # before their first component (at flat indices 0, 3, 6, and 9), and the
-        # component labels are padded to a common width so the values align.
+        # Each vector state quantity is broken into one row per component, mirroring the
+        # per-component force and moment rows above, and each component row is labeled
+        # with its variable-convention name. The four group headers are logged before
+        # their first component (at flat indices 0, 3, 6, and 9), and the component
+        # labels are padded to a common width so the values align.
         state_component_labels = [
             "cgP1X_E_Eo",
             "cgP1Y_E_Eo",
@@ -2143,8 +2147,8 @@ def _plot_state_history(
     figure.patch.set_facecolor(_figure_background_color)
     axes.set_facecolor(_figure_background_color)
 
-    # Populate the plot. Lines are drawn from thickest to thinnest so that all
-    # remain visible even when the curves overlap.
+    # Populate the plot. Lines are drawn from thickest to thinnest so that all remain
+    # visible even when the curves overlap.
     num_series = len(series)
     widths = np.linspace(_max_line_width, _min_line_width, num_series)
     for series_id, (this_series, label, color) in enumerate(
@@ -2212,8 +2216,8 @@ def _get_panel_surfaces(
             # Unravel this Wing's ndarray of Panels iterate through it.
             panels = np.ravel(_panels)
             for panel in panels:
-                # Arrange this Panel's vertices and faces into ndarrays in the
-                # proper form to represent PolyData surfaces.
+                # Arrange this Panel's vertices and faces into ndarrays in the proper
+                # form to represent PolyData surfaces.
                 panel_vertices_to_add = np.vstack(
                     (
                         panel.Flpp_GP1_CgP1,
@@ -2233,8 +2237,8 @@ def _get_panel_surfaces(
                     dtype=int,
                 )
 
-                # Add this Panel's vertices and faces to the ndarray of all vertices
-                # and faces.
+                # Add this Panel's vertices and faces to the ndarray of all vertices and
+                # faces.
                 panel_vertices = np.vstack((panel_vertices, panel_vertices_to_add))
                 panel_faces = np.hstack((panel_faces, panel_face_to_add))
 
@@ -2419,9 +2423,9 @@ def _free_flight_fit_parallel_scale(
         is 1.15.
     :return: The parallel-projection scale.
     """
-    # Build the camera's screen right and up axes in Earth axes. The camera looks from its
-    # position back toward the focal point, i.e. along the negative view direction. The up
-    # axis is the supplied up made orthogonal to that look direction.
+    # Build the camera's screen right and up axes in Earth axes. The camera looks from
+    # its position back toward the focal point, i.e. along the negative view direction.
+    # The up axis is the supplied up made orthogonal to that look direction.
     lookDirection_E = -viewDirection_E
     lookDirection_E = lookDirection_E / np.linalg.norm(lookDirection_E)
     upDirection_E = viewUp_E - np.dot(viewUp_E, lookDirection_E) * lookDirection_E
@@ -2442,10 +2446,10 @@ def _free_flight_fit_parallel_scale(
     corners_E = np.array(corners_E_Eo) - focalPoint_E_Eo
 
     # Each matrix-vector product is a batch of dot products, one per corner: the (N, 3)
-    # array of corners times a (3,) screen axis gives an (N,) array whose entries are each
-    # corner's signed distance from the focal point along that axis (the axes are unit
-    # vectors, so the dot product is the scalar projection). Take the largest magnitude
-    # along either axis so neither screen dimension is clipped.
+    # array of corners times a (3,) screen axis gives an (N,) array whose entries are
+    # each corner's signed distance from the focal point along that axis (the axes are
+    # unit vectors, so the dot product is the scalar projection). Take the largest
+    # magnitude along either axis so neither screen dimension is clipped.
     half_extent_right = float(np.abs(corners_E @ rightDirection_E).max())
     half_extent_up = float(np.abs(corners_E @ upDirection_E).max())
     return margin * max(half_extent_right, half_extent_up)

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -105,8 +105,8 @@ class SteadyProblem:
         self._airplanes[0].validate_first_airplane_constraints()
 
         # Populate GP1_CgP1 coordinates for all Airplanes' Panels. This finds the
-        # Panels' positions in the first Airplane's geometry axes, relative to the
-        # first Airplane's CG based on their locally defined positions.
+        # Panels' positions in the first Airplane's geometry axes, relative to the first
+        # Airplane's CG based on their locally defined positions.
         for airplane in self._airplanes:
             # Compute the passive transformation matrix from this Airplane's local
             # geometry axes, relative to its CG, to the first Airplane's geometry axes,
@@ -219,8 +219,8 @@ class UnsteadyProblem(_core.CoreUnsteadyProblem):
             will be converted internally to a bool. The default is False.
         :return: None
         """
-        # Validate and store the Movement before calling super().__init__() because
-        # the Movement provides the parameters that the core class needs.
+        # Validate and store the Movement before calling super().__init__() because the
+        # Movement provides the parameters that the core class needs.
         if not isinstance(movement, movements.movement.Movement):
             raise TypeError("movement must be a Movement.")
         self._movement = movement
@@ -393,8 +393,8 @@ _EXTRA_XML_INJECTION_POINTS = frozenset(
 _MUJOCO_INTEGRATORS = frozenset({"Euler", "RK4", "implicit", "implicitfast"})
 
 # Strongly coupled free-flight sub-iteration tunables. The relative and absolute
-# tolerances form the mixed convergence test on the nondimensionalized state residual. The
-# divergence tolerance guards the Aitken relaxation factor against a collapsing
+# tolerances form the mixed convergence test on the nondimensionalized state residual.
+# The divergence tolerance guards the Aitken relaxation factor against a collapsing
 # denominator. The initial relaxation factor under-relaxes the first update before the
 # Aitken formula takes over.
 _SUBITERATION_RELATIVE_TOLERANCE = 1e-6
@@ -591,10 +591,10 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                 "simulation, leave both g_E and the weight at zero)."
             )
 
-        # The free-flight dynamics never apply externalFX_W: non-aerodynamic loads
-        # enter free flight only through external_loads_fn, which is strictly more
-        # capable (full force and moment, time varying). A nonzero value would be
-        # silently ignored, so raise instead.
+        # The free-flight dynamics never apply externalFX_W: non-aerodynamic loads enter
+        # free flight only through external_loads_fn, which is strictly more capable
+        # (full force and moment, time varying). A nonzero value would be silently
+        # ignored, so raise instead.
         if initial_operating_point.externalFX_W != 0.0:
             raise ValueError(
                 "The OperatingPoint's externalFX_W must be zero for free flight. The "
@@ -608,7 +608,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
 
         # Tracks whether the external_loads_fn's return structure has been validated.
         # The return contract is static across time steps, so it is checked once, on the
-        # function's first invocation in initialize_next_problem, rather than every step.
+        # function's first invocation in initialize_next_problem, rather than every
+        # step.
         self._external_loads_validated = False
 
         # The cap on the strongly coupled sub-iteration count per free-flight time step.
@@ -653,8 +654,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             extra_xml = validated_extra_xml
 
         # Validate the mujoco_assets dict (it must be a dict, or None, mapping str
-        # filenames to bytes). Whether a referenced asset is actually supplied is left to
-        # MuJoCo's own parser.
+        # filenames to bytes). Whether a referenced asset is actually supplied is left
+        # to MuJoCo's own parser.
         if mujoco_assets is not None:
             if not isinstance(mujoco_assets, dict):
                 raise TypeError("mujoco_assets must be a dict or None.")
@@ -1038,8 +1039,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         )
         velocity_E__E = state["velocity_E__E"]
         # Rotate the angular rate from the first Airplane's body axes into Earth axes
-        # (v_E = R_pas_E_to_BP1.T @ v_BP1, a proper rotation that preserves the axial-
-        # vector sign) and convert to radians per second.
+        # (v_E = R_pas_E_to_BP1.T @ v_BP1, a proper rotation that preserves the
+        # axial-vector sign) and convert to radians per second.
         omegasRad_E__E = R_pas_E_to_BP1.T @ np.deg2rad(state["omegas_BP1__E"])
 
         return np.concatenate(
@@ -1150,9 +1151,9 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         # the model is still at it, the solver's frozen step data, and the weighting.
         # Build the transient next-step SteadyProblem over a scratch copy of the
         # prescribed next-step Airplane, so the trials evaluate aerodynamics on the copy
-        # and the canonical Airplane's set-once panel coordinates are reserved for the
-        # official SteadyProblem committed once the solve accepts. Its OperatingPoint is a
-        # placeholder; the trial OperatingPoint is supplied to each trial.
+        # and the canonical Airplane's set-once Panel coordinates are reserved for the
+        # official SteadyProblem committed once the solve accepts. Its OperatingPoint is
+        # a placeholder. The trial OperatingPoint is supplied to each trial.
         snapshot = self._mujoco_model.save_state()
         snapshot_x = self._state_to_vector(self._mujoco_model.get_state())
         next_airplane = self._free_flight_movement.airplanes[0][step + 1]
@@ -1163,7 +1164,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         solver.freeze_substep(transient_next_steady_problem)
         weights = self._build_relaxation_weights()
 
-        # Seed the iteration with the loose step, S(x_n, l_n), evaluated from the snapshot.
+        # Seed the iteration with the loose step, S(x_n, l_n), evaluated from the
+        # snapshot.
         snapshot_interval_loads = self._assemble_interval_loads(
             current_operating_point, current_airplane, step
         )
@@ -1176,7 +1178,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
 
         for iteration in range(self.k_max + 1):
             # Aerodynamic loads at the trial state: build the trial OperatingPoint,
-            # evaluate the aerodynamics at it, and assemble the Earth-axes interval load.
+            # evaluate the aerodynamics at it, and assemble the Earth-axes interval
+            # load.
             trial_operating_point = self._operating_point_from_vector(
                 trial_x, current_operating_point
             )
@@ -1248,9 +1251,9 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                 residual_norm,
             )
 
-        # Accept: the final dynamics-propagated state, at which the model now sits, is the
-        # next step's state. Commit its OperatingPoint, then restore the solver's current-
-        # step state for the official wake build in the inherited run loop.
+        # Accept: the final dynamics-propagated state, at which the model now sits, is
+        # the next step's state. Commit its OperatingPoint, then restore the solver's
+        # current-step state for the official wake build in the inherited run loop.
         accepted_operating_point = self._operating_point_from_state(
             self._mujoco_model.get_state(), current_operating_point
         )
@@ -1308,14 +1311,14 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                 self._commit_next_problem(next_operating_point, step)
 
 
-# Tolerances for the torsional spring-damper ODE integration in
-# _spring_numerical_ode. They are a few orders of magnitude stricter than scipy's
-# defaults because the integration is re-seeded from the previous state at every
-# outer time step, so its local errors compound across a simulation, and because a
-# loose absolute tolerance would swamp small torsional responses. The absolute
-# tolerance bounds both state components, the torsional angle (radians) and its
-# time derivative (rad/s). Loosen these only for local debugging (for example, a
-# nearly massless wing makes the ODE stiff and the strict tolerances expensive).
+# Tolerances for the torsional spring-damper ODE integration in _spring_numerical_ode.
+# They are a few orders of magnitude stricter than scipy's defaults because the
+# integration is re-seeded from the previous state at every outer time step, so its
+# local errors compound across a simulation, and because a loose absolute tolerance
+# would swamp small torsional responses. The absolute tolerance bounds both state
+# components, the torsional angle (radians) and its time derivative (rad/s). Loosen
+# these only for local debugging (for example, a nearly massless wing makes the ODE
+# stiff and the strict tolerances expensive).
 _SPRING_ODE_RELATIVE_TOLERANCE = 1e-6
 _SPRING_ODE_ABSOLUTE_TOLERANCE_RAD = 1e-9
 
@@ -1440,21 +1443,20 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
             step_discards  # number of initial steps to discard for numerical stability
         )
 
-        # Per-wing time series of the cumulative torsional deformation state. Indexed
-        # as [wing_idx][entry], where entry 0 is the zero-valued initial state and
-        # every generated next step appends one entry, so the last entry is always the
-        # state. Each entry is a (num_spanwise_panels + 1,) ndarray whose element n is
-        # the y component (radians) of the deformation angle vector that perturbs the
+        # Per-wing time series of the cumulative torsional deformation state. Indexed as
+        # [wing_idx][entry], where entry 0 is the zero-valued initial state and every
+        # generated next step appends one entry, so the last entry is always the state.
+        # Each entry is a (num_spanwise_panels + 1,) ndarray whose element n is the y
+        # component (radians) of the deformation angle vector that perturbs the
         # corresponding WingCrossSection's angles_Wcsp_to_Wcs_ixyz (angles describing
         # the orientation of the wing cross section axes relative to the wing cross
         # section parent axes using an intrinsic xy'z" sequence); the perturbations' x
-        # and z components are structurally zero, so only the y components are
-        # stored. The derivative entries are the angle elements' time derivatives
-        # (rad/s). They are rates of change of scalar angle components, not angular
-        # velocity vector components, and they carry no reference frame ID because
-        # differentiating a scalar coordinate involves no rotating basis (see the
-        # Angle Component Time Derivatives section of
-        # ANGLE_VECTORS_AND_TRANSFORMATIONS.md).
+        # and z components are structurally zero, so only the y components are stored.
+        # The derivative entries are the angle elements' time derivatives (rad/s). They
+        # are rates of change of scalar angle components, not angular velocity vector
+        # components, and they carry no reference frame ID because differentiating a
+        # scalar coordinate involves no rotating basis (see the Angle Component Time
+        # Derivatives section of ANGLE_VECTORS_AND_TRANSFORMATIONS.md).
         self.listDeformationAnglesYRad_Wcsp_to_Wcs_ixyz: list[list[np.ndarray]] = []
         self._listDeformationAnglesDerivativeYRad_Wcsp_to_Wcs_ixyz: list[
             list[np.ndarray]
@@ -1646,11 +1648,10 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
                     panel_offset,
                 )
 
-                # A mirror-meshed Wing's panel grid runs tip to root spanwise,
-                # while the structural solve and the WingCrossSectionMovements
-                # that consume its output run root to tip, so flip the spanwise
-                # axis of the per-panel arrays to put them in root-to-tip strip
-                # order.
+                # A mirror-meshed Wing's Panel grid runs tip to root spanwise, while the
+                # structural solve and the WingCrossSectionMovements that consume its
+                # output run root to tip, so flip the spanwise axis of the per-Panel
+                # arrays to put them in root-to-tip strip order.
                 if wing.mirror_only:
                     mass_matrix = mass_matrix[:, ::-1, :]
                     aeroMoments_GP1_Slep = aeroMoments_GP1_Slep[:, ::-1, :]
@@ -1801,9 +1802,9 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         # Append the cumulative torsional angles and their time derivatives together,
         # holding both at their previous state during the first step_discards steps,
         # whose numerical startup effects cause large aerodynamic forces. The strips'
-        # ODEs are re-seeded from the time series' last entries, so recording only
-        # one component would seed a mixed state. Each recorded entry is a fresh
-        # array, so no time series entry aliases a later one.
+        # ODEs are re-seeded from the time series' last entries, so recording only one
+        # component would seed a mixed state. Each recorded entry is a fresh array, so
+        # no time series entry aliases a later one.
         deformationAnglesYRad_Wcsp_to_Wcs_ixyz = (
             self.listDeformationAnglesYRad_Wcsp_to_Wcs_ixyz[wing_idx]
         )
@@ -1878,9 +1879,9 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         newDeformationAnglesDerivativeYRad_Wcsp_to_Wcs_ixyz = np.zeros(
             num_spanwise_panels + 1, dtype=float
         )
-        # The current structural state is the last entry of each time series list.
-        # Both reads happen before this step's entries are appended, so they see the
-        # state at the end of the previous time step.
+        # The current structural state is the last entry of each time series list. Both
+        # reads happen before this step's entries are appended, so they see the state at
+        # the end of the previous time step.
         lastDeformationAnglesYRad_Wcsp_to_Wcs_ixyz = (
             self.listDeformationAnglesYRad_Wcsp_to_Wcs_ixyz[wing_idx][-1]
         )
@@ -1895,12 +1896,11 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         )
         for span_panel in range(num_spanwise_panels):
             aeroMomentY_GP1_Slep = np.sum(aeroMoments_GP1_Slep[:, span_panel, 1])
-            # Re-seed the strip's ODE from its own state at the end of the previous
-            # time step. The state arrays hold one entry per WingCrossSection, and a
-            # strip's state lives at its outboard bounding WingCrossSection, index
-            # span_panel + 1. The WingCrossSection at index span_panel bounds this
-            # strip on its inboard side, and the root WingCrossSection (index 0) is
-            # clamped.
+            # Re-seed the strip's ODE from its own state at the end of the previous time
+            # step. The state arrays hold one entry per WingCrossSection, and a strip's
+            # state lives at its outboard bounding WingCrossSection, index span_panel +
+            # 1. The WingCrossSection at index span_panel bounds this strip on its
+            # inboard side, and the root WingCrossSection (index 0) is clamped.
             (
                 newDeformationAnglesYRad_Wcsp_to_Wcs_ixyz[span_panel + 1],
                 newDeformationAnglesDerivativeYRad_Wcsp_to_Wcs_ixyz[span_panel + 1],
@@ -1959,8 +1959,8 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         torsional_inertias = np.zeros(num_spanwise_panels, dtype=float)
         flapping_axis_inertias = np.zeros(num_spanwise_panels, dtype=float)
         assert wing.panels is not None
-        # The distance from the flapping axis to the strip's centroid, accumulated
-        # in half-span-width increments.
+        # The distance from the flapping axis to the strip's centroid, accumulated in
+        # half-span-width increments.
         d = 0.0
         for span_panel in range(num_spanwise_panels):
             mass = mass_matrix[:, span_panel, :].sum()
@@ -1968,10 +1968,9 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
                 wing.wing_cross_sections[span_panel].chord
                 + wing.wing_cross_sections[span_panel + 1].chord
             ) / 2
-            # The span_panel index runs root to tip, matching the
-            # wing_cross_sections list, but a mirror-meshed Wing's panel grid
-            # runs tip to root spanwise, so map the index when reading panel
-            # geometry.
+            # The span_panel index runs root to tip, matching the wing_cross_sections
+            # list, but a mirror-meshed Wing's Panel grid runs tip to root spanwise, so
+            # map the index when reading Panel geometry.
             if wing.mirror_only:
                 panel_span_index = num_spanwise_panels - 1 - span_panel
             else:
@@ -2085,8 +2084,8 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         """
         amp = wing_movement.ampAngles_Gs_to_Wn_ixyz[0]
 
-        # A wing with no prescribed flapping applies no inertial moment. Return the
-        # zero function before computing the flapping frequency, whose 2 * pi / period
+        # A wing with no prescribed flapping applies no inertial moment. Return the zero
+        # function before computing the flapping frequency, whose 2 * pi / period
         # expression is undefined for the zero period that a zero amplitude requires.
         if amp == 0.0:
             return lambda time: 0.0
@@ -2095,7 +2094,7 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         h_rad = np.deg2rad(wing_movement.phaseAngles_Gs_to_Wn_ixyz[0])
         spacing = wing_movement.spacingAngles_Gs_to_Wn_ixyz[0]
         if spacing == "sine":
-            # amp is in degrees (ampAngles_Gs_to_Wn_ixyz); convert to radians so
+            # Since amp is in degrees (ampAngles_Gs_to_Wn_ixyz), convert to radians so
             # the inertial moment (N*m) is consistent with the SI spring-damper ODE.
             moment_func = (
                 lambda time: -1

--- a/pterasoftware/steady_horseshoe_vortex_lattice_method.py
+++ b/pterasoftware/steady_horseshoe_vortex_lattice_method.py
@@ -166,19 +166,19 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         # Run the solve with the BLAS threading appropriate for this run's size.
         with _functions.solve_loop_thread_limits(self.num_panels):
-            # Compute the horseshoe vortex geometries and collapse them, along with
-            # each Panel's per panel scalars, into 1D ndarrays of attributes.
+            # Compute the horseshoe vortex geometries and collapse them, along with each
+            # Panel's per Panel scalars, into 1D ndarrays of attributes.
             _logger.debug(_logging.indent() + "Collapsing the geometry")
             self._collapse_geometry()
 
-            # Find the matrix of Wing-wing influence coefficients associated with
-            # this SteadyProblem's geometry.
+            # Find the matrix of Wing-Wing influence coefficients associated with this
+            # SteadyProblem's geometry.
             _logger.debug(_logging.indent() + "Calculating the Wing Wing influences")
             self._calculate_wing_wing_influences()
 
-            # Find the normal velocity (in the first Airplane's geometry axes,
-            # observed from the Earth frame) at every collocation point due solely to
-            # the freestream.
+            # Find the normal velocity (in the first Airplane's geometry axes, observed
+            # from the Earth frame) at every collocation point due solely to the
+            # freestream.
             _logger.debug(
                 _logging.indent() + "Calculating the freestream Wing influences"
             )
@@ -190,9 +190,9 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
             )
             self._calculate_vortex_strengths()
 
-            # Solve for the forces (in the first Airplane's geometry axes) and
-            # moments (in the first Airplane's geometry axes, relative to the first
-            # Airplane's CG) on each Panel.
+            # Solve for the forces (in the first Airplane's geometry axes) and moments
+            # (in the first Airplane's geometry axes, relative to the first Airplane's
+            # CG) on each Panel.
             _logger.debug(_logging.indent() + "Calculating the forces and moments")
             self._calculate_loads()
 
@@ -215,12 +215,12 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the freestream direction (in the first Airplane's geometry axes,
-        # observed from the Earth frame).
+        # Find the freestream direction (in the first Airplane's geometry axes, observed
+        # from the Earth frame).
         vInfHat_GP1__E = self.operating_point.vInfHat_GP1__E
 
-        # Initialize a variable to hold the global position of the current Panel as
-        # we iterate through them.
+        # Initialize a variable to hold the global position of the current Panel as we
+        # iterate through them.
         global_panel_position = 0
 
         # Iterate through each Airplane's Wings.
@@ -249,14 +249,14 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                     Flhvp_GP1_CgP1 = panel.Flbvp_GP1_CgP1
                     assert Flhvp_GP1_CgP1 is not None
 
-                    # The semi infinite legs trail downstream from the front
-                    # corners along the freestream direction.
+                    # The semi infinite legs trail downstream from the front corners
+                    # along the freestream direction.
                     Brhvp_GP1_CgP1 = Frhvp_GP1_CgP1 + infinite_leg_offset_GP1
                     Blhvp_GP1_CgP1 = Flhvp_GP1_CgP1 + infinite_leg_offset_GP1
 
                     # Update the solver's list of attributes with this Panel's
-                    # attributes (in the first Airplane's geometry axes, relative
-                    # to the first Airplane's CG).
+                    # attributes (in the first Airplane's geometry axes, relative to the
+                    # first Airplane's CG).
                     self.panels[global_panel_position] = panel
                     self.stackUnitNormals_GP1[global_panel_position, :] = (
                         panel.unitNormal_GP1
@@ -286,10 +286,9 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
                         _Brpp_GP1_CgP1 = panel.Brpp_GP1_CgP1
                         assert _Brpp_GP1_CgP1 is not None
 
-                        # Calculate this Panel's streamline seed point (in the
-                        # first Airplane's geometry axes, relative to the first
-                        # Airplane's CG). Add it to the solver's 1D ndarray of
-                        # seed points.
+                        # Calculate this Panel's streamline seed point (in the first
+                        # Airplane's geometry axes, relative to the first Airplane's
+                        # CG). Add it to the solver's 1D ndarray of seed points.
                         self.stackSeedPoints_GP1_CgP1 = np.vstack(
                             (
                                 self.stackSeedPoints_GP1_CgP1,
@@ -311,9 +310,9 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the 2D ndarray of normalized velocities (in the first Airplane's
-        # geometry axes, observed from the Earth frame) induced at each Panel's
-        # collocation point by each horseshoe vortex.
+        # Find the 2D ndarray of normalized velocities (in the first Airplane's geometry
+        # axes, observed from the Earth frame) induced at each Panel's collocation point
+        # by each horseshoe vortex.
         singularity_counts = np.zeros(4, dtype=np.int64)
         gridNormVIndCpp_GP1__E = (
             _aerodynamics_functions.expanded_velocities_from_horseshoe_vortices(
@@ -367,11 +366,11 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
             unexpected_singularity_counts,
         )
 
-        # Take the batch dot product of the normalized induced velocities (in the
-        # first Airplane's geometry axes, observed from the Earth frame) with each
-        # Panel's unit normal direction (in the first Airplane's geometry axes). This
-        # is now the Problem's 2D ndarray of Wing Wing influence coefficients (observed
-        # from the Earth frame).
+        # Take the batch dot product of the normalized induced velocities (in the first
+        # Airplane's geometry axes, observed from the Earth frame) with each Panel's
+        # unit normal direction (in the first Airplane's geometry axes). This is now the
+        # SteadyProblem's 2D ndarray of Wing-Wing influence coefficients (observed from
+        # the Earth frame).
         self._gridWingWingInfluences__E = np.einsum(
             "...k,...k->...",
             gridNormVIndCpp_GP1__E,
@@ -485,9 +484,8 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Calculate the velocity (in the first Airplane's geometry axes, observed
-        # from the Earth frame) at the center of every Panel's horseshoe vortex's
-        # finite leg.
+        # Calculate the velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at the center of every Panel's horseshoe vortex's finite leg.
         bound_singularity_counts = np.zeros(4, dtype=np.int64)
         stackVelocityBoundVortexCenters_GP1__E = self.calculate_solution_velocity(
             stackP_GP1_CgP1=self._stackBoundVortexCenters_GP1_CgP1,
@@ -496,9 +494,9 @@ class SteadyHorseshoeVortexLatticeMethodSolver:
 
         unexpected_bound_singularity_counts = np.copy(bound_singularity_counts)
 
-        # Subtract the expected structural collinearity before logging. Each
-        # bound vortex center is collinear with its own finite leg, producing
-        # exactly one collinearity singularity per Panel.
+        # Subtract the expected structural collinearity before logging. Each bound
+        # vortex center is collinear with its own finite leg, producing exactly one
+        # collinearity singularity per Panel.
         unexpected_bound_singularity_counts[3] -= self.num_panels
         _functions.log_unexpected_singularity_counts(
             _logger,

--- a/pterasoftware/steady_ring_vortex_lattice_method.py
+++ b/pterasoftware/steady_ring_vortex_lattice_method.py
@@ -143,8 +143,8 @@ class SteadyRingVortexLatticeMethodSolver:
         self.stackUnitNormals_GP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.panel_areas = np.zeros(self.num_panels, dtype=float)
 
-        # Collocation panel points (in the first Airplane's geometry axes, relative
-        # to the first Airplane's CG)
+        # Collocation panel points (in the first Airplane's geometry axes, relative to
+        # the first Airplane's CG)
         self.stackCpp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
 
         # Back-right, front right, front left, and back left bound ring vortex points
@@ -154,8 +154,8 @@ class SteadyRingVortexLatticeMethodSolver:
         self.stackFlbrvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackBlbrvp_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
 
-        # Center bound line vortex points for the right, front, left, and back legs (
-        # in the first Airplane's geometry axes, relative to the first Airplane's CG).
+        # Center bound line vortex points for the right, front, left, and back legs (in
+        # the first Airplane's geometry axes, relative to the first Airplane's CG).
         self.stackCblvpr_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackCblvpf_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackCblvpl_GP1_CgP1 = np.zeros((self.num_panels, 3), dtype=float)
@@ -168,10 +168,10 @@ class SteadyRingVortexLatticeMethodSolver:
         self.stackLbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackBbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
 
-        # Initialize variables that will hold data which characterizes the trailing
-        # edge Panels' horseshoe vortices. These arrays are sized by the number of
-        # trailing edge Panels, in trailing edge order, since non trailing edge Panels
-        # do not carry a horseshoe vortex.
+        # Initialize variables that will hold data which characterizes the trailing edge
+        # Panels' horseshoe vortices. These arrays are sized by the number of trailing
+        # edge Panels, in trailing edge order, since non trailing edge Panels do not
+        # carry a horseshoe vortex.
         self._stackBrhvp_GP1_CgP1 = np.zeros(
             (self.num_trailing_edge_panels, 3), dtype=float
         )
@@ -221,13 +221,13 @@ class SteadyRingVortexLatticeMethodSolver:
         # Run the solve with the BLAS threading appropriate for this run's size.
         with _functions.solve_loop_thread_limits(self.num_panels):
             # Compute the bound ring vortex and trailing edge horseshoe vortex
-            # geometries and collapse them, along with each Panel's per panel
-            # scalars, into 1D ndarrays of attributes.
+            # geometries and collapse them, along with each Panel's per panel scalars,
+            # into 1D ndarrays of attributes.
             _logger.debug(_logging.indent() + "Collapsing geometry")
             self._collapse_geometry()
 
-            # Find the matrix of Wing Wing influence coefficients associated with
-            # this SteadyProblem's geometry.
+            # Find the matrix of Wing Wing influence coefficients associated with this
+            # SteadyProblem's geometry.
             _logger.debug(_logging.indent() + "Calculating the Wing Wing influences")
             self._calculate_wing_wing_influences()
 
@@ -245,9 +245,9 @@ class SteadyRingVortexLatticeMethodSolver:
             )
             self._calculate_vortex_strengths()
 
-            # Solve for the forces (in the first Airplane's geometry axes) and
-            # moments (in the first Airplane's geometry axes, relative to the first
-            # Airplane's CG) on each Panel.
+            # Solve for the forces (in the first Airplane's geometry axes) and moments
+            # (in the first Airplane's geometry axes, relative to the first Airplane's
+            # CG) on each Panel.
             _logger.debug(_logging.indent() + "Calculating forces and moments")
             self._calculate_loads()
 
@@ -278,17 +278,17 @@ class SteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the freestream direction (in the first Airplane's geometry axes,
-        # observed from the Earth frame).
+        # Find the freestream direction (in the first Airplane's geometry axes, observed
+        # from the Earth frame).
         vInfHat_GP1__E = self.operating_point.vInfHat_GP1__E
 
-        # Initialize a variable to hold the global position of the Panel as we
-        # iterate through them.
+        # Initialize a variable to hold the global position of the Panel as we iterate
+        # through them.
         global_panel_position = 0
 
         # Initialize a variable to hold the trailing edge position as we encounter
-        # trailing edge Panels. This indexes the trailing edge sized horseshoe
-        # vortex arrays.
+        # trailing edge Panels. This indexes the trailing edge sized horseshoe vortex
+        # arrays.
         te_position = 0
 
         # Iterate through each Airplane's Wings.
@@ -308,26 +308,26 @@ class SteadyRingVortexLatticeMethodSolver:
                 _panels = wing.panels
                 assert _panels is not None
 
-                # Iterate through the chordwise and spanwise positions of this
-                # Wing's Panels.
+                # Iterate through the chordwise and spanwise positions of this Wing's
+                # Panels.
                 for chordwise_position in range(wing.num_chordwise_panels):
                     for spanwise_position in range(_num_spanwise_panels):
                         panel: _panel.Panel = _panels[
                             chordwise_position, spanwise_position
                         ]
 
-                        # Find the location of this Panel's front right and front
-                        # left bound ring vortex points (in the first Airplane's
-                        # geometry axes, relative to the first Airplane's CG).
+                        # Find the location of this Panel's front right and front left
+                        # bound ring vortex points (in the first Airplane's geometry
+                        # axes, relative to the first Airplane's CG).
                         Frrvp_GP1_CgP1 = panel.Frbvp_GP1_CgP1
                         assert Frrvp_GP1_CgP1 is not None
 
                         Flrvp_GP1_CgP1 = panel.Flbvp_GP1_CgP1
                         assert Flrvp_GP1_CgP1 is not None
 
-                        # Define the location of the back left and back right
-                        # bound ring vortex points based on whether the Panel is
-                        # along the trailing edge or not.
+                        # Define the location of the back left and back right bound ring
+                        # vortex points based on whether the Panel is along the trailing
+                        # edge or not.
                         if not panel.is_trailing_edge:
                             next_chordwise_panel = _panels[
                                 chordwise_position + 1, spanwise_position
@@ -358,8 +358,8 @@ class SteadyRingVortexLatticeMethodSolver:
                                 _Brpp_GP1_CgP1 - _Frpp_GP1_CgP1
                             )
 
-                        # Update the solver's bound ring vortex stack arrays and
-                        # per Panel scalars.
+                        # Update the solver's bound ring vortex stack arrays and per
+                        # Panel scalars.
                         _functions.update_ring_vortex_solvers_panel_attributes(
                             ring_vortex_solver=self,
                             global_panel_position=global_panel_position,
@@ -371,12 +371,12 @@ class SteadyRingVortexLatticeMethodSolver:
                         )
 
                         if panel.is_trailing_edge:
-                            # Populate the horseshoe vortex stack arrays. The
-                            # horseshoe vortex shares its front corners with the
-                            # bound ring vortex's back corners and its semi infinite
-                            # legs extend downstream along the freestream. The
-                            # strength is initialized to 1.0 and will be replaced
-                            # after the strength solve.
+                            # Populate the horseshoe vortex stack arrays. The horseshoe
+                            # vortex shares its front corners with the bound ring
+                            # vortex's back corners and its semi infinite legs extend
+                            # downstream along the freestream. The strength is
+                            # initialized to 1.0 and will be replaced after the strength
+                            # solve.
                             self._stackBrhvp_GP1_CgP1[te_position] = (
                                 Brrvp_GP1_CgP1 + infinite_leg_offset_GP1
                             )
@@ -400,11 +400,11 @@ class SteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the 2D ndarray of normalized velocities (in the first Airplane's
-        # geometry axes, observed from the Earth frame) induced at each Panel's
-        # collocation point by each ring vortex. The answer is normalized because the
-        # solver's list of ring vortex strengths was initialized to all be 1.0. This
-        # will be updated once the correct strengths are calculated.
+        # Find the 2D ndarray of normalized velocities (in the first Airplane's geometry
+        # axes, observed from the Earth frame) induced at each Panel's collocation point
+        # by each ring vortex. The answer is normalized because the solver's list of
+        # ring vortex strengths was initialized to all be 1.0. This will be updated once
+        # the correct strengths are calculated.
         singularity_counts = np.zeros(4, dtype=np.int64)
         gridRingNormVIndCpp_GP1__E = (
             _aerodynamics_functions.expanded_velocities_from_ring_vortices(
@@ -421,12 +421,12 @@ class SteadyRingVortexLatticeMethodSolver:
             )
         )
 
-        # Find the 2D ndarray of normalized velocities (in the first Airplane's
-        # geometry axes, observed from the Earth frame) induced at every Panel's
-        # collocation point by every trailing edge Panel's horseshoe vortex. The
-        # answer is normalized because the horseshoe vortex strengths were
-        # initialized to 1.0 and will be updated once the correct vortex strengths
-        # are calculated. The result has shape (num_panels, num_trailing_edge_panels,
+        # Find the 2D ndarray of normalized velocities (in the first Airplane's geometry
+        # axes, observed from the Earth frame) induced at every Panel's collocation
+        # point by every trailing edge Panel's horseshoe vortex. The answer is
+        # normalized because the horseshoe vortex strengths were initialized to 1.0 and
+        # will be updated once the correct vortex strengths are calculated. The result
+        # has shape (num_panels, num_trailing_edge_panels,
         # 3) and is later scatter added into the ring contribution at the trailing
         # edge columns.
         gridHorseshoeNormVIndCpp_GP1__E = (
@@ -499,18 +499,18 @@ class SteadyRingVortexLatticeMethodSolver:
             unexpected_singularity_counts,
         )
 
-        # Fold the trailing edge sized horseshoe contribution into the ring grid at
-        # the trailing edge columns. For non trailing edge columns the ring grid is
+        # Fold the trailing edge sized horseshoe contribution into the ring grid at the
+        # trailing edge columns. For non trailing edge columns the ring grid is
         # untouched.
         gridRingNormVIndCpp_GP1__E[
             :, self.panel_is_trailing_edge, :
         ] += gridHorseshoeNormVIndCpp_GP1__E
 
-        # Take the batch dot product of the normalized induced velocities (in the
-        # first Airplane's geometry axes, observed from the Earth frame) with each
-        # Panel's unit normal direction (in the first Airplane's geometry axes). This
-        # is now the 2D ndarray of Wing Wing influence coefficients (observed from
-        # the Earth frame).
+        # Take the batch dot product of the normalized induced velocities (in the first
+        # Airplane's geometry axes, observed from the Earth frame) with each Panel's
+        # unit normal direction (in the first Airplane's geometry axes). This is now the
+        # 2D ndarray of Wing Wing influence coefficients (observed from the Earth
+        # frame).
         self._gridWingWingInfluences__E = np.einsum(
             "...k,...k->...",
             gridRingNormVIndCpp_GP1__E,
@@ -527,8 +527,8 @@ class SteadyRingVortexLatticeMethodSolver:
             self._gridWingWingInfluences__E, -self.stackFreestreamWingInfluences__E
         )
 
-        # Mirror the trailing edge entries of the solved strengths into the
-        # trailing edge sized horseshoe vortex strength array.
+        # Mirror the trailing edge entries of the solved strengths into the trailing
+        # edge sized horseshoe vortex strength array.
         self._horseshoe_vortex_strengths = self._vortex_strengths[
             self.panel_is_trailing_edge
         ]
@@ -676,8 +676,8 @@ class SteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Initialize a variable to hold the global Panel position as we iterate
-        # through them.
+        # Initialize a variable to hold the global Panel position as we iterate through
+        # them.
         global_panel_position = 0
 
         # Initialize three 1D ndarrays to hold the effective strength of the Panels'
@@ -687,11 +687,10 @@ class SteadyRingVortexLatticeMethodSolver:
         effective_left_line_vortex_strengths = np.zeros(self.num_panels, dtype=float)
         effective_back_line_vortex_strengths = np.zeros(self.num_panels, dtype=float)
 
-        # Iterate through the Airplanes' Wings. Within a Wing, Panels are laid out
-        # in row major (chordwise outer, spanwise inner) order, so neighbouring
-        # Panel strengths can be found at fixed offsets from the current global
-        # Panel position: +1 right, -1 left, +num_spanwise back, -num_spanwise
-        # front.
+        # Iterate through the Airplanes' Wings. Within a Wing, Panels are laid out in
+        # row major (chordwise outer, spanwise inner) order, so neighbouring Panel
+        # strengths can be found at fixed offsets from the current global Panel
+        # position: +1 right, -1 left, +num_spanwise back, -num_spanwise front.
         for airplane in self.airplanes:
             for wing in airplane.wings:
                 _panels = wing.panels
@@ -716,8 +715,8 @@ class SteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective right line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex strength
-                        # and that of the Panel to the right.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the right.
                         effective_right_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._vortex_strengths[global_panel_position + 1]
@@ -731,8 +730,8 @@ class SteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective front line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex strength
-                        # and that of the Panel in front of it.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel in front of it.
                         effective_front_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._vortex_strengths[
@@ -748,24 +747,24 @@ class SteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective left line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex strength
-                        # and that of the Panel to the left.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the left.
                         effective_left_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._vortex_strengths[global_panel_position - 1]
                         ) / 2
 
                     if panel.is_trailing_edge:
-                        # Set the effective back line vortex strength to zero, as it
-                        # is perfectly canceled by the wake horseshoe vortex's finite
-                        # leg line vortex.
+                        # Set the effective back line vortex strength to zero, as it is
+                        # perfectly canceled by the wake horseshoe vortex's finite leg
+                        # line vortex.
                         effective_back_line_vortex_strengths[global_panel_position] = (
                             0.0
                         )
                     else:
                         # Set the effective back line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex strength
-                        # and that of the Panel to the back.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the back.
                         effective_back_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._vortex_strengths[
@@ -776,9 +775,9 @@ class SteadyRingVortexLatticeMethodSolver:
                     # Increment the global Panel position variable.
                     global_panel_position += 1
 
-        # Calculate the velocity (in the first Airplane's geometry axes, observed
-        # from the Earth frame) at the center of every Panels' ring vortex's right
-        # line vortex, front line vortex, left line vortex, and back line vortex.
+        # Calculate the velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at the center of every Panels' ring vortex's right line
+        # vortex, front line vortex, left line vortex, and back line vortex.
         bound_singularity_counts = np.zeros(4, dtype=np.int64)
         stackVelocityRightLineVortexCenters_GP1__E = self.calculate_solution_velocity(
             stackP_GP1_CgP1=self.stackCblvpr_GP1_CgP1,
@@ -799,12 +798,12 @@ class SteadyRingVortexLatticeMethodSolver:
 
         unexpected_bound_singularity_counts = np.copy(bound_singularity_counts)
 
-        # Subtract expected structural collinearity counts before logging. For
-        # each Wing with C chordwise and S spanwise Panels, the four leg center
-        # evaluations produce (8 * C * S - 2 * C - 2 * S) collinearity
-        # singularities from ring vortex self and adjacent shared edge pairs.
-        # Each trailing edge Panel's back leg center is also collinear with the
-        # corresponding wake horseshoe vortex's finite leg, adding S per Wing.
+        # Subtract expected structural collinearity counts before logging. For each Wing
+        # with C chordwise and S spanwise Panels, the four leg center evaluations
+        # produce (8 * C * S - 2 * C - 2 * S) collinearity singularities from ring
+        # vortex self and adjacent shared edge pairs. Each trailing edge Panel's back
+        # leg center is also collinear with the corresponding wake horseshoe vortex's
+        # finite leg, adding S per Wing.
         expected_collinearity = 0
         for airplane in self.airplanes:
             for wing in airplane.wings:
@@ -823,9 +822,9 @@ class SteadyRingVortexLatticeMethodSolver:
         )
 
         # Using the effective line vortex strengths and the Kutta-Joukowski theorem,
-        # find the forces (in the first Airplane's geometry axes) on the Panels'
-        # ring vortex's right line vortex, front line vortex, left line vortex, and back
-        # line vortex using the effective vortex strengths.
+        # find the forces (in the first Airplane's geometry axes) on the Panels' ring
+        # vortex's right line vortex, front line vortex, left line vortex, and back line
+        # vortex using the effective vortex strengths.
         rightLegForces_GP1 = (
             self.operating_point.rho
             * np.expand_dims(effective_right_line_vortex_strengths, axis=1)
@@ -872,9 +871,9 @@ class SteadyRingVortexLatticeMethodSolver:
 
         # TODO: Determine if we get any performance gains by switching to the
         #  functions.numba_1d_explicit_cross function here.
-        # Find the moments (in the first Airplane's geometry axes, relative to the
-        # first Airplane's CG) on the Panels' ring vortex's right line vortex,
-        # front line vortex, left line vortex, and back line vortex.
+        # Find the moments (in the first Airplane's geometry axes, relative to the first
+        # Airplane's CG) on the Panels' ring vortex's right line vortex, front line
+        # vortex, left line vortex, and back line vortex.
         rightLegMoments_GP1_CgP1 = np.cross(
             self.stackCblvpr_GP1_CgP1,
             rightLegForces_GP1,

--- a/pterasoftware/trim.py
+++ b/pterasoftware/trim.py
@@ -45,8 +45,8 @@ _seed = 42
 # TEST: Consider adding unit tests for this function.
 # TEST: Assess how comprehensive this function's integration tests are and update or
 #  extend them if needed.
-# TODO: It would be awesome if we could incorporate control surface deflections into
-#  the steady trim analysis.
+# TODO: It would be awesome if we could incorporate control surface deflections into the
+#  steady trim analysis.
 def analyze_steady_trim(
     problem: problems.SteadyProblem,
     solver_type: str,
@@ -190,9 +190,8 @@ def analyze_steady_trim(
         num_calls, "num_calls", min_val=1, min_inclusive=True
     )
 
-    # Get the SteadyProblem's OperatingPoint's initial parameter values and check
-    # that the ones that will vary to find a trim condition are within the specified
-    # bounds.
+    # Get the SteadyProblem's OperatingPoint's initial parameter values and check that
+    # the ones that will vary to find a trim condition are within the specified bounds.
     weight = problem.airplanes[0].weight
     baseVCg__E = problem.operating_point.vCg__E
     base_alpha = problem.operating_point.alpha
@@ -274,8 +273,8 @@ def analyze_steady_trim(
         qInf__E = trial_operating_point.qInf__E
 
         # Deep copy the airplanes so the new SteadyProblem can set fresh Panel
-        # coordinates. This ensures correctness for multi-airplane problems where
-        # Panel coordinates depend on relative airplane positions.
+        # coordinates. This ensures correctness for multi-airplane problems where Panel
+        # coordinates depend on relative airplane positions.
         trial_airplanes = [copy.deepcopy(airplane) for airplane in problem.airplanes]
 
         # Create a new SteadyProblem with the trial operating point and copied
@@ -290,13 +289,12 @@ def analyze_steady_trim(
 
         # To my knowledge, there isn't a standard way to define "external" force
         # coefficients. However, simply checking trim against forces and moments in
-        # Newtons and Newton meters isn't a good solution because, for example,
-        # an imbalance of 0.01 N may be trivial to a bird-scale UAV but critical to a
-        # flying microrobot. I'm choosing to non dimensionalize with reference area,
-        # as that is what is used for aerodynamic force coefficients. If we later
-        # allow users to apply external moments we may need to come up with a better
-        # approach, as moment coefficients non dimensionalize using different
-        # dimensions.
+        # Newtons and Newton meters isn't a good solution because, for example, an
+        # imbalance of 0.01 N may be trivial to a bird-scale UAV but critical to a
+        # flying microrobot. I'm choosing to non dimensionalize with reference area, as
+        # that is what is used for aerodynamic force coefficients. If we later allow
+        # users to apply external moments we may need to come up with a better approach,
+        # as moment coefficients non dimensionalize using different dimensions.
         externalForces_W = np.array([externalFX_W, 0.0, weight], dtype=float)
         externalForceCoefficients_W = externalForces_W / qInf__E / s_ref
 
@@ -430,9 +428,9 @@ def analyze_steady_trim(
 # TEST: Consider adding integration tests for this function.
 # TODO: Add the ability to specify running the solver with a prescribed or free wake.
 # TODO: It would be awesome if we could incorporate particular amplitude and period
-#  parameters of the AirplaneMovement's WingMovements and WingCrossSectionMovements
-#  into the unsteady trim analysis. Incorporating control surface deflection would
-#  also be great but less important.
+#  parameters of the AirplaneMovement's WingMovements and WingCrossSectionMovements into
+#  the unsteady trim analysis. Incorporating control surface deflection would also be
+#  great but less important.
 def analyze_unsteady_trim(
     problem: problems.UnsteadyProblem,
     boundsVCg__E: tuple[float | int, float | int],
@@ -585,9 +583,8 @@ def analyze_unsteady_trim(
         problem.movement.operating_point_movement.base_operating_point
     )
 
-    # Get the base OperatingPoint's initial parameter values and check
-    # that the ones that will vary to find a trim condition are within the specified
-    # bounds.
+    # Get the base OperatingPoint's initial parameter values and check that the ones
+    # that will vary to find a trim condition are within the specified bounds.
     weight = problem.movement.airplane_movements[0].base_airplane.weight
     baseVCg__E = base_operating_point.vCg__E
     base_alpha = base_operating_point.alpha
@@ -674,13 +671,12 @@ def analyze_unsteady_trim(
 
         # To my knowledge, there isn't a standard way to define "external" force
         # coefficients. However, simply checking trim against forces and moments in
-        # Newtons and Newton meters isn't a good solution because, for example,
-        # an imbalance of 0.01 N may be trivial to a bird-scale UAV but critical to a
-        # flying microrobot. I'm choosing to non dimensionalize with reference area,
-        # as that is what is used for aerodynamic force coefficients. If we later
-        # allow users to apply external moments we may need to come up with a better
-        # approach, as moment coefficients non dimensionalize using different
-        # dimensions.
+        # Newtons and Newton meters isn't a good solution because, for example, an
+        # imbalance of 0.01 N may be trivial to a bird-scale UAV but critical to a
+        # flying microrobot. I'm choosing to non dimensionalize with reference area, as
+        # that is what is used for aerodynamic force coefficients. If we later allow
+        # users to apply external moments we may need to come up with a better approach,
+        # as moment coefficients non dimensionalize using different dimensions.
         externalForces_W = np.array([externalFX_W, 0.0, weight], dtype=float)
         externalForceCoefficients_W = externalForces_W / qInf__E / s_ref
 

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -2617,12 +2617,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
                                 _lastBlpp_GP1_CgP1 = last_panel.Blpp_GP1_CgP1
                                 assert _lastBlpp_GP1_CgP1 is not None
 
-                                # Subtract (thisBlpp_GP1_CgP1 - lastBlpp_GP1_CgP1)
-                                # / self.delta_time from vInf_GP1__E to get the
-                                # apparent fluid velocity due to motion (observed
-                                # from the Earth frame, in the first Airplane's
-                                # geometry axes). This is the vector pointing
-                                # opposite the velocity from motion.
+                                # Subtract (thisBlpp_GP1_CgP1 - lastBlpp_GP1_CgP1) /
+                                # self.delta_time from vInf_GP1__E to get the apparent
+                                # fluid velocity due to motion (observed from the Earth
+                                # frame, in the first Airplane's geometry axes). This is
+                                # the vector pointing opposite the velocity from motion.
                                 Blrvp_GP1_CgP1 = (
                                     _thisBlpp_GP1_CgP1
                                     + (

--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -35,8 +35,8 @@ from . import (
 _logger = _logging.get_logger("unsteady_ring_vortex_lattice_method")
 
 
-# TODO: Add unit tests for trapezoid-rule-based averages for the mean and RMS loads
-#  and load coefficients.
+# TODO: Add unit tests for trapezoid-rule-based averages for the mean and RMS loads and
+#  load coefficients.
 # TEST: Assess how comprehensive this function's integration tests are and update or
 #  extend them if needed.
 class UnsteadyRingVortexLatticeMethodSolver:
@@ -130,11 +130,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
         "ran",
     )
 
-    # Whether this solver models body angular rates (a non-zero omegas_BP1__E on an
-    # OperatingPoint). The base solver and its coupled and aeroelastic subclasses do not,
-    # so they reject any non-zero body rate at construction. The free-flight solver, which
-    # contributes the omega cross r velocity at every evaluation point, overrides this to
-    # True.
+    # This attribute indicates whether the solver models body angular rates (a non-zero
+    # omegas_BP1__E on an OperatingPoint). The base solver and its coupled and
+    # aeroelastic subclasses do not, so they reject any non-zero body rate at
+    # construction. The free-flight solver, which contributes the omega cross r velocity
+    # at every evaluation point, overrides this to True.
     _models_body_rates = False
 
     def __init__(self, unsteady_problem: _core.CoreUnsteadyProblem) -> None:
@@ -145,7 +145,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         :return: None
         """
         # Guard direct instantiation of the base solver against coupled problems while
-        # allowing subclasses to pass their own CoreUnsteadyProblem variants via super().
+        # allowing subclasses to pass their own CoreUnsteadyProblem variants via
+        # super().
         if type(self) is UnsteadyRingVortexLatticeMethodSolver and not isinstance(
             unsteady_problem, problems.UnsteadyProblem
         ):
@@ -189,15 +190,15 @@ class UnsteadyRingVortexLatticeMethodSolver:
         )
         self._currentGridWingWingInfluences__E: np.ndarray = np.empty(0, dtype=float)
         self._currentStackWakeWingInfluences__E: np.ndarray = np.empty(0, dtype=float)
-        # Initialized to ones so that initialize_step_geometry (which can run
-        # before any strength solve) finds a sensible placeholder when shedding
-        # the next step's wake. run() overwrites this each step before solving.
+        # Initialized to ones so that initialize_step_geometry (which can run before any
+        # strength solve) finds a sensible placeholder when shedding the next step's
+        # wake. run() overwrites this each step before solving.
         self._current_bound_vortex_strengths: np.ndarray = np.ones(
             self.num_panels, dtype=float
         )
-        # _last_bound_vortex_strengths starts as zeros so step 0 sees no previous
-        # step contribution. At each step's _calculate_vortex_strengths the just
-        # solved current strengths are captured here for use by the next step.
+        # _last_bound_vortex_strengths starts as zeros so step 0 sees no previous step
+        # contribution. At each step's _calculate_vortex_strengths the just solved
+        # current strengths are captured here for use by the next step.
         self._last_bound_vortex_strengths: np.ndarray = np.zeros(
             self.num_panels, dtype=float
         )
@@ -213,9 +214,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self.stackCpp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
         self._stackLastCpp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
 
-        # The current and last time step's back right, front right, front left,
-        # and back left bound ring vortex points (in the first Airplane's geometry
-        # axes, relative to the first Airplane's CG).
+        # The current and last time step's back right, front right, front left, and back
+        # left bound ring vortex points (in the first Airplane's geometry axes, relative
+        # to the first Airplane's CG).
         self.stackBrbrvp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
         self.stackFrbrvp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
         self.stackFlbrvp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
@@ -227,16 +228,16 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         # Per step bound ring vortex corner stacks. Filled by
         # _initialize_panel_vortices_at and read by _collapse_geometry,
-        # _populate_next_airplanes_wake_vortex_points, and the last step block
-        # of the next step's _collapse_geometry. Pre-allocated in run().
+        # _populate_next_airplanes_wake_vortex_points, and the last step block of the
+        # next step's _collapse_geometry. Pre-allocated in run().
         self._listStackBrbrvp_GP1_CgP1: list[np.ndarray] = []
         self._listStackFrbrvp_GP1_CgP1: list[np.ndarray] = []
         self._listStackFlbrvp_GP1_CgP1: list[np.ndarray] = []
         self._listStackBlbrvp_GP1_CgP1: list[np.ndarray] = []
 
-        # Per (airplane, wing) flat panel offsets and shapes. Built immediately
-        # below so the bound vortex pipeline and the wake convection loop can
-        # index into the per step list arrays without re-deriving offsets.
+        # These are the per (Airplane, Wing) flat Panel offsets and shapes. They are
+        # built immediately below so the bound vortex pipeline and the wake convection
+        # loop can index into the per step list arrays without re-deriving offsets.
         self._per_wing_panel_offsets: list[list[int]] = []
         self._per_wing_num_chordwise_panels: list[list[int]] = []
         self._per_wing_num_spanwise_panels: list[list[int]] = []
@@ -264,9 +265,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
             self._per_wing_spanwise_cumsum.append(airplane_cumsum)
         total_spanwise_panels = cumulative_spanwise
 
-        # Pre-allocate the per step bound ring vortex corner stacks. These are
-        # filled by _initialize_panel_vortices_at(step) and read by the bound
-        # vortex pipeline thereafter.
+        # Pre-allocate the per step bound ring vortex corner stacks. These are filled by
+        # _initialize_panel_vortices_at(step) and read by the bound vortex pipeline
+        # thereafter.
         self._listStackBrbrvp_GP1_CgP1 = [
             np.zeros((self.num_panels, 3), dtype=float) for _ in range(self.num_steps)
         ]
@@ -280,9 +281,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
             np.zeros((self.num_panels, 3), dtype=float) for _ in range(self.num_steps)
         ]
 
-        # Pre-allocate the per step wake stacks. The number of wake ring vortices
-        # at step S is min(S, max_wake_rows) (or S if no truncation) times the
-        # total spanwise panel count summed over all wings.
+        # Pre-allocate the per step wake stacks. The number of wake ring vortices at
+        # step S is min(S, max_wake_rows) (or S if no truncation) times the total
+        # spanwise panel count summed over all wings.
         wake_sizes_per_step = []
         for step in range(self.num_steps):
             num_chordwise_wake_rows = step
@@ -326,15 +327,15 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self.stackLbrv_GP1: np.ndarray = np.empty(0, dtype=float)
         self.stackBbrv_GP1: np.ndarray = np.empty(0, dtype=float)
 
-        # Initialize variables to hold aerodynamic data that pertains details about
-        # each Panel's location on its Wing.
+        # Initialize variables to hold aerodynamic data that pertains details about each
+        # Panel's location on its Wing.
         self.panel_is_trailing_edge: np.ndarray = np.empty(0, dtype=bool)
         self.panel_is_leading_edge: np.ndarray = np.empty(0, dtype=bool)
         self.panel_is_left_edge: np.ndarray = np.empty(0, dtype=bool)
         self.panel_is_right_edge: np.ndarray = np.empty(0, dtype=bool)
 
-        # Initialize variables to hold aerodynamic data that pertains to the wake at
-        # the current time step.
+        # Initialize variables to hold aerodynamic data that pertains to the wake at the
+        # current time step.
         self._current_wake_vortex_strengths: np.ndarray = np.empty(0, dtype=float)
         self._current_wake_vortex_ages: np.ndarray = np.empty(0, dtype=float)
 
@@ -347,8 +348,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self._currentStackBlwrvp_GP1_CgP1: np.ndarray = np.empty(0, dtype=float)
 
         # The list attributes above (list_num_wake_vortices,
-        # _list_wake_vortex_strengths, listStack{Br,Fr,Fl,Bl}wrvp_GP1_CgP1)
-        # were pre-allocated above this block.
+        # _list_wake_vortex_strengths, listStack{Br,Fr,Fl,Bl}wrvp_GP1_CgP1) were
+        # pre-allocated above this block.
 
         self._currentStackBoundRc0s: np.ndarray = np.empty(0, dtype=float)
         self._currentStackWakeRc0s: np.ndarray = np.empty(0, dtype=float)
@@ -407,18 +408,18 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # under, and warn if Numba's threading layer will make them slow.
         _aerodynamics_functions.report_thread_settings()
 
-        # The per step list arrays for both bound and wake state were
-        # pre-allocated in __init__. Recompute the total panel count (used by
-        # the progress bar weighting) here.
+        # The per step list arrays for both bound and wake state were pre-allocated in
+        # __init__. Recompute the total Panel count (used by the progress bar weighting)
+        # here.
         num_wing_panels = self.num_panels
 
-        # The following loop attempts to predict how much time each time step will
-        # take, relative to the other time steps. This data will be used to generate
-        # estimates of how much longer a simulation will take, and create a smoothly
-        # advancing progress bar.
+        # The following loop attempts to predict how much time each time step will take,
+        # relative to the other time steps. This data will be used to generate estimates
+        # of how much longer a simulation will take, and create a smoothly advancing
+        # progress bar.
 
-        # Initialize list that will hold the approximate, relative times. This has
-        # one more element than the number of time steps, because I will also use the
+        # Initialize list that will hold the approximate, relative times. This has one
+        # more element than the number of time steps, because I will also use the
         # progress bar during the simulation initialization.
         approx_times = np.zeros(self.num_steps + 1, dtype=float)
         for step in range(1, self.num_steps):
@@ -426,8 +427,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
             num_wake_ring_vortices = self.list_num_wake_vortices[step]
             num_ring_vortices = num_wing_panels + num_wake_ring_vortices
 
-            # The following constant multipliers were determined empirically. Thus
-            # far, they seem to provide for adequately smooth progress bar updating.
+            # The following constant multipliers were determined empirically. Thus far,
+            # they seem to provide for adequately smooth progress bar updating.
             if step == 1:
                 approx_times[step] = num_ring_vortices * 70
             elif step == 2:
@@ -439,8 +440,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
         approx_times[0] = round(approx_partial_time / 100)
         approx_total_time = np.sum(approx_times)
 
-        # Run the solve loop with the BLAS threading appropriate for this run's
-        # size.
+        # Run the solve loop with the BLAS threading appropriate for this run's size.
         with (
             _functions.solve_loop_thread_limits(self.num_panels),
             tqdm(
@@ -461,9 +461,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
             # Iterate through the time steps.
             for step in range(self.num_steps):
 
-                # Save attributes to hold the current step, Airplanes,
-                # and OperatingPoint, and freestream velocity (in the first
-                # Airplane's geometry axes, observed from the Earth frame).
+                # Save attributes to hold the current step, Airplanes, and
+                # OperatingPoint, and freestream velocity (in the first Airplane's
+                # geometry axes, observed from the Earth frame).
                 self._current_step = step
 
                 # Initialize this step's bound ring vortices. The default does an
@@ -484,14 +484,14 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     + str(self.num_steps - 1)
                 )
 
-                # Reinitialize the per step working arrays, collapse the geometry,
-                # solve the bound ring vortex circulation, and (past the first results
-                # step) calculate the loads for this time step.
+                # Reinitialize the per step working arrays, collapse the geometry, solve
+                # the bound ring vortex circulation, and (past the first results step)
+                # calculate the loads for this time step.
                 self._evaluate_step_aerodynamics()
 
                 # Hook: subclasses may inject work between load calculation and wake
-                # shedding (e.g. coupled problems update the next step's geometry
-                # from this step's solver results).
+                # shedding (e.g. coupled problems update the next step's geometry from
+                # this step's solver results).
                 self._update_next_step_hook(step)
 
                 # Shed ring vortices into the wake.
@@ -500,11 +500,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 )
                 self._populate_next_airplanes_wake()
 
-                # Snapshot this step's solved bound ring vortex strengths so the
-                # next step can use them as the "last" strengths in its
-                # _calculate_loads (for the unsteady force term and the back leg
-                # effective strength). The copy is needed because the next step
-                # will rebind _current_bound_vortex_strengths to a new array.
+                # Snapshot this step's solved bound ring vortex strengths so the next
+                # step can use them as the "last" strengths in its _calculate_loads (for
+                # the unsteady force term and the back leg effective strength). The copy
+                # is needed because the next step will rebind
+                # _current_bound_vortex_strengths to a new array.
                 self._last_bound_vortex_strengths = (
                     self._current_bound_vortex_strengths.copy()
                 )
@@ -545,10 +545,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
         """
         step = self._current_step
 
-        # TODO: I think these steps are redundant, at least during the first
-        #  time step. Consider dropping them.
-        # Initialize attributes to hold aerodynamic data that pertain to the
-        # simulation at this time step.
+        # TODO: I think these steps are redundant, at least during the first time step.
+        #  Consider dropping them.
+        # Initialize attributes to hold aerodynamic data that pertain to the simulation
+        # at this time step.
         self._currentVInf_GP1__E = self.current_operating_point.vInf_GP1__E
         self._currentStackFreestreamWingInfluences__E = np.zeros(
             self.num_panels, dtype=float
@@ -558,10 +558,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
         )
         self._currentStackWakeWingInfluences__E = np.zeros(self.num_panels, dtype=float)
         self._current_bound_vortex_strengths = np.ones(self.num_panels, dtype=float)
-        # _last_bound_vortex_strengths is left alone here. At step 0 it is
-        # the zeros allocated in __init__. At step > 0 it holds the
-        # previous step's solved strengths, captured at the end of the
-        # previous step's _calculate_vortex_strengths.
+        # _last_bound_vortex_strengths is left alone here. At step 0 it is the zeros
+        # allocated in __init__. At step > 0 it holds the previous step's solved
+        # strengths, captured at the end of the previous step's
+        # _calculate_vortex_strengths.
 
         # Initialize attributes to hold geometric data that pertain to this
         # UnsteadyProblem.
@@ -595,8 +595,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
         self.stackLbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
         self.stackBbrv_GP1 = np.zeros((self.num_panels, 3), dtype=float)
 
-        # Initialize variables to hold details about each Panel's location on
-        # its Wing.
+        # Initialize variables to hold details about each Panel's location on its Wing.
         self.panel_is_trailing_edge = np.zeros(self.num_panels, dtype=bool)
         self.panel_is_leading_edge = np.zeros(self.num_panels, dtype=bool)
         self.panel_is_left_edge = np.zeros(self.num_panels, dtype=bool)
@@ -605,8 +604,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # Hook: subclasses may reinitialize step-specific arrays here.
         self._reinitialize_step_arrays_hook()
 
-        # Get the pre-allocated (but still all zero) arrays of wake
-        # information that are associated with this time step.
+        # Get the pre-allocated (but still all zero) arrays of wake information that are
+        # associated with this time step.
         self._current_wake_vortex_strengths = self._list_wake_vortex_strengths[step]
         self._currentStackBrwrvp_GP1_CgP1 = self.listStackBrwrvp_GP1_CgP1[step]
         self._currentStackFrwrvp_GP1_CgP1 = self.listStackFrwrvp_GP1_CgP1[step]
@@ -624,20 +623,19 @@ class UnsteadyRingVortexLatticeMethodSolver:
         _logger.debug(_logging.indent() + "Collapsing the geometry")
         self._collapse_geometry()
 
-        # Find the matrix of Wing Wing influence coefficients associated with
-        # the Airplanes' geometries at this time step.
+        # Find the matrix of Wing Wing influence coefficients associated with the
+        # Airplanes' geometries at this time step.
         _logger.debug(_logging.indent() + "Calculating the Wing Wing influences")
         self._calculate_wing_wing_influences()
 
-        # Find the normal velocity (in the first Airplane's geometry axes,
-        # observed from the Earth frame) at every collocation point due
-        # solely to the freestream.
+        # Find the normal velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at every collocation point due solely to the freestream.
         _logger.debug(_logging.indent() + "Calculating the freestream Wing influences")
         self._calculate_freestream_wing_influences()
 
-        # Find the normal velocity (in the first Airplane's geometry axes,
-        # observed from the Earth frame) at every collocation point due
-        # solely to the wake ring vortices.
+        # Find the normal velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at every collocation point due solely to the wake ring
+        # vortices.
         _logger.debug(_logging.indent() + "Calculating the wake Wing influences")
         self._calculate_wake_wing_influences()
 
@@ -645,9 +643,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
         _logger.debug(_logging.indent() + "Calculating bound ring vortex strengths")
         self._calculate_vortex_strengths()
 
-        # Solve for the forces (in the first Airplane's geometry axes) and
-        # moments (in the first Airplane's geometry axes, relative to the
-        # first Airplane's CG) on each Panel.
+        # Solve for the forces (in the first Airplane's geometry axes) and moments (in
+        # the first Airplane's geometry axes, relative to the first Airplane's CG) on
+        # each Panel.
         if self._current_step >= self.first_results_step:
             _logger.debug(_logging.indent() + "Calculating forces and moments")
             self._calculate_loads()
@@ -783,8 +781,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 # Convert this Wing's 2D ndarray of Panels into a 1D ndarray.
                 panels = np.ravel(_panels)
 
-                # Iterate through the 1D ndarray of this Wing's Panels and write
-                # the per Panel scalars plus the corner-derived bound leg arrays.
+                # Iterate through the 1D ndarray of this Wing's Panels and write the per
+                # Panel scalars plus the corner-derived bound leg arrays.
                 panel: _panel.Panel
                 for panel in panels:
                     _functions.update_ring_vortex_solvers_panel_attributes(
@@ -799,10 +797,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     self._currentStackBoundRc0s[global_panel_position] = wing_r_c0
                     global_panel_position += 1
 
-                # Set the wake characteristic core radius for every wake
-                # ring vortex contributed by this Wing at this step. The wake
-                # corner positions and strengths are stored in the per step list arrays
-                # aliased to self._currentStack* in run() and populated by
+                # Set the wake characteristic core radius for every wake ring vortex
+                # contributed by this Wing at this step. The wake corner positions and
+                # strengths are stored in the per step list arrays aliased to
+                # self._currentStack* in run() and populated by
                 # _populate_next_airplanes_wake_vortices. Ages are derived from row
                 # position because each retained wake row is one delta_time older than
                 # the row before it.
@@ -814,15 +812,14 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     block_start = global_wake_ring_vortex_position
                     block_end = block_start + num_wing_wake_vortices
 
-                    # The initial core radius is constant across this Wing's
-                    # wake block, so it fills in a single slice.
+                    # The initial core radius is constant across this Wing's wake block,
+                    # so it fills in a single slice.
                     self._currentStackWakeRc0s[block_start:block_end] = wing_r_c0
 
-                    # Each chordwise wake row is one delta_time older than the
-                    # row shed after it, so row index c (0-based, newest
-                    # first) has age (c + 1) * delta_time. Repeat each row's
-                    # age across that row's spanwise wake vortices to match
-                    # the block layout used by
+                    # Each chordwise wake row is one delta_time older than the row shed
+                    # after it, so row index c (0-based, newest first) has age (c + 1) *
+                    # delta_time. Repeat each row's age across that row's spanwise wake
+                    # vortices to match the block layout used by
                     # _populate_next_airplanes_wake_vortices.
                     row_ages = (
                         np.arange(1, num_chordwise_wake_rows + 1, dtype=float)
@@ -847,18 +844,17 @@ class UnsteadyRingVortexLatticeMethodSolver:
             self._lastStackBlbrvp_GP1_CgP1[:] = lastStackBl
             self._lastStackBrbrvp_GP1_CgP1[:] = lastStackBr
 
-            # Last step bound leg center points, derived inline from corners.
-            # Right leg: back right -> front right. Front leg: front right ->
-            # front left. Left leg: front left -> back left. Back leg: back
-            # left -> back right.
+            # Last step bound leg center points, derived inline from corners. Right leg:
+            # back right -> front right. Front leg: front right -> front left. Left leg:
+            # front left -> back left. Back leg: back left -> back right.
             self._lastStackCblvpr_GP1_CgP1[:] = 0.5 * (lastStackBr + lastStackFr)
             self._lastStackCblvpf_GP1_CgP1[:] = 0.5 * (lastStackFr + lastStackFl)
             self._lastStackCblvpl_GP1_CgP1[:] = 0.5 * (lastStackFl + lastStackBl)
             self._lastStackCblvpb_GP1_CgP1[:] = 0.5 * (lastStackBl + lastStackBr)
 
-            # Last step Panel collocation points. Panel topology is invariant,
-            # but Panel positions move when the geometry is unsteady, so these
-            # need to be re-read from the previous step's Airplanes.
+            # Last step Panel collocation points. Panel topology is invariant, but Panel
+            # positions move when the geometry is unsteady, so these need to be re-read
+            # from the previous step's Airplanes.
             global_panel_position = 0
             last_problem = self._get_steady_problem_at(last_step)
             for last_airplane in last_problem.airplanes:
@@ -881,11 +877,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the 2D ndarray of normalized velocities (in the first Airplane's
-        # geometry axes, observed from the Earth frame) induced at each Panel's
-        # collocation point by each bound ring vortex. The answer is normalized
-        # because the solver's list of bound ring vortex strengths was initialized to
-        # all be 1.0. This will be updated once the correct strengths are calculated.
+        # Find the 2D ndarray of normalized velocities (in the first Airplane's geometry
+        # axes, observed from the Earth frame) induced at each Panel's collocation point
+        # by each bound ring vortex. The answer is normalized because the solver's list
+        # of bound ring vortex strengths was initialized to all be 1.0. This will be
+        # updated once the correct strengths are calculated.
         singularity_counts = np.zeros(4, dtype=np.int64)
         gridNormVIndCpp_GP1_E = (
             _aerodynamics_functions.expanded_velocities_from_ring_vortices(
@@ -941,11 +937,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
             unexpected_singularity_counts,
         )
 
-        # Take the batch dot product of the normalized induced velocities (in the
-        # first Airplane's geometry axes, observed from the Earth frame) with each
-        # Panel's unit normal direction (in the first Airplane's geometry axes). This
-        # is now the 2D ndarray of Wing Wing influence coefficients (observed from
-        # the Earth frame).
+        # Take the batch dot product of the normalized induced velocities (in the first
+        # Airplane's geometry axes, observed from the Earth frame) with each Panel's
+        # unit normal direction (in the first Airplane's geometry axes). This is now the
+        # 2D ndarray of Wing Wing influence coefficients (observed from the Earth
+        # frame).
         self._currentGridWingWingInfluences__E = np.einsum(
             "...k,...k->...",
             gridNormVIndCpp_GP1_E,
@@ -1045,9 +1041,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Find the normal components of the freestream only Wing influence
-        # coefficients (observed from the Earth frame) at each Panel's collocation
-        # point by taking a batch dot product.
+        # Find the normal components of the freestream only Wing influence coefficients
+        # (observed from the Earth frame) at each Panel's collocation point by taking a
+        # batch dot product.
         currentStackFreestreamOnlyWingInfluences__E = np.einsum(
             "ij,j->i",
             self.stackUnitNormals_GP1,
@@ -1064,16 +1060,17 @@ class UnsteadyRingVortexLatticeMethodSolver:
         )
 
         # Get the current apparent-motion influence coefficients at each Panel's
-        # collocation point (observed from the Earth frame) by taking a batch dot product.
+        # collocation point (observed from the Earth frame) by taking a batch dot
+        # product.
         currentStackApparentInfluences__E = np.einsum(
             "ij,ij->i",
             self.stackUnitNormals_GP1,
             currentStackApparentV_GP1_E,
         )
 
-        # Calculate the total current freestream Wing influence coefficients by
-        # summing the freestream-only influence coefficients and the apparent-motion
-        # influence coefficients (all observed from the Earth frame).
+        # Calculate the total current freestream Wing influence coefficients by summing
+        # the freestream-only influence coefficients and the apparent-motion influence
+        # coefficients (all observed from the Earth frame).
         self._currentStackFreestreamWingInfluences__E = (
             currentStackFreestreamOnlyWingInfluences__E
             + currentStackApparentInfluences__E
@@ -1096,8 +1093,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         :return: None
         """
         if self._current_step > 0:
-            # Get the velocities (in the first Airplane's geometry axes, observed
-            # from the Earth frame) induced by the wake ring vortices at each Panel's
+            # Get the velocities (in the first Airplane's geometry axes, observed from
+            # the Earth frame) induced by the wake ring vortices at each Panel's
             # collocation point.
             singularity_counts = np.zeros(4, dtype=np.int64)
             currentStackWakeV_GP1_E = (
@@ -1154,17 +1151,17 @@ class UnsteadyRingVortexLatticeMethodSolver:
                 unexpected_singularity_counts,
             )
 
-            # Get the current wake Wing influence coefficients (observed from the
-            # Earth frame) by taking a batch dot product with each Panel's normal
-            # vector (in the first Airplane's geometry axes).
+            # Get the current wake Wing influence coefficients (observed from the Earth
+            # frame) by taking a batch dot product with each Panel's normal vector (in
+            # the first Airplane's geometry axes).
             self._currentStackWakeWingInfluences__E = np.einsum(
                 "ij,ij->i", currentStackWakeV_GP1_E, self.stackUnitNormals_GP1
             )
 
         else:
             # If this is the first time step, set all the current Wake-wing influence
-            # coefficients to 0.0 (observed from the Earth frame) because no wake
-            # ring vortices have been shed.
+            # coefficients to 0.0 (observed from the Earth frame) because no wake ring
+            # vortices have been shed.
             self._currentStackWakeWingInfluences__E = np.zeros(
                 self.num_panels, dtype=float
             )
@@ -1388,8 +1385,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         :return: None
         """
-        # Initialize a variable to hold the global Panel position as we iterate
-        # through them.
+        # Initialize a variable to hold the global Panel position as we iterate through
+        # them.
         global_panel_position = 0
 
         # Initialize three 1D ndarrays to hold the effective strength of the Panels'
@@ -1399,11 +1396,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
         effective_left_line_vortex_strengths = np.zeros(self.num_panels, dtype=float)
         effective_back_line_vortex_strengths = np.zeros(self.num_panels, dtype=float)
 
-        # Iterate through the Airplanes' Wings. Within a Wing, Panels are laid
-        # out in row major (chordwise outer, spanwise inner) order, so
-        # neighbouring Panel strengths can be found at fixed offsets from the
-        # current global Panel position: +1 right, -1 left,
-        # +num_spanwise_panels back, -num_spanwise_panels front.
+        # Iterate through the Airplanes' Wings. Within a Wing, Panels are laid out in
+        # row major (chordwise outer, spanwise inner) order, so neighbouring Panel
+        # strengths can be found at fixed offsets from the current global Panel
+        # position: +1 right, -1 left, +num_spanwise_panels back, -num_spanwise_panels
+        # front.
         for airplane in self.current_airplanes:
             for wing in airplane.wings:
                 _panels = wing.panels
@@ -1428,8 +1425,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective right line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex
-                        # strength and that of the Panel to the right.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the right.
                         effective_right_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._current_bound_vortex_strengths[
@@ -1443,8 +1440,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective front line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex
-                        # strength and that of the Panel in front of it.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel in front of it.
                         effective_front_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._current_bound_vortex_strengths[
@@ -1458,8 +1455,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         )
                     else:
                         # Set the effective left line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex
-                        # strength and that of the Panel to the left.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the left.
                         effective_left_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._current_bound_vortex_strengths[
@@ -1469,20 +1466,19 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
                     if panel.is_trailing_edge:
                         if self._current_step == 0:
-                            # No wake ring vortex exists yet to cancel out this
-                            # Panel's back line vortex contribution, so the
-                            # effective back strength is the full ring vortex
-                            # strength.
+                            # No wake ring vortex exists yet to cancel out this Panel's
+                            # back line vortex contribution, so the effective back
+                            # strength is the full ring vortex strength.
                             effective_back_line_vortex_strengths[
                                 global_panel_position
                             ] = this_strength
                         else:
-                            # The Panel's back line vortex is partially cancelled
-                            # by the front line vortex of the wake ring vortex
-                            # immediately to its rear. That wake ring vortex
-                            # carries the strength this Panel's bound ring vortex
-                            # had last time step, so the effective back strength
-                            # is the difference between this step and the last.
+                            # The Panel's back line vortex is partially cancelled by the
+                            # front line vortex of the wake ring vortex immediately to
+                            # its rear. That wake ring vortex carries the strength this
+                            # Panel's bound ring vortex had last time step, so the
+                            # effective back strength is the difference between this
+                            # step and the last.
                             effective_back_line_vortex_strengths[
                                 global_panel_position
                             ] = (
@@ -1493,8 +1489,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                             )
                     else:
                         # Set the effective back line vortex strength to 1/2 the
-                        # difference between this Panel's bound ring vortex
-                        # strength and that of the Panel to the back.
+                        # difference between this Panel's bound ring vortex strength and
+                        # that of the Panel to the back.
                         effective_back_line_vortex_strengths[global_panel_position] = (
                             this_strength
                             - self._current_bound_vortex_strengths[
@@ -1504,11 +1500,11 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
                     global_panel_position += 1
 
-        # Calculate the velocity (in the first Airplane's geometry axes, observed
-        # from the Earth frame) at the center of every Panels' ring vortex's right
-        # line vortex, front line vortex, left line vortex, and back line vortex. For
-        # solvers that model body rotation, this also includes the body angular rate
-        # (omega cross r) at each leg center.
+        # Calculate the velocity (in the first Airplane's geometry axes, observed from
+        # the Earth frame) at the center of every Panels' ring vortex's right line
+        # vortex, front line vortex, left line vortex, and back line vortex. For solvers
+        # that model body rotation, this also includes the body angular rate (omega
+        # cross r) at each leg center.
         bound_singularity_counts = np.zeros(4, dtype=np.int64)
         wake_singularity_counts = np.zeros(4, dtype=np.int64)
         stackVelocityRightLineVortexCenters_GP1__E = self._apply_body_rate(
@@ -1553,10 +1549,10 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
         # Subtract the expected structural collinearity before logging. For each Wing
         # with C chordwise and S spanwise Panels, the four leg center evaluations
-        # produce (8 * C * S - 2 * C - 2 * S) bound collinearity singularities from
-        # ring vortex self and adjacent shared edge pairs. When there is a wake (time
-        # step > 0), each trailing edge Panel's back leg center is also collinear with
-        # and on-filament for the first wake row's front leg, adding S wake collinearity
+        # produce (8 * C * S - 2 * C - 2 * S) bound collinearity singularities from ring
+        # vortex self and adjacent shared edge pairs. When there is a wake (time step >
+        # 0), each trailing edge Panel's back leg center is also collinear with and
+        # on-filament for the first wake row's front leg, adding S wake collinearity
         # singularities per Wing.
         expected_bound_collinearity = 0
         expected_wake_collinearity = 0
@@ -1587,9 +1583,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
         )
 
         # Using the effective line vortex strengths and the Kutta-Joukowski theorem,
-        # find the forces (in the first Airplane's geometry axes) on the Panels'
-        # ring vortex's right line vortex, front line vortex, left line vortex, and back
-        # line vortex using the effective vortex strengths.
+        # find the forces (in the first Airplane's geometry axes) on the Panels' ring
+        # vortex's right line vortex, front line vortex, left line vortex, and back line
+        # vortex using the effective vortex strengths.
         rightLegForces_GP1 = (
             self.current_operating_point.rho
             * np.expand_dims(effective_right_line_vortex_strengths, axis=1)
@@ -1629,8 +1625,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # unsteady force term because it depends on both vortex strength and the normal
         # vector. When converting from CCW to CW, the strength changes sign but the
         # normal vector does not, requiring a sign correction. In contrast, steady
-        # Kutta-Joukowski forces depend on the strength and the line vortex vectors. Both
-        # have flipped signs, causing the negatives to cancel. See issue #27:
+        # Kutta-Joukowski forces depend on the strength and the line vortex vectors.
+        # Both have flipped signs, causing the negatives to cancel. See issue #27:
         # https://github.com/camUrban/PteraSoftware/issues/27
 
         # Calculate the unsteady component of the force on each Panel (in geometry
@@ -1685,9 +1681,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
             (in the first Airplane's geometry axes, relative to the first Airplane's CG)
             on every Panel at the current time step.
         """
-        # Find the moments (in the first Airplane's geometry axes, relative to the
-        # first Airplane's CG) on the Panels' ring vortex's right line vortex,
-        # front line vortex, left line vortex, and back line vortex.
+        # Find the moments (in the first Airplane's geometry axes, relative to the first
+        # Airplane's CG) on the Panels' ring vortex's right line vortex, front line
+        # vortex, left line vortex, and back line vortex.
         rightLegMoments_GP1_CgP1 = _functions.numba_1d_explicit_cross(
             self.stackCblvpr_GP1_CgP1, rightLegForces_GP1
         )
@@ -1705,8 +1701,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # unsteady force acts on the bound ring vortex, whose center is at the
         # collocation point, not at the Panel's centroid.
 
-        # Find the moments (in the first Airplane's geometry axes, relative to the
-        # first Airplane's CG) due to the unsteady component of the force on each Panel.
+        # Find the moments (in the first Airplane's geometry axes, relative to the first
+        # Airplane's CG) due to the unsteady component of the force on each Panel.
         unsteady_moments_GP1_CgP1 = _functions.numba_1d_explicit_cross(
             self.stackCpp_GP1_CgP1, unsteady_forces_GP1
         )
@@ -1838,13 +1834,13 @@ class UnsteadyRingVortexLatticeMethodSolver:
             convectionOmegasRad_GP1__E = self._convectionOmegasRad_GP1__E()
 
             # The induced (Biot-Savart) part of the aged wake grid's transport velocity
-            # reads only the current step's bound geometry, strengths, and wake, so it is
-            # independent of the next step's body state. When a caller has not already
-            # computed it, compute it once here for all Wings; a strongly coupled free-
-            # flight sub-iteration instead precomputes it once per step and passes it in
-            # to reuse it unchanged across trials. It is only needed past the first time
-            # step, where an aged grid exists, and only for a free wake, since a
-            # prescribed wake convects with the freestream alone.
+            # reads only the current step's bound geometry, strengths, and wake, so it
+            # is independent of the next step's body state. When a caller has not
+            # already computed it, compute it once here for all Wings; a strongly
+            # coupled free-flight sub-iteration instead precomputes it once per step and
+            # passes it in to reuse it unchanged across trials. It is only needed past
+            # the first time step, where an aged grid exists, and only for a free wake,
+            # since a prescribed wake convects with the freestream alone.
             if (
                 stackVIndGridWrvp_GP1__E is None
                 and self._current_step > 0
@@ -1877,9 +1873,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # Set the chordwise position to be at the trailing edge.
                         chordwise_panel_id = num_chordwise_panels - 1
 
-                        # Initialize a ndarray to hold the points of the new row of
-                        # wake ring vortices (in the first Airplane's geometry axes,
-                        # relative to the first Airplane's CG).
+                        # Initialize a ndarray to hold the points of the new row of wake
+                        # ring vortices (in the first Airplane's geometry axes, relative
+                        # to the first Airplane's CG).
                         newRowWrvp_GP1_CgP1 = np.zeros(
                             (1, num_spanwise_panels + 1, 3), dtype=float
                         )
@@ -1899,15 +1895,15 @@ class UnsteadyRingVortexLatticeMethodSolver:
                             te_global_idx = te_panel_base + spanwise_panel_id
 
                             # The position of the new front left wake ring vortex's
-                            # point is the next time step's Panel's bound
-                            # ring vortex's back left point.
+                            # point is the next time step's Panel's bound ring vortex's
+                            # back left point.
                             newRowWrvp_GP1_CgP1[0, spanwise_panel_id] = next_stackBl[
                                 te_global_idx
                             ]
 
-                            # If the Panel is at the right edge of the Wing, add
-                            # its back right bound ring vortex point to the row
-                            # of new wake ring vortex points.
+                            # If the Panel is at the right edge of the Wing, add its
+                            # back right bound ring vortex point to the row of new wake
+                            # ring vortex points.
                             if spanwise_panel_id == (num_spanwise_panels - 1):
                                 newRowWrvp_GP1_CgP1[0, spanwise_panel_id + 1] = (
                                     next_stackBr[te_global_idx]
@@ -1918,9 +1914,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # This is correct because it is currently the first time step.
                         next_wing.gridWrvp_GP1_CgP1 = np.copy(newRowWrvp_GP1_CgP1)
 
-                        # If the wake is prescribed, the velocity at every point is
-                        # the freestream velocity (in the first Airplane's geometry
-                        # axes, observed from the Earth frame). Otherwise, batch one
+                        # If the wake is prescribed, the velocity at every point is the
+                        # freestream velocity (in the first Airplane's geometry axes,
+                        # observed from the Earth frame). Otherwise, batch one
                         # solution-velocity call across all of the row's points.
                         if self._prescribed_wake:
                             vRowWrvp_GP1__E = convectionVInf_GP1__E
@@ -1950,9 +1946,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # collocation points and bound line vortex leg centers, so the
                         # wake convects with the fluid velocity relative to the rotating
                         # body frame. Without this term, a nonzero body rate would carry
-                        # the wake along with the body instead of leaving it fixed in the
-                        # Earth frame. When the solver does not model body rotation, this
-                        # is a no-op.
+                        # the wake along with the body instead of leaving it fixed in
+                        # the Earth frame. When the solver does not model body rotation,
+                        # this is a no-op.
                         vRowWrvp_GP1__E = self._apply_body_rate(
                             next_wing.gridWrvp_GP1_CgP1,
                             vRowWrvp_GP1__E,
@@ -1980,18 +1976,18 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         assert _thisGridWrvp_GP1_CgP1 is not None
 
                         # Set the next time step's Wing's grid of wake ring vortex
-                        # points to a copy of this time step's Wing's grid of wake
-                        # ring vortex points.
+                        # points to a copy of this time step's Wing's grid of wake ring
+                        # vortex points.
                         next_wing.gridWrvp_GP1_CgP1 = np.copy(_thisGridWrvp_GP1_CgP1)
 
-                        # If the wake is prescribed, the velocity at every point is
-                        # the freestream velocity (in the first Airplane's geometry
-                        # axes, observed from the Earth frame). Otherwise, add the next
-                        # step's freestream (the interval's end frame, rather than the
-                        # current step's freestream that calculate_solution_velocity
-                        # would add) to the induced velocity at the aged grid, computed
-                        # up front for this call or supplied by a strongly coupled sub-
-                        # iteration that reuses it across trials.
+                        # If the wake is prescribed, the velocity at every point is the
+                        # freestream velocity (in the first Airplane's geometry axes,
+                        # observed from the Earth frame). Otherwise, add the next step's
+                        # freestream (the interval's end frame, rather than the current
+                        # step's freestream that calculate_solution_velocity would add)
+                        # to the induced velocity at the aged grid, computed up front
+                        # for this call or supplied by a strongly coupled sub-iteration
+                        # that reuses it across trials.
                         if self._prescribed_wake:
                             vGridWrvp_GP1__E = convectionVInf_GP1__E
                         else:
@@ -2010,9 +2006,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         # collocation points and bound line vortex leg centers, so the
                         # wake convects with the fluid velocity relative to the rotating
                         # body frame. Without this term, a nonzero body rate would carry
-                        # the wake along with the body instead of leaving it fixed in the
-                        # Earth frame. When the solver does not model body rotation, this
-                        # is a no-op.
+                        # the wake along with the body instead of leaving it fixed in
+                        # the Earth frame. When the solver does not model body rotation,
+                        # this is a no-op.
                         vGridWrvp_GP1__E = self._apply_body_rate(
                             next_wing.gridWrvp_GP1_CgP1,
                             vGridWrvp_GP1__E,
@@ -2031,8 +2027,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         _num_spanwise_panels = this_wing.num_spanwise_panels
                         assert _num_spanwise_panels is not None
 
-                        # Initialize a new ndarray to hold the new row of wake
-                        # ring vortex vertices.
+                        # Initialize a new ndarray to hold the new row of wake ring
+                        # vortex vertices.
                         newRowWrvp_GP1_CgP1 = np.zeros(
                             (1, _num_spanwise_panels + 1, 3), dtype=float
                         )
@@ -2052,22 +2048,22 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         for spanwise_panel_id in range(_num_spanwise_panels):
                             te_global_idx = te_panel_base + spanwise_panel_id
 
-                            # Add the Panel's back left bound ring vortex point to
-                            # the grid of new wake ring vortex points.
+                            # Add the Panel's back left bound ring vortex point to the
+                            # grid of new wake ring vortex points.
                             newRowWrvp_GP1_CgP1[0, spanwise_panel_id] = next_stackBl[
                                 te_global_idx
                             ]
 
-                            # If the Panel is at the right edge of the Wing, add
-                            # its back right bound ring vortex point to the grid
-                            # of new wake ring vortex vertices.
+                            # If the Panel is at the right edge of the Wing, add its
+                            # back right bound ring vortex point to the grid of new wake
+                            # ring vortex vertices.
                             if spanwise_panel_id == (_num_spanwise_panels - 1):
                                 newRowWrvp_GP1_CgP1[0, spanwise_panel_id + 1] = (
                                     next_stackBr[te_global_idx]
                                 )
 
-                        # Stack the new row of wake ring vortex points above the
-                        # Wing's grid of wake ring vortex points.
+                        # Stack the new row of wake ring vortex points above the Wing's
+                        # grid of wake ring vortex points.
                         next_wing.gridWrvp_GP1_CgP1 = np.vstack(
                             (
                                 newRowWrvp_GP1_CgP1,
@@ -2138,9 +2134,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
         next_stackBl = self.listStackBlwrvp_GP1_CgP1[next_step]
         next_stackBr = self.listStackBrwrvp_GP1_CgP1[next_step]
 
-        # This step's wake snapshots, used as the source of inherited rows.
-        # When this_num_chordwise_rows is 0 (i.e. step 0 -> 1), they are zero
-        # length and never indexed.
+        # This step's wake snapshots, used as the source of inherited rows. When
+        # this_num_chordwise_rows is 0 (i.e. step 0 -> 1), they are zero length and
+        # never indexed.
         this_strengths = self._list_wake_vortex_strengths[this_step]
 
         next_problem = self._get_steady_problem_at(next_step)
@@ -2153,8 +2149,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     wing_id
                 ]
 
-                # Per wing flat block bases inside this step's and the next
-                # step's global wake stacks.
+                # These are the per Wing flat block bases inside this step's and the
+                # next step's global wake stacks.
                 next_wing_wake_base = (
                     next_num_chordwise_rows * cumulative_prior_spanwise
                 )
@@ -2197,9 +2193,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     ]
                 )
 
-                # Inherited rows (c >= 1): aged versions of this step's rows
-                # 0 .. inherited_rows - 1. When wake truncation drops the
-                # oldest row, the highest-c row of this step is excluded.
+                # The inherited rows (c >= 1) are aged versions of this step's rows 0 ..
+                # inherited_rows - 1. When wake truncation drops the oldest row, the
+                # highest-c row of this step is excluded.
                 for c in range(1, next_num_chordwise_rows):
                     old_c = c - 1
                     new_start = next_wing_wake_base + c * wing_num_spanwise
@@ -2363,7 +2359,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
         :return: None
         """
         # Get this solver's time step characteristics. Note that the first time step
-        # ( time step 0), occurs at 0 seconds.
+        # (time step 0), occurs at 0 seconds.
         num_steps_to_average = self.num_steps - self._first_averaging_step
 
         # Determine if this SteadyProblem's geometry is static or variable.
@@ -2408,10 +2404,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
 
             results_step += 1
 
-        # For each Airplane, calculate and then save the final or cycle-averaged and
-        # RMS loads and load coefficients. For variable geometry cases, use the
-        # trapezoidal rule to compute the time-averaged mean and RMS over the final
-        # cycle.
+        # For each Airplane, calculate and then save the final or cycle-averaged and RMS
+        # loads and load coefficients. For variable geometry cases, use the trapezoidal
+        # rule to compute the time-averaged mean and RMS over the final cycle.
         first_problem: problems.SteadyProblem = self._get_steady_problem_at(0)
         for airplane_id, airplane in enumerate(first_problem.airplanes):
             if static:
@@ -2426,8 +2421,8 @@ class UnsteadyRingVortexLatticeMethodSolver:
                     moment_coefficients_W_CgP1[airplane_id, :, -1]
                 )
             else:
-                # The number of intervals for the trapezoidal rule is one less
-                # than the number of samples.
+                # The number of intervals for the trapezoidal rule is one less than the
+                # number of samples.
                 num_intervals = num_steps_to_average - 1
 
                 self.unsteady_problem.finalMeanForces_W.append(
@@ -2561,9 +2556,9 @@ class UnsteadyRingVortexLatticeMethodSolver:
                         Flrvp_GP1_CgP1 = _Flbvp_GP1_CgP1
                         Frrvp_GP1_CgP1 = _Frbvp_GP1_CgP1
 
-                        # Define the location of the back left and back right
-                        # bound ring vortex points based on whether the Panel is
-                        # along the trailing edge.
+                        # Define the location of the back left and back right bound ring
+                        # vortex points based on whether the Panel is along the trailing
+                        # edge.
                         if not panel.is_trailing_edge:
                             next_chordwise_panel: _panel.Panel = _panels[
                                 chordwise_position + 1, spanwise_position
@@ -2578,14 +2573,13 @@ class UnsteadyRingVortexLatticeMethodSolver:
                             Blrvp_GP1_CgP1 = _nextFlbvp_GP1_CgP1
                             Brrvp_GP1_CgP1 = _nextFrbvp_GP1_CgP1
                         else:
-                            # As these vertices are directly behind the trailing
-                            # edge, they are spaced back from their Panel's vertex
-                            # by one quarter of the distance traveled by the
-                            # trailing edge during a time step. This is to more
-                            # accurately predict drag. More information can be
-                            # found on pages 37-39 of "Modeling of aerodynamic
-                            # forces in flapping flight with the Unsteady Vortex
-                            # Lattice Method" by Thomas Lambert.
+                            # As these vertices are directly behind the trailing edge,
+                            # they are spaced back from their Panel's vertex by one
+                            # quarter of the distance traveled by the trailing edge
+                            # during a time step. This is to more accurately predict
+                            # drag. More information can be found on pages 37-39 of
+                            # "Modeling of aerodynamic forces in flapping flight with
+                            # the Unsteady Vortex Lattice Method" by Thomas Lambert.
                             if step == 0:
                                 _Blpp_GP1_CgP1 = panel.Blpp_GP1_CgP1
                                 assert _Blpp_GP1_CgP1 is not None
@@ -2626,7 +2620,7 @@ class UnsteadyRingVortexLatticeMethodSolver:
                                 # Subtract (thisBlpp_GP1_CgP1 - lastBlpp_GP1_CgP1)
                                 # / self.delta_time from vInf_GP1__E to get the
                                 # apparent fluid velocity due to motion (observed
-                                # in the Earth frame, in the first Airplane's
+                                # from the Earth frame, in the first Airplane's
                                 # geometry axes). This is the vector pointing
                                 # opposite the velocity from motion.
                                 Blrvp_GP1_CgP1 = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,16 @@ source = ["pterasoftware"]
 black = true
 recursive = true
 force-wrap = true
+
+[tool.octowrap]
+line-length = 88
+recursive = true
+inline = true
+list-wrap = true
+diff-only = false
+diff-base = "HEAD"
+todo-case-sensitive = true
+todo-multiline = true
+extend-exclude = ["private", ".venv-wsl", "experimental"]
+todo-patterns = ["TODO:", "FIXME:"]
+extend-todo-patterns = ["TEST:"]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ coverage
 docformatter
 isort
 mypy
+octowrap == 0.6.2
 pre-commit
 scipy-stubs
 twine

--- a/scripts/analyze_webp.py
+++ b/scripts/analyze_webp.py
@@ -28,17 +28,16 @@ from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.colors import to_rgb
 from matplotlib.figure import Figure
 
-# The backdrop marks every pixel that is not part of a frame. Light red is used
-# because it is unlikely to appear in real rendered output, so it is visually
-# unambiguous.
+# The backdrop marks every pixel that is not part of a frame. Light red is used because
+# it is unlikely to appear in real rendered output, so it is visually unambiguous.
 BACKDROP_RGB = np.array([1.0, 0.815, 0.815], dtype=float)
 
 DPI = 110.0
 
-# At this module's DPI constant, this width makes a default 9-tile sheet of 4:3
-# frames render at about 2000 x 1600 pixels, which fits within the resolution
-# at which current Claude models view images natively (2576 pixels on the long
-# edge and roughly 3.6 megapixels) with no downscaling.
+# At this module's DPI constant, this width makes a default 9-tile sheet of 4:3 frames
+# render at about 2000 x 1600 pixels, which fits within the resolution at which current
+# Claude models view images natively (2576 pixels on the long edge and roughly 3.6
+# megapixels) with no downscaling.
 SHEET_TILE_WIDTH_INCHES = 6.0
 
 
@@ -129,18 +128,18 @@ def _render_tiles(
         ax.axis("off")
     fig.tight_layout()
 
-    # Render the figure with a fully transparent background so the pixels
-    # inside each frame keep their original alpha values.
+    # Render the figure with a fully transparent background so the pixels inside each
+    # frame keep their original alpha values.
     buffer = io.BytesIO()
     fig.savefig(buffer, format="png", dpi=DPI, transparent=True)
     buffer.seek(0)
     rendered = mpimg.imread(buffer)
     height, width = rendered.shape[:2]
 
-    # Composite the whole render over the opaque backdrop, then refill each
-    # frame's exact extent: with the raw pixels (keeping their original alpha
-    # values) by default, or composited over the given background color. Labels
-    # land in the margins, so they survive the backdrop compositing.
+    # Composite the whole render over the opaque backdrop, then refill each frame's
+    # exact extent: with the raw pixels (keeping their original alpha values) by
+    # default, or composited over the given background color. Labels land in the
+    # margins, so they survive the backdrop compositing.
     alpha = rendered[:, :, 3:4]
     out = np.empty((height, width, 4), dtype=float)
     out[:, :, :3] = rendered[:, :, :3] * alpha + BACKDROP_RGB * (1.0 - alpha)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 """Contains the tests for Ptera Software."""
 
-# Must be the first import so environment variables are set before any other
-# module reads them.
+# Must be the first import so environment variables are set before any other module
+# reads them.
 import tests._test_environment  # noqa: F401

--- a/tests/integration/test_aeroelastic_unsteady_ring_vortex_lattice_method.py
+++ b/tests/integration/test_aeroelastic_unsteady_ring_vortex_lattice_method.py
@@ -77,8 +77,8 @@ def _make_aeroelastic_solver(
     airfoil = ps.geometry.airfoil.Airfoil(name="naca2412")
 
     # Three WingCrossSections: root, one intermediate, and tip. Each non-tip
-    # WingCrossSection has num_spanwise_panels=1 so each strip is modeled as a
-    # single torsional spring element.
+    # WingCrossSection has num_spanwise_panels=1 so each strip is modeled as a single
+    # torsional spring element.
     root_wing_cross_section = ps.geometry.wing_cross_section.WingCrossSection(
         num_spanwise_panels=1,
         chord=1.0,
@@ -113,10 +113,10 @@ def _make_aeroelastic_solver(
         airfoil=airfoil,
     )
 
-    # Wing root is offset slightly from the symmetry plane (y=0), which produces
-    # type-5 (non-coincident) symmetry and causes the Airplane constructor to generate
-    # a reflected Wing at airplane.wings[1]. AeroelasticUnsteadyProblem requires at
-    # least two WingMovements so that wings[0] and wings[1] both receive deformation.
+    # Wing root is offset slightly from the symmetry plane (y=0), which produces type-5
+    # (non-coincident) symmetry and causes the Airplane constructor to generate a
+    # reflected Wing at airplane.wings[1]. AeroelasticUnsteadyProblem requires at least
+    # two WingMovements so that wings[0] and wings[1] both receive deformation.
     main_wing = ps.geometry.wing.Wing(
         wing_cross_sections=[
             root_wing_cross_section,
@@ -142,9 +142,9 @@ def _make_aeroelastic_solver(
         weight=0.0,
     )
 
-    # Build WingCrossSectionMovements from wings[0]'s WingCrossSections. Following
-    # the example's pattern, the same movement objects are reused for the reflected
-    # Wing (wings[1]) since both halves flap symmetrically.
+    # Build WingCrossSectionMovements from wings[0]'s WingCrossSections. Following the
+    # example's pattern, the same movement objects are reused for the reflected Wing
+    # (wings[1]) since both halves flap symmetrically.
     wing_cross_section_movements = [
         ps.movements.aeroelastic_wing_cross_section_movement.AeroelasticWingCrossSectionMovement(
             base_wing_cross_section=wing_cross_section,

--- a/tests/integration/test_free_flight_unsteady_ring_vortex_lattice_method.py
+++ b/tests/integration/test_free_flight_unsteady_ring_vortex_lattice_method.py
@@ -62,8 +62,8 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethod(unittest.TestCase):
             [operating_point.omegas_BP1__E for operating_point in operating_points]
         )
 
-        # In Ptera Software's wind axes, lift is the negative z-component of the wind-axes
-        # force.
+        # In Ptera Software's wind axes, lift is the negative z component of the wind
+        # axes force.
         forces_W = np.array(
             [
                 steady_problem.airplanes[0].forces_W
@@ -167,8 +167,8 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethod(unittest.TestCase):
         # (increasing z) loses potential energy.
         potential_energies = -self.mass * (self.positions_E_Eo @ self.g_E)
 
-        # Rotational kinetic energy, using the body-axes angular velocity (converted from
-        # degrees per second to radians per second) and inertia matrix.
+        # Rotational kinetic energy, using the body-axes angular velocity (converted
+        # from degrees per second to radians per second) and inertia matrix.
         omegasRad_BP1__E = np.deg2rad(self.omegas_BP1__E)
         rotational_kinetic_energies = np.array(
             [
@@ -232,8 +232,8 @@ class TestFreeFlightUnsteadyRingVortexLatticeMethodFlapping(unittest.TestCase):
             [operating_point.CgP1_E_Eo for operating_point in operating_points]
         )
 
-        # In Ptera Software's wind axes, lift is the negative z-component of the wind-axes
-        # force and the lateral side force is the y-component.
+        # In Ptera Software's wind axes, lift is the negative z component of the wind
+        # axes force and the lateral side force is the y component.
         forces_W = np.array(
             [
                 steady_problem.airplanes[0].forces_W

--- a/tests/integration/test_output.py
+++ b/tests/integration/test_output.py
@@ -34,8 +34,8 @@ class TestOutput(unittest.TestCase):
         :return: None
         """
 
-        # Call the plot_results_versus_time method on the solver fixture. The show
-        # flag is set to False, so the figures will not be displayed.
+        # Call the plot_results_versus_time method on the solver fixture. The show flag
+        # is set to False, so the figures will not be displayed.
         ps.output.plot_results_versus_time(
             unsteady_solver=self.unsteady_solver, show=False
         )
@@ -46,8 +46,8 @@ class TestOutput(unittest.TestCase):
         :return: None
         """
 
-        # Call the animate function on the unsteady solver fixture. The testing flag
-        # is true so the animation will start automatically after 1 second.
+        # Call the animate function on the unsteady solver fixture. The testing flag is
+        # true so the animation will start automatically after 1 second.
         ps.output.animate(
             unsteady_solver=self.unsteady_solver,
             scalar_type=None,
@@ -62,8 +62,8 @@ class TestOutput(unittest.TestCase):
         :return: None
         """
 
-        # Call the draw function on the unsteady solver fixture. The testing flag is
-        # set to true, so the plotter will close after 1 second.
+        # Call the draw function on the unsteady solver fixture. The testing flag is set
+        # to true, so the plotter will close after 1 second.
         ps.output.draw(
             solver=self.unsteady_solver,
             scalar_type=None,

--- a/tests/integration/test_steady_convergence.py
+++ b/tests/integration/test_steady_convergence.py
@@ -279,8 +279,8 @@ class TestSteadyConvergence(unittest.TestCase):
                 cache_path=cache_path,
             )
 
-            # On the warm run every mesh should be a cache hit, so the solver must
-            # never run. Patching run to raise turns any solve into a test failure.
+            # On the warm run every mesh should be a cache hit, so the solver must never
+            # run. Patching run to raise turns any solve into a test failure.
             solver_class = (
                 ps.steady_ring_vortex_lattice_method.SteadyRingVortexLatticeMethodSolver
             )
@@ -322,8 +322,8 @@ class TestSteadyConvergence(unittest.TestCase):
             )
 
             # On the warm run every mesh's spanwise Panel counts should be cache hits,
-            # so the resolver must never recompute one. Patching the computation to raise
-            # turns any recomputation into a test failure.
+            # so the resolver must never recompute one. Patching the computation to
+            # raise turns any recomputation into a test failure.
             with mock.patch.object(
                 _convergence_meshing,
                 "_get_wing_section_num_spanwise_panels",

--- a/tests/integration/test_unsteady_convergence.py
+++ b/tests/integration/test_unsteady_convergence.py
@@ -155,8 +155,8 @@ class TestUnsteadyConvergence(unittest.TestCase):
                 cache_path=cache_path,
             )
 
-            # On the warm run every mesh should be a cache hit, so the solver must
-            # never run. Patching run to raise turns any solve into a test failure.
+            # On the warm run every mesh should be a cache hit, so the solver must never
+            # run. Patching run to raise turns any solve into a test failure.
             solver_class = (
                 ps.unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver
             )
@@ -257,9 +257,9 @@ class TestUnsteadyConvergence(unittest.TestCase):
             cache_path = Path(tmp) / "cache.json"
 
             # A cold run over wider Panel aspect ratio bounds populates the cache with
-            # every mesh the narrower run below will need. The memos are keyed on absolute
-            # mesh values, so they carry over even though the two runs index their sweeps
-            # differently.
+            # every mesh the narrower run below will need. The memos are keyed on
+            # absolute mesh values, so they carry over even though the two runs index
+            # their sweeps differently.
             ps.convergence.analyze_unsteady_convergence(
                 ref_problem=self.unsteady_validation_problem,
                 prescribed_wake=True,
@@ -273,9 +273,9 @@ class TestUnsteadyConvergence(unittest.TestCase):
                 cache_path=cache_path,
             )
 
-            # The narrower run reuses those cached memos, so its delta_time optimizer must
-            # never run despite the different bounds. Patching it to raise turns any
-            # optimization into a test failure.
+            # The narrower run reuses those cached memos, so its delta_time optimizer
+            # must never run despite the different bounds. Patching it to raise turns
+            # any optimization into a test failure.
             with mock.patch.object(
                 ps.movements.movement,
                 "_optimize_delta_time",
@@ -408,9 +408,9 @@ class TestUnsteadyConvergence(unittest.TestCase):
 
         # The Panel aspect ratio and chordwise Panel bounds are kept tight because an
         # edge-defined Wing refined to a fine Panel aspect ratio with many chordwise
-        # Panels needs many WingCrossSections, which makes the unsteady solves expensive.
-        # These bounds still span enough of each parameter direction to detect
-        # convergence.
+        # Panels needs many WingCrossSections, which makes the unsteady solves
+        # expensive. These bounds still span enough of each parameter direction to
+        # detect convergence.
         converged_parameters = ps.convergence.analyze_unsteady_convergence(
             ref_problem=edge_defined_unsteady_problem,
             prescribed_wake=True,

--- a/tests/unit/fixtures/aeroelastic_airplane_movement_fixtures.py
+++ b/tests/unit/fixtures/aeroelastic_airplane_movement_fixtures.py
@@ -28,8 +28,8 @@ def make_static_aeroelastic_airplane_movement_fixture():
     )
 
     # Build a static AeroelasticWingCrossSectionMovement for each of the base Wing's
-    # WingCrossSections, which keeps the generated Wings valid (in particular, the
-    # first WingCrossSection keeps its required zero Lp_Wcsp_Lpp).
+    # WingCrossSections, which keeps the generated Wings valid (in particular, the first
+    # WingCrossSection keeps its required zero Lp_Wcsp_Lpp).
     wing_cross_section_movements = [
         ps.movements.aeroelastic_wing_cross_section_movement.AeroelasticWingCrossSectionMovement(
             base_wing_cross_section=wing_cross_section

--- a/tests/unit/fixtures/aeroelastic_wing_cross_section_movement_fixtures.py
+++ b/tests/unit/fixtures/aeroelastic_wing_cross_section_movement_fixtures.py
@@ -44,8 +44,8 @@ def make_basic_aeroelastic_wing_cross_section_movement_fixture():
         AeroelasticWingCrossSectionMovement
         This is the AeroelasticWingCrossSectionMovement with general-purpose values.
     """
-    # Initialize the constructing fixture.
-    # Use the tip fixture to ensure Lp values stay non negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the basic AeroelasticWingCrossSectionMovement.

--- a/tests/unit/fixtures/aeroelastic_wing_movement_fixtures.py
+++ b/tests/unit/fixtures/aeroelastic_wing_movement_fixtures.py
@@ -16,9 +16,9 @@ def make_static_aeroelastic_wing_movement_fixture():
         WingCrossSections so that the generated Wings stay valid.
     """
     # Initialize the constructing fixtures. Build a static
-    # AeroelasticWingCrossSectionMovement for each of the base Wing's
-    # WingCrossSections, which keeps the generated Wings valid (in particular, the
-    # first WingCrossSection keeps its required zero Lp_Wcsp_Lpp).
+    # AeroelasticWingCrossSectionMovement for each of the base Wing's WingCrossSections,
+    # which keeps the generated Wings valid (in particular, the first WingCrossSection
+    # keeps its required zero Lp_Wcsp_Lpp).
     base_wing = geometry_fixtures.make_origin_wing_fixture()
     wing_cross_section_movements = [
         ps.movements.aeroelastic_wing_cross_section_movement.AeroelasticWingCrossSectionMovement(

--- a/tests/unit/fixtures/core_wing_cross_section_movement_fixtures.py
+++ b/tests/unit/fixtures/core_wing_cross_section_movement_fixtures.py
@@ -67,8 +67,8 @@ def make_mixed_spacing_Lp_core_wing_cross_section_movement_fixture():
     :return mixed_spacing_Lp_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with mixed spacing for Lp_Wcsp_Lpp.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture which has Lp_Wcsp_Lpp[1] = 2.0, allowing for amplitude of 1.5.
+    # Initialize the constructing fixture. Use the tip fixture, which has Lp_Wcsp_Lpp[1]
+    # = 2.0, allowing for amplitude of 1.5.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the CoreWingCrossSectionMovement with mixed spacing.
@@ -226,8 +226,8 @@ def make_basic_core_wing_cross_section_movement_fixture():
     :return basic_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with general-purpose values.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the basic CoreWingCrossSectionMovement.
@@ -254,8 +254,8 @@ def make_Lp_only_core_wing_cross_section_movement_fixture():
     :return Lp_only_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with only Lp_Wcsp_Lpp movement.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the Lp-only CoreWingCrossSectionMovement.
@@ -310,8 +310,8 @@ def make_phase_offset_Lp_core_wing_cross_section_movement_fixture():
     :return phase_offset_Lp_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with phase offset for Lp_Wcsp_Lpp.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the phase-offset CoreWingCrossSectionMovement.
@@ -370,8 +370,8 @@ def make_multiple_periods_core_wing_cross_section_movement_fixture():
     :return multiple_periods_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with different periods.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the multiple-periods CoreWingCrossSectionMovement.
@@ -400,8 +400,8 @@ def make_custom_spacing_Lp_core_wing_cross_section_movement_fixture():
     :return custom_spacing_Lp_core_wing_cross_section_movement_fixture: CoreWingCrossSectionMovement
         This is the CoreWingCrossSectionMovement with custom spacing for Lp_Wcsp_Lpp.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Define a custom harmonic spacing function.
@@ -495,8 +495,8 @@ def make_mixed_custom_and_standard_spacing_core_wing_cross_section_movement_fixt
         This is the CoreWingCrossSectionMovement with mixed custom and standard
         spacing.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Define a custom harmonic spacing function.

--- a/tests/unit/fixtures/core_wing_movement_fixtures.py
+++ b/tests/unit/fixtures/core_wing_movement_fixtures.py
@@ -582,9 +582,9 @@ def make_rotation_point_offset_core_wing_movement_fixture():
         core_wing_cross_section_movement_fixtures.make_static_tip_core_wing_cross_section_movement_fixture(),
     ]
 
-    # Create the CoreWingMovement with rotation point offset.
-    # The offset is in y direction (0.0, 0.5, 0.0), and we rotate about the x axis.
-    # This causes the wing to trace an arc in the yz plane as it rotates.
+    # Create the CoreWingMovement with rotation point offset. The offset is in y
+    # direction (0.0, 0.5, 0.0), and we rotate about the x axis. This causes the wing to
+    # trace an arc in the yz plane as it rotates.
     rotation_point_offset_core_wing_movement_fixture = CoreWingMovement(
         base_wing=base_wing,
         wing_cross_section_movements=wcs_movements,
@@ -620,8 +620,8 @@ def make_periodic_geometry_core_wing_movement_fixture():
         core_wing_cross_section_movement_fixtures.make_static_tip_core_wing_cross_section_movement_fixture(),
     ]
 
-    # Create the periodic geometry CoreWingMovement.
-    # Use a 0.1s period for angular motion (plunging wing motion).
+    # Create the periodic geometry CoreWingMovement. Use a 0.1 s period for angular
+    # motion (plunging wing motion).
     periodic_geometry_core_wing_movement_fixture = CoreWingMovement(
         base_wing=base_wing,
         wing_cross_section_movements=wcs_movements,

--- a/tests/unit/fixtures/movement_fixtures.py
+++ b/tests/unit/fixtures/movement_fixtures.py
@@ -63,8 +63,8 @@ def make_basic_aeroelastic_movement_fixture():
         base_wing_cross_section=airplane.wings[0].wing_cross_sections[1],
     )
 
-    # Create a wing movement with sinusoidal flapping (non-zero period required
-    # by _generate_inertial_moment_function when spacing is "sine").
+    # Create a WingMovement with sinusoidal flapping (non-zero period required by
+    # _generate_inertial_moment_function when spacing is "sine").
     wing_movement = ps.movements.aeroelastic_wing_movement.AeroelasticWingMovement(
         base_wing=airplane.wings[0],
         wing_cross_section_movements=[root_wcs_movement, tip_wcs_movement],

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -246,9 +246,9 @@ def make_basic_free_flight_unsteady_problem_fixture(
 
     # Create the FreeFlightOperatingPointMovement. Free flight requires the Airplane's
     # weight, the mass, and the gravitational field to agree (weight == mass * |g_E|).
-    # The shared operating-point fixtures default to no gravity, so rebuild the operating
-    # point with standard gravity here (preserving every other field) and derive the
-    # matching mass from the Airplane's weight.
+    # The shared OperatingPoint fixtures default to no gravity, so rebuild the
+    # OperatingPoint with standard gravity here (preserving every other field) and
+    # derive the matching mass from the Airplane's weight.
     if base_operating_point is None:
         base_operating_point = (
             operating_point_fixtures.make_basic_operating_point_fixture()

--- a/tests/unit/fixtures/wing_cross_section_movement_fixtures.py
+++ b/tests/unit/fixtures/wing_cross_section_movement_fixtures.py
@@ -72,8 +72,8 @@ def make_basic_wing_cross_section_movement_fixture():
     :return basic_wing_cross_section_movement_fixture: WingCrossSectionMovement
         This is the WingCrossSectionMovement with general-purpose values.
     """
-    # Initialize the constructing fixture.
-    # Use tip fixture to ensure Lp values stay non-negative during oscillation.
+    # Initialize the constructing fixture. Use the tip fixture to ensure Lp values stay
+    # non-negative during oscillation.
     base_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
 
     # Create the basic WingCrossSectionMovement.

--- a/tests/unit/test_aerodynamics_functions.py
+++ b/tests/unit/test_aerodynamics_functions.py
@@ -911,8 +911,8 @@ class TestSingularityGuards(unittest.TestCase):
         )
 
         # Simple (non degenerate) ring vortex fixture for vertex proximity and
-        # collinearity tests. Corners: Br=(1,0.5,0), Fr=(0,0.5,0),
-        # Fl=(0,-0.5,0), Bl=(1,-0.5,0).
+        # collinearity tests. Corners: Br = (1.0, 0.5, 0.0), Fr = (0.0, 0.5, 0.0), Fl =
+        # (0.0, -0.5, 0.0), Bl = (1.0, -0.5, 0.0).
         (
             self.ring_Brrvp,
             self.ring_Frrvp,
@@ -921,9 +921,9 @@ class TestSingularityGuards(unittest.TestCase):
             self.ring_strengths,
         ) = aerodynamics_functions_fixtures.make_simple_ring_vortex_arrays_fixture()
 
-        # Simple (non degenerate) horseshoe vortex fixture for vertex proximity
-        # and collinearity tests. Corners: Br = (20.0, 0.5, 0.0), Fr = (0.0, 0.5, 0.0),
-        # Fl = (0.0, -0.5, 0.0), Bl = (20.0, -0.5, 0.0).
+        # Simple (non degenerate) horseshoe vortex fixture for vertex proximity and
+        # collinearity tests. Corners: Br = (20.0, 0.5, 0.0), Fr = (0.0, 0.5, 0.0), Fl =
+        # (0.0, -0.5, 0.0), Bl = (20.0, -0.5, 0.0).
         (
             self.horseshoe_Brhvp,
             self.horseshoe_Frhvp,

--- a/tests/unit/test_aerodynamics_functions.py
+++ b/tests/unit/test_aerodynamics_functions.py
@@ -675,8 +675,8 @@ class TestAerodynamicsFunctions(unittest.TestCase):
         v1_A__I = self.ref_calculate_biot_savart_velocity(S1_A_a, E1_A_a, P_A_a, gamma)
         v2_A__I = self.ref_calculate_biot_savart_velocity(S2_A_a, E2_A_a, P_A_a, gamma)
 
-        # The total velocity (in A axes, observed from an inertial frame) should have
-        # a zero y-component (due to symmetry) and should have a non-zero magnitude.
+        # The total velocity (in A axes, observed from an inertial frame) should have a
+        # zero y component (due to symmetry) and should have a non-zero magnitude.
         v_A__I = v1_A__I + v2_A__I
         self.assertAlmostEqual(v_A__I[1], 0.0, places=10)
         self.assertGreater(np.linalg.norm(v_A__I), 0.0)
@@ -922,8 +922,8 @@ class TestSingularityGuards(unittest.TestCase):
         ) = aerodynamics_functions_fixtures.make_simple_ring_vortex_arrays_fixture()
 
         # Simple (non degenerate) horseshoe vortex fixture for vertex proximity
-        # and collinearity tests. Corners: Br=(20,0.5,0), Fr=(0,0.5,0),
-        # Fl=(0,-0.5,0), Bl=(20,-0.5,0).
+        # and collinearity tests. Corners: Br = (20.0, 0.5, 0.0), Fr = (0.0, 0.5, 0.0),
+        # Fl = (0.0, -0.5, 0.0), Bl = (20.0, -0.5, 0.0).
         (
             self.horseshoe_Brhvp,
             self.horseshoe_Frhvp,
@@ -934,7 +934,7 @@ class TestSingularityGuards(unittest.TestCase):
             aerodynamics_functions_fixtures.make_simple_horseshoe_vortex_arrays_fixture()
         )
 
-        # Zero initial core radii for coreless comparison with the reference
+        # The initial core radii are zero for coreless comparison with the reference
         # Biot-Savart implementation.
         self.zero_rc0s = np.zeros(1, dtype=float)
 
@@ -1055,8 +1055,8 @@ class TestSingularityGuards(unittest.TestCase):
             singularity_counts=np.zeros(4, dtype=np.int64),
         )
 
-        # Compute expected velocity from the two non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the two non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_left = ref(self.ring_Flrvp[0], self.ring_Blrvp[0], P, gamma)
@@ -1091,8 +1091,8 @@ class TestSingularityGuards(unittest.TestCase):
             singularity_counts=np.zeros(4, dtype=np.int64),
         )
 
-        # Compute expected velocity from the two non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the two non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_left = ref(self.ring_Flrvp[0], self.ring_Blrvp[0], P, gamma)
@@ -1131,8 +1131,8 @@ class TestSingularityGuards(unittest.TestCase):
             )
         )
 
-        # Compute expected velocity from the one non singular leg using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the one non singular leg using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         expected = ref(self.horseshoe_Flhvp[0], self.horseshoe_Blhvp[0], P, gamma)
@@ -1169,8 +1169,8 @@ class TestSingularityGuards(unittest.TestCase):
             singularity_counts=np.zeros(4, dtype=np.int64),
         )
 
-        # Compute expected velocity from the three non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the three non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_front = ref(self.ring_Frrvp[0], self.ring_Flrvp[0], P, gamma)
@@ -1208,8 +1208,8 @@ class TestSingularityGuards(unittest.TestCase):
             singularity_counts=np.zeros(4, dtype=np.int64),
         )
 
-        # Compute expected velocity from the three non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the three non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_front = ref(self.ring_Frrvp[0], self.ring_Flrvp[0], P, gamma)
@@ -1248,8 +1248,8 @@ class TestSingularityGuards(unittest.TestCase):
             singularity_counts=np.zeros(4, dtype=np.int64),
         )
 
-        # Compute expected velocity from the three non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the three non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_front = ref(self.ring_Frrvp[0], self.ring_Flrvp[0], P, gamma)
@@ -1290,8 +1290,8 @@ class TestSingularityGuards(unittest.TestCase):
             )
         )
 
-        # Compute expected velocity from the two non singular legs using the
-        # reference Biot-Savart implementation.
+        # Compute expected velocity from the two non singular legs using the reference
+        # Biot-Savart implementation.
         ref = TestAerodynamicsFunctions.ref_calculate_biot_savart_velocity
         P = point[0]
         v_right = ref(self.horseshoe_Brhvp[0], self.horseshoe_Frhvp[0], P, gamma)
@@ -1317,8 +1317,7 @@ class TestCoreRadiusFormula(unittest.TestCase):
             self.ring_strengths,
         ) = aerodynamics_functions_fixtures.make_simple_ring_vortex_arrays_fixture()
 
-        # Evaluation point above the ring vortex center, away from any
-        # singularity.
+        # Evaluation point above the ring vortex center, away from any singularity.
         self.center_point = np.array([[0.5, 0.0, 1.0]], dtype=float)
 
     @staticmethod
@@ -1501,8 +1500,8 @@ class TestCoreRadiusFormula(unittest.TestCase):
         # Call the kernel.
         velocities = self._call_collapsed_ring(rc0s)
 
-        # Compute expected velocity from all four legs using the regularized
-        # reference implementation.
+        # Compute expected velocity from all four legs using the regularized reference
+        # implementation.
         expected = self._compute_reference_ring_velocity(r_c)
 
         # Verify the kernel result matches the reference.
@@ -1522,8 +1521,8 @@ class TestCoreRadiusFormula(unittest.TestCase):
         rc0s = np.array([r_c0], dtype=float)
         ages = np.array([age], dtype=float)
 
-        # Manually compute r_c using the Ramasamy-Leishman formula with the
-        # module's physical constants.
+        # Manually compute r_c using the Ramasamy-Leishman formula with the module's
+        # physical constants.
         lamb = _aerodynamics_functions._lamb
         squire = _aerodynamics_functions._squire
         r_c = np.sqrt(r_c0**2 + 4.0 * lamb * (nu + squire * abs(gamma)) * age)
@@ -1531,8 +1530,8 @@ class TestCoreRadiusFormula(unittest.TestCase):
         # Call the kernel.
         velocities = self._call_collapsed_ring(rc0s, ages=ages, nu=nu)
 
-        # Compute expected velocity from all four legs using the regularized
-        # reference implementation.
+        # Compute expected velocity from all four legs using the regularized reference
+        # implementation.
         expected = self._compute_reference_ring_velocity(r_c)
 
         # Verify the kernel result matches the reference.
@@ -1617,9 +1616,9 @@ class TestSingularityCounters(unittest.TestCase):
             singularity_counts=singularity_counts,
         )
 
-        # The right leg (Br to Fr) hits the r2/r0 guard (counter 2) because
-        # the evaluation point is at Fr. The front leg (Fr to Fl) hits the
-        # r1/r0 guard (counter 1) because the evaluation point is at Fr.
+        # The right leg (Br to Fr) hits the r2 / r0 guard (counter 2) because the
+        # evaluation point is at Fr. The front leg (Fr to Fl) hits the r1 / r0 guard
+        # (counter 1) because the evaluation point is at Fr.
         self.assertGreater(singularity_counts[1], 0)
         self.assertGreater(singularity_counts[2], 0)
 
@@ -1664,8 +1663,8 @@ class TestSingularityCounters(unittest.TestCase):
             singularity_counts=singularity_counts,
         )
 
-        # The point is collinear with the right leg (Br to Fr) but lies off the
-        # filament (c_3 > 0), so the counter is not incremented.
+        # The point is collinear with the right leg (Br to Fr) but lies off the filament
+        # (c_3 > 0), so the counter is not incremented.
         self.assertEqual(singularity_counts[3], 0)
 
     def test_non_singular_configuration_has_zero_counts(self):
@@ -1951,8 +1950,8 @@ class TestReportThreadSettings(unittest.TestCase):
             with self.assertWarns(UserWarning) as caught:
                 _aerodynamics_functions.report_thread_settings()
 
-        # The warning has to name the layer and both of its remedies to be worth
-        # raising at all.
+        # The warning has to name the layer and both of its remedies to be worth raising
+        # at all.
         message = str(caught.warning)
         self.assertIn("workqueue", message)
         self.assertIn("tbb", message)
@@ -2305,9 +2304,9 @@ class TestParallelDispatchWrappers(unittest.TestCase):
         # three quarters of the pool width, rounded down, never below 1.
         ceiling = max((3 * numba.config.NUMBA_NUM_THREADS) // 4, 1)
 
-        # With one ring vortex, this stack of points makes each leg's launch span
-        # one more grain than the ceiling, so the work-proportional count exceeds
-        # the ceiling.
+        # With one ring vortex, this stack of points makes each leg's launch span one
+        # more grain than the ceiling, so the work-proportional count exceeds the
+        # ceiling.
         stackP_GP1_CgP1 = aerodynamics_functions_fixtures.make_origin_points_fixture(
             (ceiling + 1) * _aerodynamics_functions._GRAIN
         )
@@ -2332,9 +2331,9 @@ class TestParallelDispatchWrappers(unittest.TestCase):
         below_ceiling_mask = _aerodynamics_functions._ceiling() - 1
         numba.set_num_threads(below_ceiling_mask)
 
-        # With one ring vortex, this stack of points makes each leg's launch span
-        # one more grain than the ceiling, so only the mask holds its thread count
-        # below the ceiling.
+        # With one ring vortex, this stack of points makes each leg's launch span one
+        # more grain than the ceiling, so only the mask holds its thread count below the
+        # ceiling.
         stackP_GP1_CgP1 = aerodynamics_functions_fixtures.make_origin_points_fixture(
             (_aerodynamics_functions._ceiling() + 1) * _aerodynamics_functions._GRAIN
         )
@@ -2352,9 +2351,9 @@ class TestParallelDispatchWrappers(unittest.TestCase):
         # Simulate a user capping the thread count exactly at the ceiling.
         numba.set_num_threads(_aerodynamics_functions._ceiling())
 
-        # With one ring vortex, this stack of points makes each leg's launch span
-        # one more grain than the ceiling, so the work-proportional count exceeds
-        # the ceiling.
+        # With one ring vortex, this stack of points makes each leg's launch span one
+        # more grain than the ceiling, so the work-proportional count exceeds the
+        # ceiling.
         stackP_GP1_CgP1 = aerodynamics_functions_fixtures.make_origin_points_fixture(
             (_aerodynamics_functions._ceiling() + 1) * _aerodynamics_functions._GRAIN
         )
@@ -2375,9 +2374,9 @@ class TestParallelDispatchWrappers(unittest.TestCase):
         # default, so the dispatch throttles both the same way.
         numba.set_num_threads(numba.config.NUMBA_NUM_THREADS)
 
-        # With one ring vortex, this stack of points makes each leg's launch span
-        # one more grain than the ceiling, so the work-proportional count exceeds
-        # the ceiling.
+        # With one ring vortex, this stack of points makes each leg's launch span one
+        # more grain than the ceiling, so the work-proportional count exceeds the
+        # ceiling.
         stackP_GP1_CgP1 = aerodynamics_functions_fixtures.make_origin_points_fixture(
             (_aerodynamics_functions._ceiling() + 1) * _aerodynamics_functions._GRAIN
         )

--- a/tests/unit/test_aeroelastic_airplane_movement.py
+++ b/tests/unit/test_aeroelastic_airplane_movement.py
@@ -381,8 +381,8 @@ class TestAeroelasticAirplaneMovementMixedWings(unittest.TestCase):
                 atol=1e-14,
             )
 
-        # The standard Wing (index 1) is advanced without deformation, so it matches
-        # its static base.
+        # The standard Wing (index 1) is advanced without deformation, so it matches its
+        # static base.
         base_standard_wing_cross_sections = base_airplane.wings[1].wing_cross_sections
         standard_wing_cross_sections = airplane.wings[1].wing_cross_sections
         for index in range(len(base_standard_wing_cross_sections)):

--- a/tests/unit/test_aeroelastic_movement.py
+++ b/tests/unit/test_aeroelastic_movement.py
@@ -64,8 +64,8 @@ class TestAeroelasticMovement(unittest.TestCase):
         """Test that AeroelasticMovement rejects a CoreOperatingPointMovement that is
         not an OperatingPointMovement.
         """
-        # A FreeFlightOperatingPointMovement is a CoreOperatingPointMovement but not
-        # an OperatingPointMovement, so it must be rejected.
+        # A FreeFlightOperatingPointMovement is a CoreOperatingPointMovement but not an
+        # OperatingPointMovement, so it must be rejected.
         airplane_movements = [
             aeroelastic_airplane_movement_fixtures.make_static_aeroelastic_airplane_movement_fixture()
         ]

--- a/tests/unit/test_aeroelastic_unsteady_problem.py
+++ b/tests/unit/test_aeroelastic_unsteady_problem.py
@@ -116,11 +116,11 @@ class TestAeroelasticUnsteadyProblem(unittest.TestCase):
             aeroelastic_wing_movement_fixtures.make_static_aeroelastic_wing_movement_fixture()
         )
 
-        # Choose the per-entry mass so the strip's torsional inertia, I = (1 / 2) *
-        # mass * L^2 with mass summed over the strip's mass-matrix entries, is exactly
-        # 1.0. With spring_constant_rad = 10.0 and damping_constant_rad = 20.0, the ODE
-        # is then overdamped (c^2 > 4 * k * I) with a slowest decay rate of about 0.5
-        # per second, so it is far from settled within one 0.1 s time step.
+        # Choose the per-entry mass so the strip's torsional inertia, I = (1 / 2) * mass
+        # * L^2 with mass summed over the strip's mass-matrix entries, is exactly 1.0.
+        # With spring_constant_rad = 10.0 and damping_constant_rad = 20.0, the ODE is
+        # then overdamped (c^2 > 4 * k * I) with a slowest decay rate of about 0.5 per
+        # second, so it is far from settled within one 0.1 s time step.
         L = (wing.wing_cross_sections[0].chord + wing.wing_cross_sections[1].chord) / 2
         num_mass_entries = num_chordwise_panels * num_spanwise_panels * 3
         mass_matrix = np.full(
@@ -129,9 +129,9 @@ class TestAeroelasticUnsteadyProblem(unittest.TestCase):
         )
 
         # Apply a constant aerodynamic moment y component (in the first Airplane's
-        # geometry axes, relative to the strip's leading edge point), summing to 2.0
-        # N*m over the strip's chordwise panels, so the static deformation angle y
-        # component is M / k = 0.2 rad.
+        # geometry axes, relative to the strip's leading edge point), summing to 2.0 N*m
+        # over the strip's chordwise panels, so the static deformation angle y component
+        # is M / k = 0.2 rad.
         aeroMoments_GP1_Slep = np.zeros(
             (num_chordwise_panels, num_spanwise_panels, 3), dtype=float
         )
@@ -563,8 +563,8 @@ class TestRecordNullStepForWing(unittest.TestCase):
         self.problem_std._calculate_wing_deformation(solver=mock_solver, step=0)
 
         problem = self.problem_std
-        # The two structural state time series are seeded with an initial-state entry
-        # at construction, so one recorded step brings them to two entries.
+        # The two structural state time series are seeded with an initial-state entry at
+        # construction, so one recorded step brings them to two entries.
         self.assertEqual(
             len(problem.listDeformationAnglesYRad_Wcsp_to_Wcs_ixyz[wing_idx]), 2
         )

--- a/tests/unit/test_aeroelastic_wing_movement.py
+++ b/tests/unit/test_aeroelastic_wing_movement.py
@@ -310,8 +310,8 @@ class TestAeroelasticWingMovementRotationPointOffset(unittest.TestCase):
             aeroelastic_wing_movement_fixtures.make_rotation_offset_aeroelastic_wing_movement_fixture()
         )
 
-        # At step 1 the sine spaced angular motion is non zero, so the offset
-        # adjustment shifts Ler_Gs_Cgs.
+        # At step 1 the sine spaced angular motion is non zero, so the offset adjustment
+        # shifts Ler_Gs_Cgs.
         basic_wing = basic_wing_movement.generate_wing_at_time_step(
             step=1, delta_time=0.1
         )

--- a/tests/unit/test_airfoil.py
+++ b/tests/unit/test_airfoil.py
@@ -236,8 +236,8 @@ class TestAirfoil(unittest.TestCase):
         """Test that invalid parameters raise appropriate errors."""
         # Test outlines with insufficient points in upper portion. These outlines have
         # only 4 points total, and the point ordering places only 1 point in the upper
-        # portion (the leading point itself), which fails the requirement for at least
-        # 3 unique points in each portion.
+        # portion (the leading point itself), which fails the requirement for at least 3
+        # unique points in each portion.
         invalid_outline = np.array([[-0.1, 0.0], [0.5, 0.1], [1.0, 0.0], [0.5, -0.1]])
         with self.assertRaises(ValueError):
             ps.geometry.airfoil.Airfoil(
@@ -267,9 +267,9 @@ class TestAirfoil(unittest.TestCase):
         airfoil_30_percent = ps.geometry.airfoil.Airfoil(name="NACA0030")
         self.assertIsNotNone(airfoil_30_percent.outline_A_lp)
 
-        # Test that airfoils with inconsistent camber parameters (first two digits must
-        # both be zero or both be non zero) raise a ValueError.
-        # Case 1: Camber without camber location (e.g., NACA1012, NACA9012).
+        # Test that Airfoils with inconsistent camber parameters (first two digits must
+        # both be zero or both be non zero) raise a ValueError. Case 1: camber without
+        # camber location (e.g., NACA1012, NACA9012).
         with self.assertRaises(ValueError):
             ps.geometry.airfoil.Airfoil(name="NACA1012")
 
@@ -291,26 +291,27 @@ class TestAirfoil(unittest.TestCase):
         airfoil_cambered = ps.geometry.airfoil.Airfoil(name="NACA2412")
         self.assertIsNotNone(airfoil_cambered.outline_A_lp)
 
-        # Test that airfoils with position of maximum camber too close to the leading
+        # Test that Airfoils with position of maximum camber too close to the leading
         # edge relative to camber and thickness raise a ValueError. The constraint is:
-        # camber_loc >= max_camber + thickness / 2.
-        # NACA9130: camber_loc=0.1, max_camber=0.09, thickness=0.30
-        # 0.1 < 0.09 + 0.15 = 0.24, so this should fail.
+        # camber_loc >= max_camber + thickness / 2.0. NACA9130: camber_loc = 0.1,
+        # max_camber = 0.09, thickness = 0.3. Since 0.1 < 0.09 + 0.15 = 0.24, this
+        # should fail.
+        # octowrap: on
         with self.assertRaises(ValueError):
             ps.geometry.airfoil.Airfoil(name="NACA9130")
 
-        # NACA5115: camber_loc=0.1, max_camber=0.05, thickness=0.15
-        # 0.1 < 0.05 + 0.075 = 0.125, so this should fail.
+        # NACA5115: camber_loc = 0.1, max_camber = 0.05, thickness = 0.15 0.1 < 0.05 +
+        # 0.075 = 0.125, so this should fail.
         with self.assertRaises(ValueError):
             ps.geometry.airfoil.Airfoil(name="NACA5115")
 
-        # NACA4212: camber_loc=0.2, max_camber=0.04, thickness=0.12
-        # 0.2 >= 0.04 + 0.06 = 0.10, so this should pass.
+        # NACA4212: camber_loc = 0.2, max_camber = 0.04, thickness = 0.12 0.2 >= 0.04 +
+        # 0.06 = 0.10, so this should pass.
         airfoil_valid_camber_pos = ps.geometry.airfoil.Airfoil(name="NACA4212")
         self.assertIsNotNone(airfoil_valid_camber_pos.outline_A_lp)
 
-        # NACA2110: camber_loc=0.1, max_camber=0.02, thickness=0.10
-        # 0.1 >= 0.02 + 0.05 = 0.07, so this should pass.
+        # NACA2110: camber_loc = 0.1, max_camber = 0.02, thickness = 0.10 0.1 >= 0.02 +
+        # 0.05 = 0.07, so this should pass.
         airfoil_boundary_camber_pos = ps.geometry.airfoil.Airfoil(name="NACA2110")
         self.assertIsNotNone(airfoil_boundary_camber_pos.outline_A_lp)
 
@@ -321,8 +322,8 @@ class TestAirfoil(unittest.TestCase):
             outline_A_lp = airfoil.outline_A_lp
             outlineY_A_lp = outline_A_lp[:, 1]
 
-            # Find upper and lower surfaces roughly
-            # For properly ordered airfoils, we expect some variation in y
+            # Find upper and lower surfaces roughly. For properly ordered airfoils, we
+            # expect some variation in y.
             max_thickness = np.max(outlineY_A_lp) - np.min(outlineY_A_lp)
             self.assertAlmostEqual(max_thickness, 0.12, places=2)
 
@@ -464,8 +465,8 @@ class TestAirfoil(unittest.TestCase):
 
     def test_self_intersection_rejection(self):
         """Test that self-intersecting outlines are rejected."""
-        # Create an outline where upper surface crosses below lower surface
-        # This is a "twisted" airfoil that would self-intersect
+        # Create an outline where upper surface crosses below lower surface. This is a
+        # "twisted" airfoil that would self-intersect.
         self_intersecting_outline = np.array(
             [
                 [1.00, 0.00],
@@ -593,7 +594,8 @@ class TestAirfoil(unittest.TestCase):
                 outline_A_lp=too_few_points,
                 resample=False,
             )
-        # Should fail for either "at least five points" or "at least three unique points"
+        # Should fail for either "at least five points" or "at least three unique
+        # points."
         error_msg = str(context.exception).lower()
         self.assertTrue(
             "five" in error_msg or "three" in error_msg or "unique" in error_msg
@@ -620,7 +622,8 @@ class TestAirfoil(unittest.TestCase):
                     if (max_camber > 0) != (camber_loc > 0):
                         continue
 
-                    # Constraint: For cambered airfoils, camber_loc >= max_camber + thickness/2
+                    # Constraint: for cambered Airfoils, camber_loc >= max_camber +
+                    # thickness / 2.0.
                     if max_camber > 0:
                         thickness_fraction = thickness * 0.01
                         if camber_loc < max_camber + thickness_fraction / 2:

--- a/tests/unit/test_airplane.py
+++ b/tests/unit/test_airplane.py
@@ -52,8 +52,8 @@ class TestAirplane(unittest.TestCase):
 
     def test_name_parameter_validation(self):
         """Test name parameter validation."""
-        # Test valid string name
-        # Create fresh fixture since Wings can only be processed once
+        # Test a valid string name. Create a fresh fixture since Wings can only be
+        # processed once.
         test_wing = geometry_fixtures.make_type_1_wing_fixture()
         airplane = ps.geometry.airplane.Airplane(
             wings=[test_wing], name="Valid Test Name"
@@ -134,8 +134,8 @@ class TestAirplane(unittest.TestCase):
                         wings=[test_wing], weight=invalid_weight
                     )
 
-        # Test invalid weight types
-        # Create fresh fixture since Wings can only be processed once
+        # Test invalid weight types. Create fresh fixture since Wings can only be
+        # processed once.
         test_wing = geometry_fixtures.make_type_1_wing_fixture()
         with self.assertRaises(TypeError):
             # noinspection PyTypeChecker
@@ -159,8 +159,8 @@ class TestAirplane(unittest.TestCase):
         self.assertEqual(self.custom_reference_airplane.c_ref, 2.0)
         self.assertEqual(self.custom_reference_airplane.b_ref, 10.0)
 
-        # Test validation of reference dimensions
-        # Create fresh fixtures since Wings can only be processed once
+        # Test validation of reference dimensions. Create fresh fixtures since Wings can
+        # only be processed once.
         test_wing = geometry_fixtures.make_type_1_wing_fixture()
         with self.assertRaises(ValueError):
             ps.geometry.airplane.Airplane(wings=[test_wing], s_ref=-1.0)
@@ -347,11 +347,12 @@ class TestAirplane(unittest.TestCase):
 
     def test_process_wing_symmetry_control_surface_validation_types_1_2_3(self):
         """Test control surface validation for symmetry types 1, 2, 3."""
-        # Type 1: should fail with control surfaces
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Type 1: should fail with control surfaces. Create fresh fixtures since
+        # WingCrossSections can only be validated once.
         wing_cross_sections = [
             geometry_fixtures.make_root_wing_cross_section_fixture(),
-            geometry_fixtures.make_basic_wing_cross_section_fixture(),  # Has control surface
+            # This fixture has a control surface.
+            geometry_fixtures.make_basic_wing_cross_section_fixture(),
         ]
         with self.assertRaises(ValueError):
             wing_type_1 = ps.geometry.wing.Wing(
@@ -361,11 +362,12 @@ class TestAirplane(unittest.TestCase):
             )
             ps.geometry.airplane.Airplane.process_wing_symmetry(wing_type_1)
 
-        # Type 2: should fail with control surfaces
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Type 2: should fail with control surfaces. Create fresh fixtures since
+        # WingCrossSections can only be validated once.
         wing_cross_sections = [
             geometry_fixtures.make_root_wing_cross_section_fixture(),
-            geometry_fixtures.make_basic_wing_cross_section_fixture(),  # Has control surface
+            # This fixture has a control surface.
+            geometry_fixtures.make_basic_wing_cross_section_fixture(),
         ]
         with self.assertRaises(ValueError):
             wing_type_2 = ps.geometry.wing.Wing(
@@ -382,7 +384,8 @@ class TestAirplane(unittest.TestCase):
         # Create Wings without control surface configurations
         wing_cross_sections = [
             geometry_fixtures.make_root_wing_cross_section_fixture(),
-            geometry_fixtures.make_minimal_wing_cross_section_fixture(),  # No control surface
+            # This fixture has no control surface.
+            geometry_fixtures.make_minimal_wing_cross_section_fixture(),
         ]
 
         # Type 4: should fail without control surfaces
@@ -398,8 +401,8 @@ class TestAirplane(unittest.TestCase):
 
     def test_process_wing_symmetry_type_5_control_surface_deflections(self):
         """Test type 5 Wing processing with different control surface deflections."""
-        # Create asymmetric control surface Wing cross sections
-        # Use root fixture with asymmetric control surface already configured
+        # Create the asymmetric control surface WingCrossSections. Use the root fixture
+        # with an asymmetric control surface already configured.
         root_wcs = (
             geometry_fixtures.make_root_asymmetric_control_surface_wing_cross_section_fixture()
         )
@@ -423,7 +426,8 @@ class TestAirplane(unittest.TestCase):
         # Should return two Wings
         self.assertEqual(len(result), 2)
 
-        # Check that asymmetric control surface deflections are negated in reflected Wing
+        # Check that asymmetric control surface deflections are negated in the reflected
+        # Wing.
         original_wing = result[0]
         reflected_wing = result[1]
 

--- a/tests/unit/test_convergence_cache.py
+++ b/tests/unit/test_convergence_cache.py
@@ -261,7 +261,8 @@ class TestMemoTranslation(unittest.TestCase):
         ar_list = [4, 3, 2, 1]
         chord_list = [3, 4]
 
-        # The sweep index (1, 0) resolves to Panel aspect ratio 3 and 3 chordwise Panels.
+        # The sweep index (1, 0) resolves to Panel aspect ratio 3 and 3 chordwise
+        # Panels.
         num_spanwise_panels_cache = {(1, 0, 0, 0, 0): 5}
         num_wing_cross_sections_cache = {(1, 0, 0, 0): 7}
         delta_time_cache = {(1, 0): 0.0125}

--- a/tests/unit/test_convergence_meshing.py
+++ b/tests/unit/test_convergence_meshing.py
@@ -71,8 +71,8 @@ class TestGetWingSectionNumSpanwisePanels(unittest.TestCase):
         upper_difference = abs(self._average_panel_aspect_ratio(result + 1) - target)
         self.assertLessEqual(chosen_difference, upper_difference)
 
-        # The smallest valid number of spanwise Panels is one, so the lower neighbor only
-        # exists above that.
+        # The smallest valid number of spanwise Panels is one, so the lower neighbor
+        # only exists above that.
         if result > 1:
             lower_difference = abs(
                 self._average_panel_aspect_ratio(result - 1) - target
@@ -169,8 +169,8 @@ class TestGetNumWingCrossSectionsForPanelAr(unittest.TestCase):
         upper_difference = abs(self._average_panel_aspect_ratio(result + 1) - target)
         self.assertLessEqual(chosen_difference, upper_difference)
 
-        # An edge-defined Wing needs at least two WingCrossSections, so the lower neighbor
-        # only exists above that.
+        # An edge-defined Wing needs at least two WingCrossSections, so the lower
+        # neighbor only exists above that.
         if result > 2:
             lower_difference = abs(
                 self._average_panel_aspect_ratio(result - 1) - target

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -98,8 +98,7 @@ class TestLcmFunctions(unittest.TestCase):
 
     def test_lcm_multiple_non_integer_periods(self):
         """Test _lcm_multiple returns correct LCM for non integer periods."""
-        # LCM(1.5, 2.0, 2.5) = 30.0.
-        # 30.0/1.5=20, 30.0/2.0=15, 30.0/2.5=12.
+        # LCM(1.5, 2.0, 2.5) = 30.0. 30.0/1.5=20, 30.0/2.0=15, 30.0/2.5=12.
         result = ps._core.lcm_multiple([1.5, 2.0, 2.5])
         self.assertAlmostEqual(result, 30.0, places=6)
 

--- a/tests/unit/test_core_airplane_movement.py
+++ b/tests/unit/test_core_airplane_movement.py
@@ -61,8 +61,8 @@ class TestCoreAirplaneMovement(unittest.TestCase):
             delta_time=delta_time,
         )
 
-        # Extract positions (in Earth axes, relative to the simulation starting
-        # point) from generated Airplanes.
+        # Extract positions (in Earth axes, relative to the simulation starting point)
+        # from generated Airplanes.
         x_positions = np.array([airplane.Cg_GP1_CgP1[0] for airplane in airplanes])
 
         # Calculate expected sine wave values.
@@ -82,8 +82,8 @@ class TestCoreAirplaneMovement(unittest.TestCase):
             delta_time=delta_time,
         )
 
-        # Extract positions (in Earth axes, relative to the simulation starting
-        # point) from generated Airplanes.
+        # Extract positions (in Earth axes, relative to the simulation starting point)
+        # from generated Airplanes.
         x_positions = np.array([airplane.Cg_GP1_CgP1[0] for airplane in airplanes])
 
         # Calculate expected triangular wave values.
@@ -102,8 +102,8 @@ class TestCoreAirplaneMovement(unittest.TestCase):
             delta_time=delta_time,
         )
 
-        # Extract positions (in Earth axes, relative to the simulation starting
-        # point) from generated Airplanes.
+        # Extract positions (in Earth axes, relative to the simulation starting point)
+        # from generated Airplanes.
         x_positions = np.array([airplane.Cg_GP1_CgP1[0] for airplane in airplanes])
         y_positions = np.array([airplane.Cg_GP1_CgP1[1] for airplane in airplanes])
         z_positions = np.array([airplane.Cg_GP1_CgP1[2] for airplane in airplanes])
@@ -415,9 +415,9 @@ class TestCoreAirplaneMovement(unittest.TestCase):
 
         airplanes = airplane_movement.generate_airplanes(num_steps=10, delta_time=0.01)
 
-        # Check that non-changing attributes are preserved. Note: s_ref, c_ref,
-        # and b_ref are NOT included because they are calculated from the Wings,
-        # which change due to WingMovement or WingCrossSectionMovement.
+        # Check that non-changing attributes are preserved. Note: s_ref, c_ref, and
+        # b_ref are not included because they are calculated from the Wings, which
+        # change due to WingMovement or WingCrossSectionMovement.
         for airplane in airplanes:
             self.assertEqual(airplane.name, base_airplane.name)
             self.assertEqual(airplane.weight, base_airplane.weight)
@@ -438,14 +438,13 @@ class TestCoreAirplaneMovement(unittest.TestCase):
         airplane_movement = self.phase_offset_Cg_airplane_movement
         airplanes = airplane_movement.generate_airplanes(num_steps=100, delta_time=0.01)
 
-        # Extract positions (in Earth axes, relative to the simulation starting
-        # point).
+        # Extract positions (in Earth axes, relative to the simulation starting point).
         x_positions = np.array([airplane.Cg_GP1_CgP1[0] for airplane in airplanes])
         y_positions = np.array([airplane.Cg_GP1_CgP1[1] for airplane in airplanes])
         z_positions = np.array([airplane.Cg_GP1_CgP1[2] for airplane in airplanes])
 
-        # Verify that phase offset causes non-zero initial values.
-        # With phase offsets, the first values should not all be at the base position.
+        # Verify that phase offset causes non-zero initial values. With phase offsets,
+        # the first values should not all be at the base position.
         self.assertFalse(np.allclose(x_positions[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(y_positions[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(z_positions[0], 0.0, atol=1e-10))
@@ -455,8 +454,7 @@ class TestCoreAirplaneMovement(unittest.TestCase):
         airplane_movement = self.sine_spacing_Cg_airplane_movement
         airplanes = airplane_movement.generate_airplanes(num_steps=50, delta_time=0.01)
 
-        # Extract positions (in Earth axes, relative to the simulation starting
-        # point).
+        # Extract positions (in Earth axes, relative to the simulation starting point).
         x_positions = np.array([airplane.Cg_GP1_CgP1[0] for airplane in airplanes])
         y_positions = np.array([airplane.Cg_GP1_CgP1[1] for airplane in airplanes])
         z_positions = np.array([airplane.Cg_GP1_CgP1[2] for airplane in airplanes])
@@ -478,8 +476,8 @@ class TestCoreAirplaneMovement(unittest.TestCase):
         # Verify that values vary (not constant).
         self.assertFalse(np.allclose(x_positions, x_positions[0]))
 
-        # Verify that values are within expected range.
-        # For custom_harmonic with amp=0.08, values should be in [-0.08, 0.08].
+        # Verify that values are within expected range. For custom_harmonic with
+        # amp=0.08, values should be in [-0.08, 0.08].
         self.assertTrue(np.all(x_positions >= -0.09))
         self.assertTrue(np.all(x_positions <= 0.09))
 
@@ -585,8 +583,8 @@ class TestCoreAirplaneMovementVariableGeometryOptimization(unittest.TestCase):
         """Test that variable geometry optimization applies for periodic motion."""
         airplane_movement = self.periodic_geometry_airplane_movement
 
-        # Use delta_time = 0.01 and period = 0.1, so steps_per_period = 10.
-        # With 30 steps, we get 3 periods, so optimization should apply.
+        # Use delta_time = 0.01 and period = 0.1, so steps_per_period = 10. With 30
+        # steps, we get 3 periods, so optimization should apply.
         num_steps = 30
         delta_time = 0.01
 
@@ -614,8 +612,8 @@ class TestCoreAirplaneMovementVariableGeometryOptimization(unittest.TestCase):
             num_steps=num_steps, delta_time=delta_time
         )
 
-        # Check that geometry repeats at period boundaries.
-        # Compare step 0 to step 10 to step 20.
+        # Check that geometry repeats at period boundaries. Compare step 0 to step 10 to
+        # step 20.
         for period_num in range(1, 3):
             base_step = 0
             compare_step = period_num * steps_per_period
@@ -1052,9 +1050,8 @@ class TestCoreAirplaneMovementAllPeriods(unittest.TestCase):
     def test_all_periods_Cg_only_movement(self):
         """Test that all_periods includes Cg periods."""
         airplane_movement = self.Cg_airplane_movement
-        # periodCg_GP1_CgP1 is (1.5, 1.5, 1.5), all non zero.
-        # WingMovement is static, so no geometry periods.
-        # Should return tuple with three 1.5 values.
+        # periodCg_GP1_CgP1 is (1.5, 1.5, 1.5), all non zero. WingMovement is static, so
+        # no geometry periods. Should return tuple with three 1.5 values.
         self.assertEqual(airplane_movement.all_periods, (1.5, 1.5, 1.5))
 
     def test_all_periods_returns_tuple(self):
@@ -1067,9 +1064,8 @@ class TestCoreAirplaneMovementAllPeriods(unittest.TestCase):
         airplane_movement = self.multiple_periods_airplane_movement
         all_periods = airplane_movement.all_periods
 
-        # Should include periods from both Cg and WingMovements.
-        # Cg periods: (1.0, 2.0, 3.0).
-        # WingMovements contribute additional periods.
+        # Should include periods from both Cg and WingMovements. Cg periods: (1.0, 2.0,
+        # 3.0). WingMovements contribute additional periods.
         self.assertIn(1.0, all_periods)
         self.assertIn(2.0, all_periods)
         self.assertIn(3.0, all_periods)

--- a/tests/unit/test_core_movement.py
+++ b/tests/unit/test_core_movement.py
@@ -48,8 +48,8 @@ class TestCoreMovement(unittest.TestCase):
 
     def test_lcm_period_for_single_period_core_movement(self):
         """Test that lcm_period returns correct value when all periods are the same."""
-        # The basic_core_movement has period of 2.0 for all motion.
-        # LCM of identical periods should equal that period.
+        # The basic_core_movement has period of 2.0 for all motion. LCM of identical
+        # periods should equal that period.
         self.assertEqual(self.basic_core_movement.lcm_period, 2.0)
 
     def test_lcm_period_with_multiple_wings_same_airplane(self):
@@ -132,8 +132,8 @@ class TestCoreMovement(unittest.TestCase):
         # The max_period should be 4.0 (the max of 3.0 and 4.0).
         self.assertEqual(core_movement.max_period, 4.0)
 
-        # The lcm_period should be LCM(3.0, 4.0) = 12.0, not 4.0. This test will fail
-        # if lcm_period only uses max_period from each CoreAirplaneMovement instead of
+        # The lcm_period should be LCM(3.0, 4.0) = 12.0, not 4.0. This test will fail if
+        # lcm_period only uses max_period from each CoreAirplaneMovement instead of
         # collecting all individual periods.
         self.assertEqual(core_movement.lcm_period, 12.0)
 
@@ -188,8 +188,8 @@ class TestCoreMovement(unittest.TestCase):
             Cg_GP1_CgP1=(0.0, 0.0, 0.0),
         )
 
-        # Root CoreWingCrossSectionMovement must be static.
-        # Middle has period 3.0 s, tip has period 4.0 s.
+        # Root CoreWingCrossSectionMovement must be static. Middle has period 3.0 s, tip
+        # has period 4.0 s.
         wing_cross_section_movements = [
             ps._core.CoreWingCrossSectionMovement(
                 base_wing_cross_section=base_wing.wing_cross_sections[0],
@@ -236,8 +236,8 @@ class TestCoreMovement(unittest.TestCase):
         # The max_period should be 4.0 (the max of 3.0 and 4.0).
         self.assertEqual(core_movement.max_period, 4.0)
 
-        # The lcm_period should be LCM(3.0, 4.0) = 12.0, not 4.0. This test will fail
-        # if lcm_period only uses max_period from each CoreWingMovement instead of
+        # The lcm_period should be LCM(3.0, 4.0) = 12.0, not 4.0. This test will fail if
+        # lcm_period only uses max_period from each CoreWingMovement instead of
         # collecting all individual periods from CoreWingCrossSectionMovements.
         self.assertEqual(core_movement.lcm_period, 12.0)
 
@@ -357,8 +357,8 @@ class TestCoreMovement(unittest.TestCase):
             num_steps=1,
         )
 
-        # The CoreMovement has one static (period 0.0) and one with period 2.0.
-        # Should return 2.0.
+        # The CoreMovement has one static (period 0.0) and one with period 2.0. Should
+        # return 2.0.
         self.assertEqual(core_movement.max_period, 2.0)
 
 
@@ -429,8 +429,8 @@ class TestCoreMovementWithOperatingPointMovementPeriod(unittest.TestCase):
             num_steps=1,
         )
 
-        # The lcm_period should be 3.0 (from CoreOperatingPointMovement).
-        # Since the CoreAirplaneMovement is static (period 0.0), the only period is 3.0.
+        # The lcm_period should be 3.0 (from CoreOperatingPointMovement). Since the
+        # CoreAirplaneMovement is static (period 0.0), the only period is 3.0.
         self.assertEqual(core_movement.lcm_period, 3.0)
 
     def test_lcm_period_combines_airplane_and_operating_point_periods(self):

--- a/tests/unit/test_core_operating_point_movement.py
+++ b/tests/unit/test_core_operating_point_movement.py
@@ -444,9 +444,8 @@ class TestCoreOperatingPointMovement(unittest.TestCase):
         # Verify that values vary (not constant).
         self.assertFalse(np.allclose(vCg_values, vCg_values[0]))
 
-        # Verify that values are within expected range.
-        # For custom_harmonic with amp=15.0 and base=100.0, values should be roughly
-        # in [85.0, 115.0].
+        # Verify that values are within expected range. For custom_harmonic with amp =
+        # 15.0 and base = 100.0, values should be roughly in [85.0, 115.0].
         self.assertTrue(np.all(vCg_values >= 80.0))
         self.assertTrue(np.all(vCg_values <= 120.0))
 
@@ -575,7 +574,8 @@ class TestCoreOperatingPointMovement(unittest.TestCase):
         # Use low-speed operating point with vCg__E = 10.0.
         base_op = operating_point_fixtures.make_basic_operating_point_fixture()
 
-        # Create CoreOperatingPointMovement with amplitude that will drive vCg__E negative.
+        # Create CoreOperatingPointMovement with amplitude that will drive vCg__E
+        # negative.
         core_op_movement = ps._core.CoreOperatingPointMovement(
             base_operating_point=base_op,
             ampVCg__E=15.0,

--- a/tests/unit/test_core_unsteady_problem.py
+++ b/tests/unit/test_core_unsteady_problem.py
@@ -95,8 +95,7 @@ class TestCoreUnsteadyProblem(unittest.TestCase):
             max_wake_rows=None,
             lcm_period=0.0,
         )
-        # When only_final_results is True, first_results_step ==
-        # first_averaging_step.
+        # When only_final_results is True, first_results_step == first_averaging_step.
         self.assertEqual(
             core_unsteady_problem.first_results_step,
             core_unsteady_problem.first_averaging_step,

--- a/tests/unit/test_core_wing_cross_section_movement.py
+++ b/tests/unit/test_core_wing_cross_section_movement.py
@@ -648,9 +648,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
     def test_max_period_mixed(self):
         """Test that max_period returns maximum of all periods for mixed movement."""
         core_wcs_movement = self.multiple_periods_core_wcs_movement
-        # periodLp_Wcsp_Lpp is (1.0, 2.0, 3.0).
-        # periodAngles_Wcsp_to_Wcs_ixyz is (0.5, 1.5, 2.5).
-        # Maximum should be 3.0.
+        # periodLp_Wcsp_Lpp is (1.0, 2.0, 3.0). periodAngles_Wcsp_to_Wcs_ixyz is (0.5,
+        # 1.5, 2.5). Maximum should be 3.0.
         self.assertEqual(core_wcs_movement.max_period, 3.0)
 
     def test_max_period_multiple_dimensions(self):
@@ -669,24 +668,22 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         """Test that all_periods returns correct periods for Lp only movement."""
         wing_cross_section_movement = self.Lp_only_core_wcs_movement
         # periodLp_Wcsp_Lpp is (1.5, 1.5, 1.5), all non zero.
-        # periodAngles_Wcsp_to_Wcs_ixyz is (0.0, 0.0, 0.0).
-        # Should return tuple with three 1.5 values.
+        # periodAngles_Wcsp_to_Wcs_ixyz is (0.0, 0.0, 0.0). Should return tuple with
+        # three 1.5 values.
         self.assertEqual(wing_cross_section_movement.all_periods, (1.5, 1.5, 1.5))
 
     def test_all_periods_angles_only(self):
         """Test that all_periods returns correct periods for angles only movement."""
         wing_cross_section_movement = self.angles_only_core_wcs_movement
-        # periodLp_Wcsp_Lpp is (0.0, 0.0, 0.0).
-        # periodAngles_Wcsp_to_Wcs_ixyz is (1.5, 1.5, 1.5), all non zero.
-        # Should return tuple with three 1.5 values.
+        # periodLp_Wcsp_Lpp is (0.0, 0.0, 0.0). periodAngles_Wcsp_to_Wcs_ixyz is (1.5,
+        # 1.5, 1.5), all non zero. Should return tuple with three 1.5 values.
         self.assertEqual(wing_cross_section_movement.all_periods, (1.5, 1.5, 1.5))
 
     def test_all_periods_mixed(self):
         """Test that all_periods returns all non zero periods for mixed movement."""
         wing_cross_section_movement = self.multiple_periods_core_wcs_movement
-        # periodLp_Wcsp_Lpp is (1.0, 2.0, 3.0).
-        # periodAngles_Wcsp_to_Wcs_ixyz is (0.5, 1.5, 2.5).
-        # Should return tuple with all six values.
+        # periodLp_Wcsp_Lpp is (1.0, 2.0, 3.0). periodAngles_Wcsp_to_Wcs_ixyz is (0.5,
+        # 1.5, 2.5). Should return tuple with all six values.
         expected = (1.0, 2.0, 3.0, 0.5, 1.5, 2.5)
         self.assertEqual(wing_cross_section_movement.all_periods, expected)
 
@@ -704,8 +701,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         """Test all_periods with only some dimensions having non zero periods."""
         wing_cross_section_movement = self.sine_spacing_Lp_core_wcs_movement
         # periodLp_Wcsp_Lpp is (1.0, 0.0, 0.0), only first element is non zero.
-        # periodAngles_Wcsp_to_Wcs_ixyz is (0.0, 0.0, 0.0).
-        # Should return tuple with one 1.0 value.
+        # periodAngles_Wcsp_to_Wcs_ixyz is (0.0, 0.0, 0.0). Should return tuple with one
+        # 1.0 value.
         self.assertEqual(wing_cross_section_movement.all_periods, (1.0,))
 
     def test_generate_wing_cross_sections_parameter_validation(self):
@@ -802,7 +799,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
             num_steps=50, delta_time=0.01
         )
 
-        # All WingCrossSections should have same Lp_Wcsp_Lpp and angles_Wcsp_to_Wcs_ixyz.
+        # All WingCrossSections should have same Lp_Wcsp_Lpp and
+        # angles_Wcsp_to_Wcs_ixyz.
         for wcs in wing_cross_sections:
             npt.assert_array_equal(wcs.Lp_Wcsp_Lpp, base_wcs.Lp_Wcsp_Lpp)
             npt.assert_array_equal(
@@ -821,8 +819,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         y_positions = np.array([wcs.Lp_Wcsp_Lpp[1] for wcs in wing_cross_sections])
         z_positions = np.array([wcs.Lp_Wcsp_Lpp[2] for wcs in wing_cross_sections])
 
-        # Verify that phase offset causes non-zero initial values.
-        # With phase offsets, the first values should not all be at the base position.
+        # Verify that phase offset causes non-zero initial values. With phase offsets,
+        # the first values should not all be at the base position.
         self.assertFalse(np.allclose(x_positions[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(y_positions[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(z_positions[0], 0.0, atol=1e-10))
@@ -845,8 +843,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
             [wcs.angles_Wcsp_to_Wcs_ixyz[2] for wcs in wing_cross_sections]
         )
 
-        # Verify that phase offset causes non-zero initial values.
-        # With phase offsets, the first values should not all be at the base angles.
+        # Verify that phase offset causes non-zero initial values. With phase offsets,
+        # the first values should not all be at the base angles.
         self.assertFalse(np.allclose(angles_z[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(angles_y[0], 0.0, atol=1e-10))
         self.assertFalse(np.allclose(angles_x[0], 0.0, atol=1e-10))
@@ -951,8 +949,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         # Verify that values vary (not constant).
         self.assertFalse(np.allclose(x_positions, x_positions[0]))
 
-        # Verify that values are within expected range.
-        # For custom_harmonic with amp=1.0, values should be in [-1.0, 1.0].
+        # Verify that values are within expected range. For custom_harmonic with
+        # amp=1.0, values should be in [-1.0, 1.0].
         self.assertTrue(np.all(x_positions >= -1.1))
         self.assertTrue(np.all(x_positions <= 1.1))
 
@@ -971,8 +969,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         # Verify that values vary (not constant).
         self.assertFalse(np.allclose(angles_z, angles_z[0]))
 
-        # Verify that values are within expected range.
-        # For custom_triangle with amp=10.0, values should be in [-10.0, 10.0].
+        # Verify that values are within expected range. For custom_triangle with
+        # amp=10.0, values should be in [-10.0, 10.0].
         self.assertTrue(np.all(angles_z >= -11.0))
         self.assertTrue(np.all(angles_z <= 11.0))
 
@@ -1143,8 +1141,8 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         # Use root fixture with Lp_Wcsp_Lpp = [0.0, 0.0, 0.0].
         base_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
 
-        # Create CoreWingCrossSectionMovement with amplitude that will drive the second element in
-        # Lp_Wcsp_Lpp negative, which is never allowed by WingCrossSection.
+        # Create CoreWingCrossSectionMovement with amplitude that will drive the second
+        # element in Lp_Wcsp_Lpp negative, which is never allowed by WingCrossSection.
         core_wcs_movement = ps._core.CoreWingCrossSectionMovement(
             base_wing_cross_section=base_wcs,
             ampLp_Wcsp_Lpp=(0.0, 1.0, 0.0),
@@ -1169,8 +1167,9 @@ class TestCoreWingCrossSectionMovement(unittest.TestCase):
         # Use root fixture with angles = [0.0, 0.0, 0.0].
         base_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
 
-        # Create CoreWingCrossSectionMovement with amplitude that will drive angles out of valid range.
-        # Valid range for angles is (-180, 180], so amplitude 181 with base 0 will exceed.
+        # Create CoreWingCrossSectionMovement with amplitude that will drive angles out
+        # of valid range. Valid range for angles is (-180, 180], so amplitude 181 with
+        # base 0 will exceed.
         core_wcs_movement = ps._core.CoreWingCrossSectionMovement(
             base_wing_cross_section=base_wcs,
             ampAngles_Wcsp_to_Wcs_ixyz=(179.0, 0.0, 0.0),

--- a/tests/unit/test_core_wing_movement.py
+++ b/tests/unit/test_core_wing_movement.py
@@ -674,21 +674,21 @@ class TestCoreWingMovement(unittest.TestCase):
             delta_time=delta_time,
         )
 
-        # With rotation about a point offset in y (0.5m in y direction from Ler),
-        # z positions should vary when rotating about x axis.
-        # The offset is perpendicular to the rotation axis, so position changes occur.
+        # With rotation about a point offset in y (0.5 m in y direction from Ler), z
+        # positions should vary when rotating about x axis. The offset is perpendicular
+        # to the rotation axis, so position changes occur.
         z_positions = np.array([wing.Ler_Gs_Cgs[2] for wing in wings])
         y_positions = np.array([wing.Ler_Gs_Cgs[1] for wing in wings])
 
         # Verify that z positions are not all zero (they should oscillate).
         self.assertFalse(np.allclose(z_positions, 0.0))
 
-        # For rotation about x axis with offset P = (0, 0.5, 0), the position
-        # adjustment is (I - R) @ P where R is the rotation matrix about x.
-        # The active rotation matrix for angle theta about x is:
+        # For rotation about x axis with offset P = (0, 0.5, 0), the position adjustment
+        # is (I - R) @ P where R is the rotation matrix about x. The active rotation
+        # matrix for angle theta about x is:
         # R = [[1, 0, 0], [0, cos(theta), -sin(theta)], [0, sin(theta), cos(theta)]]
-        # So (I - R) @ [0, 0.5, 0] = [0, 0.5*(1 - cos(theta)), -0.5*sin(theta)]
-        # Thus y_adj = 0.5*(1 - cos(theta)) and z_adj = -0.5*sin(theta)
+        # So (I - R) @ [0, 0.5, 0] = [0, 0.5 * (1 - cos(theta)), -0.5 * sin(theta)].
+        # Thus y_adj = 0.5 * (1 - cos(theta)) and z_adj = -0.5 * sin(theta).
         times = np.linspace(0, num_steps * delta_time, num_steps, endpoint=False)
         stackAngleXRads = np.deg2rad(10.0 * np.sin(2 * np.pi * times / 1.0))
         expected_y = 0.5 * (1.0 - np.cos(stackAngleXRads))
@@ -772,29 +772,26 @@ class TestCoreWingMovement(unittest.TestCase):
     def test_all_periods_Ler_only(self):
         """Test that all_periods returns correct periods for Ler only movement."""
         wing_movement = self.Ler_only_wing_movement
-        # periodLer_Gs_Cgs is (1.5, 1.5, 1.5), all non zero.
-        # periodAngles_Gs_to_Wn_ixyz is (0.0, 0.0, 0.0).
-        # WingCrossSectionMovements are static (all zeros).
-        # Should return tuple with three 1.5 values.
+        # periodLer_Gs_Cgs is (1.5, 1.5, 1.5), all non zero. periodAngles_Gs_to_Wn_ixyz
+        # is (0.0, 0.0, 0.0). WingCrossSectionMovements are static (all zeros). The
+        # property should return a tuple with three 1.5 values.
         self.assertEqual(wing_movement.all_periods, (1.5, 1.5, 1.5))
 
     def test_all_periods_angles_only(self):
         """Test that all_periods returns correct periods for angles only movement."""
         wing_movement = self.angles_only_wing_movement
-        # periodLer_Gs_Cgs is (0.0, 0.0, 0.0).
-        # periodAngles_Gs_to_Wn_ixyz is (1.5, 1.5, 1.5), all non zero.
-        # WingCrossSectionMovements are static (all zeros).
-        # Should return tuple with three 1.5 values.
+        # periodLer_Gs_Cgs is (0.0, 0.0, 0.0). periodAngles_Gs_to_Wn_ixyz is (1.5, 1.5,
+        # 1.5), all non zero. WingCrossSectionMovements are static (all zeros). The
+        # property should return a tuple with three 1.5 values.
         self.assertEqual(wing_movement.all_periods, (1.5, 1.5, 1.5))
 
     def test_all_periods_mixed(self):
         """Test that all_periods returns all non zero periods for mixed movement."""
         wing_movement = self.multiple_periods_wing_movement
-        # periodLer_Gs_Cgs is (1.0, 2.0, 3.0).
-        # periodAngles_Gs_to_Wn_ixyz is (0.5, 1.5, 2.5).
-        # WingCrossSectionMovements include one with multiple periods.
-        # Should return tuple with all non zero values from WingCrossSectionMovements first,
-        # then CoreWingMovement's own periods.
+        # periodLer_Gs_Cgs is (1.0, 2.0, 3.0). periodAngles_Gs_to_Wn_ixyz is (0.5, 1.5,
+        # 2.5). WingCrossSectionMovements include one with multiple periods. The
+        # property should return a tuple with all non zero values from
+        # WingCrossSectionMovements first, then CoreWingMovement's own periods.
         all_periods = wing_movement.all_periods
 
         # Verify CoreWingMovement's own periods are included.
@@ -812,9 +809,9 @@ class TestCoreWingMovement(unittest.TestCase):
         wing_movement = self.basic_wing_movement
         all_periods = wing_movement.all_periods
 
-        # Both periodLer_Gs_Cgs and periodAngles_Gs_to_Wn_ixyz are (2.0, 2.0, 2.0).
-        # This contributes six 2.0 values. Plus WingCrossSectionMovement periods.
-        # Count how many times 2.0 appears (should be at least 6 from CoreWingMovement).
+        # Both periodLer_Gs_Cgs and periodAngles_Gs_to_Wn_ixyz are (2.0, 2.0, 2.0). This
+        # contributes six 2.0 values, plus WingCrossSectionMovement periods. Count how
+        # many times 2.0 appears (should be at least 6 from CoreWingMovement).
         count_2_0 = all_periods.count(2.0)
         self.assertGreaterEqual(count_2_0, 6)
 
@@ -822,9 +819,8 @@ class TestCoreWingMovement(unittest.TestCase):
         """Test all_periods with only some dimensions having non zero periods."""
         wing_movement = self.sine_spacing_Ler_wing_movement
         # periodLer_Gs_Cgs is (1.0, 0.0, 0.0), only first element is non zero.
-        # periodAngles_Gs_to_Wn_ixyz is (0.0, 0.0, 0.0).
-        # WingCrossSectionMovements are static.
-        # Should return tuple with one 1.0 value.
+        # periodAngles_Gs_to_Wn_ixyz is (0.0, 0.0, 0.0). WingCrossSectionMovements are
+        # static. The property should return a tuple with one 1.0 value.
         self.assertEqual(wing_movement.all_periods, (1.0,))
 
 

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -380,7 +380,8 @@ class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
         self.final_step = self.problem.num_steps - 1
 
         # The solver populates the current Airplane's load attributes via
-        # _calculate_loads before invoking initialize_next_problem, so emulate that here.
+        # _calculate_loads before invoking initialize_next_problem, so emulate that
+        # here.
         self.current_airplane = self.problem.steady_problems[0].airplanes[0]
         self.current_airplane.forces_W = np.array([1.0, 2.0, 3.0], dtype=float)
         self.current_airplane.forceCoefficients_W = np.array(

--- a/tests/unit/test_movement.py
+++ b/tests/unit/test_movement.py
@@ -94,8 +94,8 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Test with positive delta_time works. Use num_steps=1 to speed up the test;
-        # we only need to verify delta_time is accepted, not generate many airplanes.
+        # Test with positive delta_time works. Use num_steps = 1 to speed up the test.
+        # We only need to verify delta_time is accepted, not generate many Airplanes.
         movement = ps.movements.movement.Movement(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -245,8 +245,8 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Test with valid positive integer. Use num_cycles=1 to speed up the test;
-        # the validation logic doesn't depend on the specific value.
+        # Test with valid positive integer. Use num_cycles = 1 to speed up the test. The
+        # validation logic doesn't depend on the specific value.
         movement = ps.movements.movement.Movement(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -275,8 +275,8 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Test with valid positive integer. Use num_chords=1 to speed up the test;
-        # the validation logic doesn't depend on the specific value.
+        # Test with valid positive integer. Use num_chords = 1 to speed up the test. The
+        # validation logic doesn't depend on the specific value.
         movement = ps.movements.movement.Movement(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -305,8 +305,8 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Test with valid positive integer. Use num_steps=1 to speed up the test;
-        # the validation logic doesn't depend on the specific value.
+        # Test with valid positive integer. Use num_steps = 1 to speed up the test. The
+        # validation logic doesn't depend on the specific value.
         movement = ps.movements.movement.Movement(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -438,8 +438,8 @@ class TestMovement(unittest.TestCase):
             num_chords=5,
         )
 
-        # num_steps should be at least num_chords * c_ref / (delta_time * vCg__E).
-        # Since we use math.ceil, it should be an integer.
+        # num_steps should be at least num_chords * c_ref / (delta_time * vCg__E). Since
+        # we use math.ceil, it should be an integer.
         self.assertIsInstance(movement.num_steps, int)
         self.assertGreater(movement.num_steps, 0)
 
@@ -459,8 +459,8 @@ class TestMovement(unittest.TestCase):
             num_cycles=3,
         )
 
-        # num_steps should be at least num_cycles * max_period / delta_time.
-        # Since we use math.ceil, it should be an integer.
+        # num_steps should be at least num_cycles * max_period / delta_time. Since we
+        # use math.ceil, it should be an integer.
         self.assertIsInstance(movement.num_steps, int)
         self.assertGreater(movement.num_steps, 0)
 
@@ -496,8 +496,8 @@ class TestMovement(unittest.TestCase):
             for wcs in processed_wing.wing_cross_sections
         ]
 
-        # Create a WingMovement with rotation that will cause the symmetry plane
-        # to become non-coincident (type 4->5 transition).
+        # Create a WingMovement with rotation that will cause the symmetry plane to
+        # become non-coincident (type 4->5 transition).
         wing_movement = ps.movements.wing_movement.WingMovement(
             base_wing=processed_wing,
             wing_cross_section_movements=wcs_movements,
@@ -559,8 +559,8 @@ class TestMovement(unittest.TestCase):
             for wcs in processed_wing.wing_cross_sections
         ]
 
-        # Create a WingMovement with rotation that will cause the symmetry plane
-        # to become coincident (type 3->2 transition).
+        # Create a WingMovement with rotation that will cause the symmetry plane to
+        # become coincident (type 3->2 transition).
         wing_movement = ps.movements.wing_movement.WingMovement(
             base_wing=processed_wing,
             wing_cross_section_movements=wcs_movements,
@@ -623,8 +623,8 @@ class TestMovement(unittest.TestCase):
             for wcs in processed_wing.wing_cross_sections
         ]
 
-        # Create a WingMovement with rotation that will cause the symmetry plane
-        # to become non-coincident (type 2->3 transition).
+        # Create a WingMovement with rotation that will cause the symmetry plane to
+        # become non-coincident (type 2->3 transition).
         wing_movement = ps.movements.wing_movement.WingMovement(
             base_wing=processed_wing,
             wing_cross_section_movements=wcs_movements,
@@ -803,8 +803,8 @@ class TestMovement(unittest.TestCase):
             # Verify the analytical optimizer was called exactly once.
             mock_analytical.assert_called_once()
 
-            # Verify the iterative optimizer was called exactly once with the
-            # analytical result as initial_delta_time.
+            # Verify the iterative optimizer was called exactly once with the analytical
+            # result as initial_delta_time.
             mock_iterative.assert_called_once()
             call_kwargs = mock_iterative.call_args[1]
             self.assertEqual(
@@ -827,8 +827,8 @@ class TestMovement(unittest.TestCase):
 
     def test_min_period_with_multiple_periods(self):
         """Test that min_period returns the smallest non zero period."""
-        # Reuse the multi airplane fixture which has periods 2.0 and 0.0.
-        # The min non zero period should be 2.0.
+        # Reuse the multi airplane fixture which has periods 2.0 and 0.0. The min non
+        # zero period should be 2.0.
         movement = self.movement_with_multiple_airplanes
         self.assertEqual(movement.min_period, 2.0)
 
@@ -913,10 +913,10 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Mock _analytically_optimize_delta_time to return a known value instantly.
-        # The value is below this fixture's clamp threshold (an LCM period of 2.0
-        # seconds divided by the minimum of 30 time steps per LCM period), so it
-        # passes through the clamp unchanged.
+        # Mock _analytically_optimize_delta_time to return a known value instantly. The
+        # value is below this fixture's clamp threshold (an LCM period of 2.0 seconds
+        # divided by the minimum of 30 time steps per LCM period), so it passes through
+        # the clamp unchanged.
         fake_optimized_delta_time = 0.0123456789
 
         with patch(
@@ -924,8 +924,8 @@ class TestMovement(unittest.TestCase):
         ) as mock_optimize:
             mock_optimize.return_value = fake_optimized_delta_time
 
-            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the
-            # only time spent is generating Airplanes after getting the delta_time.
+            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the only
+            # time spent is generating Airplanes after getting the delta_time.
             movement = ps.movements.movement.Movement(
                 airplane_movements=airplane_movements,
                 operating_point_movement=operating_point_movement,
@@ -953,9 +953,9 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Mock _analytically_optimize_delta_time to return a value far above the
-        # clamp threshold (an LCM period of 2.0 seconds divided by the minimum of
-        # 30 time steps per LCM period).
+        # Mock _analytically_optimize_delta_time to return a value far above the clamp
+        # threshold (an LCM period of 2.0 seconds divided by the minimum of 30 time
+        # steps per LCM period).
         fake_optimized_delta_time = 10.0
 
         with patch(
@@ -963,8 +963,8 @@ class TestMovement(unittest.TestCase):
         ) as mock_optimize:
             mock_optimize.return_value = fake_optimized_delta_time
 
-            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the
-            # only time spent is generating Airplanes after getting the delta_time.
+            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the only
+            # time spent is generating Airplanes after getting the delta_time.
             movement = ps.movements.movement.Movement(
                 airplane_movements=airplane_movements,
                 operating_point_movement=operating_point_movement,
@@ -972,8 +972,8 @@ class TestMovement(unittest.TestCase):
                 num_steps=1,
             )
 
-            # Verify the Movement clamped the optimizer's return value to the LCM
-            # period divided by the minimum number of time steps per LCM period.
+            # Verify the Movement clamped the optimizer's return value to the LCM period
+            # divided by the minimum number of time steps per LCM period.
             self.assertEqual(movement.delta_time, movement.lcm_period / 30)
 
     def test_delta_time_estimate_not_clamped_for_static_movement(self):
@@ -990,9 +990,9 @@ class TestMovement(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Mock _analytically_optimize_delta_time to return a large value instantly.
-        # For a static Movement, the real optimizer would return its initial
-        # estimate unchanged.
+        # Mock _analytically_optimize_delta_time to return a large value instantly. For
+        # a static Movement, the real optimizer would return its initial estimate
+        # unchanged.
         fake_optimized_delta_time = 10.0
 
         with patch(
@@ -1000,8 +1000,8 @@ class TestMovement(unittest.TestCase):
         ) as mock_optimize:
             mock_optimize.return_value = fake_optimized_delta_time
 
-            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the
-            # only time spent is generating Airplanes after getting the delta_time.
+            # Use num_steps=1 to speed up the test. The optimizer is mocked, so the only
+            # time spent is generating Airplanes after getting the delta_time.
             movement = ps.movements.movement.Movement(
                 airplane_movements=airplane_movements,
                 operating_point_movement=operating_point_movement,
@@ -1009,8 +1009,7 @@ class TestMovement(unittest.TestCase):
                 num_steps=1,
             )
 
-            # Verify the Movement used the optimizer's return value without
-            # clamping it.
+            # Verify the Movement used the optimizer's return value without clamping it.
             self.assertEqual(movement.delta_time, fake_optimized_delta_time)
 
     def test_max_wake_rows_default_none(self):
@@ -1325,8 +1324,8 @@ class TestComputeWakeAreaMismatch(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Use a delta_time that results in only 1 step for static movement.
-        # With max_period = 0, num_steps will be 1, so step > 0 never runs.
+        # Use a delta_time that results in only 1 step for a static Movement. With
+        # max_period = 0, num_steps will be 1, so step > 0 never runs.
         delta_time = 0.01
 
         mismatch = _compute_wake_area_mismatch(
@@ -1444,10 +1443,10 @@ class TestOptimizeDeltaTimeNonStatic(unittest.TestCase):
             all_periods.extend(airplane_movement.all_periods)
         lcm_period = lcm_multiple(all_periods)
 
-        # Seed with the analytical result so the brute force bracket is centered
-        # near the true optimum, mirroring real usage. The analytical's
-        # initial_delta_time is only used as a fallback for fully static
-        # Movements, so any positive placeholder works here.
+        # Seed with the analytical result so the brute force bracket is centered near
+        # the true optimum, mirroring real usage. The analytical's initial_delta_time is
+        # only used as a fallback for fully static Movements, so any positive
+        # placeholder works here.
         initial_delta_time = _analytically_optimize_delta_time(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -1485,10 +1484,10 @@ class TestOptimizeDeltaTimeNonStatic(unittest.TestCase):
             all_periods.extend(airplane_movement.all_periods)
         lcm_period = lcm_multiple(all_periods)
 
-        # Seed with the analytical result so the brute force bracket is centered
-        # near the true optimum, mirroring real usage. The analytical's
-        # initial_delta_time is only used as a fallback for fully static
-        # Movements, so any positive placeholder works here.
+        # Seed with the analytical result so the brute force bracket is centered near
+        # the true optimum, mirroring real usage. The analytical's initial_delta_time is
+        # only used as a fallback for fully static Movements, so any positive
+        # placeholder works here.
         initial_delta_time = _analytically_optimize_delta_time(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -1526,12 +1525,12 @@ class TestOptimizeDeltaTime(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Seed the iterative optimizer with the analytical result. This keeps the
-        # brute force bracket centered near the true optimum so the search does
-        # not hit either bound, mirroring real usage. The initial_delta_time
-        # passed to _analytically_optimize_delta_time is only used as a fallback
-        # for fully static Movements, so any positive placeholder works here
-        # since the fixture has motion.
+        # Seed the iterative optimizer with the analytical result. This keeps the brute
+        # force bracket centered near the true optimum so the search does not hit either
+        # bound, mirroring real usage. The initial_delta_time passed to
+        # _analytically_optimize_delta_time is only used as a fallback for fully static
+        # Movements, so any positive placeholder works here since the fixture has
+        # motion.
         initial_delta_time = _analytically_optimize_delta_time(
             airplane_movements=airplane_movements,
             operating_point_movement=operating_point_movement,
@@ -1900,8 +1899,8 @@ class TestAnalyticallyOptimizeDeltaTimeEdgeCases(unittest.TestCase):
             _analytically_optimize_delta_time,
         )
 
-        # Create a multi wing Airplane with Cg_GP1_CgP1 at origin.
-        # Use simple tapered wings.
+        # Create an Airplane with multiple Wings, with Cg_GP1_CgP1 at the origin. Use
+        # simple tapered Wings.
         base_wing_1 = geometry_fixtures.make_simple_tapered_wing_fixture()
         base_wing_2 = geometry_fixtures.make_simple_tapered_wing_fixture()
 
@@ -1966,11 +1965,12 @@ class TestAnalyticallyOptimizeDeltaTimeEdgeCases(unittest.TestCase):
             _analytically_optimize_delta_time,
         )
 
-        # Create an AirplaneMovement with very fast motion (short period) and few
-        # chordwise panels. This should result in fewer than 20 steps per min period.
-        # The basic fixture has period 2.0 s. With few chordwise panels and fast motion,
-        # the trailing edge panels are large relative to the motion displacement.
-        # Create a Wing with only 2 chordwise panels to make trailing edge panels large.
+        # Create an AirplaneMovement with very fast motion (a short period) and few
+        # chordwise Panels. This should result in fewer than 20 steps per min period.
+        # The basic fixture has a period of 2.0 s. With few chordwise Panels and fast
+        # motion, the trailing edge Panels are large relative to the motion
+        # displacement. Create a Wing with only 2 chordwise Panels to make trailing edge
+        # Panels large.
         base_airplane = geometry_fixtures.make_2_chordwise_panels_airplane_fixture()
         wing = base_airplane.wings[0]
 
@@ -2137,8 +2137,8 @@ class TestComputeWakeAreaMismatchEdgeCases(unittest.TestCase):
             base_operating_point=operating_point_fixtures.make_basic_operating_point_fixture()
         )
 
-        # Use a delta_time that results in multiple time steps over the max period.
-        # The basic fixture has period 2.0 s. With delta_time=0.5, we get 4 steps.
+        # Use a delta_time that results in multiple time steps over the max period. The
+        # basic fixture has period 2.0 s. With delta_time=0.5, we get 4 steps.
         delta_time = 0.5
 
         mismatch = _compute_wake_area_mismatch(
@@ -2271,8 +2271,8 @@ class TestEvaluateCachedWakeAreaMismatch(unittest.TestCase):
             _evaluate_cached_wake_area_mismatch,
         )
 
-        # The function returns early before touching cache_per_wing or
-        # v_inf_high_res, so minimal placeholder inputs are sufficient.
+        # The function returns early before touching cache_per_wing or v_inf_high_res,
+        # so minimal placeholder inputs are sufficient.
         result = _evaluate_cached_wake_area_mismatch(
             cache_per_wing=[],
             v_inf_high_res=np.zeros((1, 3)),
@@ -2312,7 +2312,7 @@ class TestOptimizeDeltaTimeNonStaticWarnings(unittest.TestCase):
 
         # Mock the cached batch evaluator to return mismatches that increase
         # with num_steps, so the best is at min_num_steps (lower bound = largest
-        # delta_time). Mirrors the original 1.0 / delta_time shape via
+        # delta_time). This mirrors the original 1.0 / delta_time shape via
         # delta_time = lcm_period / num_steps.
         # noinspection PyUnusedLocal,PyShadowingNames
         def mock_cached_mismatches(
@@ -2371,10 +2371,10 @@ class TestOptimizeDeltaTimeNonStaticWarnings(unittest.TestCase):
         lcm_period = 2.0  # Fixture has period 2.0.
         initial_delta_time = 0.1  # Results in ~20 steps, search range ~10 to ~41.
 
-        # Mock the cached batch evaluator to return mismatches that decrease
-        # with num_steps, so the best is at max_num_steps (upper bound =
-        # smallest delta_time). Mirrors the original delta_time * 10.0 shape
-        # via delta_time = lcm_period / num_steps.
+        # Mock the cached batch evaluator to return mismatches that decrease with
+        # num_steps, so the best is at max_num_steps (upper bound = smallest
+        # delta_time). Mirrors the original delta_time * 10.0 shape via delta_time =
+        # lcm_period / num_steps.
         # noinspection PyUnusedLocal,PyShadowingNames
         def mock_cached_mismatches(
             airplane_movements,

--- a/tests/unit/test_movement.py
+++ b/tests/unit/test_movement.py
@@ -2310,10 +2310,10 @@ class TestOptimizeDeltaTimeNonStaticWarnings(unittest.TestCase):
         lcm_period = 2.0  # Fixture has period 2.0.
         initial_delta_time = 0.1  # Results in ~20 steps, search range ~10 to ~41.
 
-        # Mock the cached batch evaluator to return mismatches that increase
-        # with num_steps, so the best is at min_num_steps (lower bound = largest
-        # delta_time). This mirrors the original 1.0 / delta_time shape via
-        # delta_time = lcm_period / num_steps.
+        # Mock the cached batch evaluator to return mismatches that increase with
+        # num_steps, so the best is at min_num_steps (lower bound = largest delta_time).
+        # This mirrors the original 1.0 / delta_time shape via delta_time = lcm_period /
+        # num_steps.
         # noinspection PyUnusedLocal,PyShadowingNames
         def mock_cached_mismatches(
             airplane_movements,

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -736,8 +736,8 @@ class TestMuJoCoModelConventions(unittest.TestCase):
 
         velocity_E__E = self.model.get_state()["velocity_E__E"]
 
-        # The body accelerates along Earth +x, so the velocity is dominated by a positive
-        # x component with negligible y and z components.
+        # The body accelerates along Earth +x, so the velocity is dominated by a
+        # positive x component with negligible y and z components.
         self.assertGreater(velocity_E__E[0], 0.0)
         self.assertGreater(abs(velocity_E__E[0]), 10.0 * abs(velocity_E__E[1]))
         self.assertGreater(abs(velocity_E__E[0]), 10.0 * abs(velocity_E__E[2]))

--- a/tests/unit/test_operating_point.py
+++ b/tests/unit/test_operating_point.py
@@ -314,45 +314,43 @@ class TestOperatingPoint(unittest.TestCase):
         """Test transformation with zero alpha and beta."""
         op = self.zero_alpha_beta_op
 
-        # With alpha = beta = 0, wind axes align with body axes.
-        # The freestream direction in wind axes is [-1, 0, 0].
-        # Transform to the first Airplane's geometry axes to verify direction.
+        # With alpha = beta = 0, wind axes align with body axes. The freestream
+        # direction in wind axes is [-1, 0, 0]. Transform to the first Airplane's
+        # geometry axes to verify direction.
         vInfHat_GP1__E = op.vInfHat_GP1__E
 
-        # Geometry axes: +x = aft, +y = right, +z = up
-        # Body axes: +x = forward, +y = right, +z = down
-        # With alpha = beta = 0, wind axes align with body axes.
-        # So freestream [-1, 0, 0] in wind axes means freestream comes from
-        # backward in body axes (forward velocity).
-        # In geometry axes, this should be [+1, 0, 0] (forward in geometry is
-        # aft direction, opposite of body).
+        # In geometry axes, +x points aft, +y points right, and +z points up. In body
+        # axes, +x points forward, +y points right, and +z points down. With alpha =
+        # beta = 0, wind axes align with body axes. So freestream [-1, 0, 0] in wind
+        # axes means freestream comes from backward in body axes (forward velocity). In
+        # geometry axes, this should be [+1, 0, 0] (forward in geometry axes is the aft
+        # direction, opposite of body axes).
         npt.assert_allclose(vInfHat_GP1__E[0], 1.0, atol=1e-14)
         npt.assert_allclose(vInfHat_GP1__E[1], 0.0, atol=1e-14)
         npt.assert_allclose(vInfHat_GP1__E[2], 0.0, atol=1e-14)
 
     def test_transformation_alpha_only(self):
         """Test transformation with alpha only (beta = 0)."""
-        # Positive alpha means the nose points above the direction of travel,
-        # so the relative wind comes from below. In the first Airplane's geometry
-        # axes (+z = up), the freestream velocity vector should have a positive
-        # z-component.
+        # Positive alpha means the nose points above the direction of travel, so the
+        # relative wind comes from below. In the first Airplane's geometry axes (+z =
+        # up), the freestream velocity vector should have a positive z component.
         op_positive_alpha = ps.operating_point.OperatingPoint(alpha=10.0, beta=0.0)
         vInf_GP1__E_pos = op_positive_alpha.vInfHat_GP1__E
 
-        # With positive alpha, the freestream should have a positive z-component
-        # in the first Airplane's geometry axes (wind comes from below).
+        # With positive alpha, the freestream should have a positive z component in the
+        # first Airplane's geometry axes (wind comes from below).
         self.assertGreater(vInf_GP1__E_pos[2], 0.0)
 
         # The y-component should be approximately zero (no sideslip).
         npt.assert_allclose(vInf_GP1__E_pos[1], 0.0, atol=1e-14)
 
-        # Negative alpha means the nose points below the direction of travel,
-        # so the relative wind comes from above.
+        # Negative alpha means the nose points below the direction of travel, so the
+        # relative wind comes from above.
         op_negative_alpha = ps.operating_point.OperatingPoint(alpha=-10.0, beta=0.0)
         vInf_GP1__E_neg = op_negative_alpha.vInfHat_GP1__E
 
-        # With negative alpha, the freestream should have a negative z-component
-        # in the first Airplane's geometry axes (wind comes from above).
+        # With negative alpha, the freestream should have a negative z component in the
+        # first Airplane's geometry axes (wind comes from above).
         self.assertLess(vInf_GP1__E_neg[2], 0.0)
 
         # The y-component should be approximately zero (no sideslip).
@@ -360,29 +358,29 @@ class TestOperatingPoint(unittest.TestCase):
 
     def test_transformation_beta_only(self):
         """Test transformation with beta only (alpha = 0)."""
-        # Positive beta means the nose points to the left of the direction of
-        # travel, so the airplane moves to the right of where the nose points.
-        # The relative wind comes from the right. In the first Airplane's geometry
-        # axes (+y = right), the freestream velocity vector should have a negative
-        # y-component (pointing left, opposite the airplane's rightward motion).
+        # Positive beta means the nose points to the left of the direction of travel, so
+        # the airplane moves to the right of where the nose points. The relative wind
+        # comes from the right. In the first Airplane's geometry axes (+y = right), the
+        # freestream velocity vector should have a negative y-component (pointing left,
+        # opposite the airplane's rightward motion).
         op_positive_beta = ps.operating_point.OperatingPoint(alpha=0.0, beta=10.0)
         vInf_GP1__E_pos = op_positive_beta.vInfHat_GP1__E
 
-        # With positive beta, the freestream should have a negative y-component
-        # in the first Airplane's geometry axes (wind from right, pointing left).
+        # With positive beta, the freestream should have a negative y component in the
+        # first Airplane's geometry axes (wind from right, pointing left).
         self.assertLess(vInf_GP1__E_pos[1], 0.0)
 
         # The z-component should be approximately zero (no vertical component).
         npt.assert_allclose(vInf_GP1__E_pos[2], 0.0, atol=1e-14)
 
-        # Negative beta means the nose points to the right of the direction of
-        # travel, so the airplane moves to the left of where the nose points.
-        # The relative wind comes from the left.
+        # Negative beta means the nose points to the right of the direction of travel,
+        # so the airplane moves to the left of where the nose points. The relative wind
+        # comes from the left.
         op_negative_beta = ps.operating_point.OperatingPoint(alpha=0.0, beta=-10.0)
         vInf_GP1__E_neg = op_negative_beta.vInfHat_GP1__E
 
-        # With negative beta, the freestream should have a positive y-component
-        # in the first Airplane's geometry axes (wind from left, pointing right).
+        # With negative beta, the freestream should have a positive y component in the
+        # first Airplane's geometry axes (wind from left, pointing right).
         self.assertGreater(vInf_GP1__E_neg[1], 0.0)
 
         # The z-component should be approximately zero (no vertical component).
@@ -443,8 +441,8 @@ class TestOperatingPoint(unittest.TestCase):
     def test_vInfHat_GP1__E_direction(self):
         """Test vInfHat_GP1__E direction consistency."""
         # For zero alpha and beta, verify direction aligns as expected. In wind axes,
-        # freestream is [-1, 0, 0]. Transform to the first Airplane's geometry axes
-        # and verify it's a unit vector.
+        # freestream is [-1, 0, 0]. Transform to the first Airplane's geometry axes and
+        # verify it's a unit vector.
         op = self.zero_alpha_beta_op
         vInfHat_GP1__E = op.vInfHat_GP1__E
 
@@ -1524,24 +1522,22 @@ class TestOperatingPoint(unittest.TestCase):
             surfacePoint_E_Eo=(0.0, 0.0, 0.0),
         )
 
-        # With zero attitude angles, E to GP1 flips z. The surface point
-        # relative to CG is (0, 0, -Cg_z) in Earth, which maps to (0, 0, Cg_z)
-        # in GP1. But Cg_z is negative (above ground), so the GP1 z component
-        # should be negative (below CG in GP1's z up frame).
+        # With zero attitude angles, E to GP1 flips z. The surface point relative to CG
+        # is (0, 0, -Cg_z) in Earth, which maps to (0, 0, Cg_z) in GP1. But Cg_z is
+        # negative (above ground), so the GP1 z component should be negative (below CG
+        # in GP1's z up frame).
         point_near = op_near.surfacePoint_GP1_CgP1
         point_far = op_far.surfacePoint_GP1_CgP1
 
-        # The airplane further from the ground should have a more negative
-        # z component in GP1.
+        # The airplane further from the ground should have a more negative z component
+        # in GP1.
         self.assertLess(point_far[2], point_near[2])
 
-        # Verify specific values. E to GP1 flips x and z.
-        # Near: surfacePoint_E_CgP1 = (0,0,0) - (0,0,-5) = (0,0,5).
-        # In GP1: (0,0,-5).
+        # Verify specific values. E to GP1 flips x and z. Near: surfacePoint_E_CgP1 =
+        # (0,0,0) - (0,0,-5) = (0,0,5). In GP1: (0,0,-5).
         npt.assert_allclose(point_near, [0.0, 0.0, -5.0], atol=1e-14)
 
-        # Far: surfacePoint_E_CgP1 = (0,0,0) - (0,0,-20) = (0,0,20).
-        # In GP1: (0,0,-20).
+        # Far: surfacePoint_E_CgP1 = (0,0,0) - (0,0,-20) = (0,0,20). In GP1: (0,0,-20).
         npt.assert_allclose(point_far, [0.0, 0.0, -20.0], atol=1e-14)
 
     def test_derived_surface_properties_read_only(self):
@@ -1624,11 +1620,12 @@ class TestOperatingPoint(unittest.TestCase):
 
         reflected = _transformations.apply_T_to_vectors(T, point, is_position=True)
 
-        # The surface point in GP1_CgP1 is at z = -10 (10 meters below CgP1 in
-        # GP1 z, corresponding to the ground at z = 0 in Earth). The surface
-        # normal in GP1 is (0, 0, 1) (180 degree y rotation flips Earth's
-        # (0, 0, -1) to (0, 0, 1)). Reflecting (1, 2, 3) across a plane at
-        # z = -10 with normal (0, 0, 1) gives (1, 2, -23).
+        # The surface point in GP1_CgP1 is at z = -10.0 (10.0 meters below CgP1 in the
+        # GP1 z direction, corresponding to the ground at z = 0.0 in Earth axes). The
+        # surface normal in GP1 axes is (0.0, 0.0, 1.0) (a 180 degree rotation about the
+        # y axis flips Earth's (0.0, 0.0, -1.0) to (0.0, 0.0, 1.0)). Reflecting (1.0,
+        # 2.0, 3.0) across a plane at z = -10.0 with normal (0.0, 0.0, 1.0) gives (1.0,
+        # 2.0, -23.0).
         expected = np.array([1.0, 2.0, -23.0])
         npt.assert_allclose(reflected, expected, atol=1e-12)
 
@@ -1643,8 +1640,8 @@ class TestOperatingPoint(unittest.TestCase):
         op = self.with_ground_surface_op
         T = op.surfaceReflect_T_act_GP1_CgP1
 
-        # The surface normal in GP1 is (0, 0, 1) for this fixture. Reflecting
-        # a velocity vector should negate only the z component.
+        # The surface normal in GP1 is (0, 0, 1) for this fixture. Reflecting a velocity
+        # vector should negate only the z component.
         velocity = np.array([5.0, -3.0, 7.0])
         reflected = _transformations.apply_T_to_vectors(T, velocity, is_position=False)
 
@@ -1694,8 +1691,8 @@ class TestOperatingPoint(unittest.TestCase):
         op = self.with_tilted_surface_op
         T = op.surfaceReflect_T_act_GP1_CgP1
 
-        # The surface point in GP1_CgP1 should lie on the reflection plane.
-        # Reflecting it should return the same point.
+        # The surface point in GP1_CgP1 should lie on the reflection plane. Reflecting
+        # it should return the same point.
         surface_point = op.surfacePoint_GP1_CgP1
         reflected = _transformations.apply_T_to_vectors(
             T, surface_point, is_position=True

--- a/tests/unit/test_oscillation.py
+++ b/tests/unit/test_oscillation.py
@@ -68,8 +68,8 @@ class TestOscillation(unittest.TestCase):
             time=0.0,
         )
 
-        # Verify that phase offset shifts the waveform.
-        # At t=0.0, sine with 90.0 degree phase should equal the amplitude.
+        # Verify that phase offset shifts the waveform. At t = 0.0, sine with 90.0
+        # degree phase should equal the amplitude.
         npt.assert_allclose(result, self.phase_offset_amp, rtol=1e-10, atol=1e-14)
 
     def test_oscillating_sin_at_time_max_phase(self):
@@ -82,8 +82,8 @@ class TestOscillation(unittest.TestCase):
             time=0.0,
         )
 
-        # Verify that max phase (180.0 degrees) inverts the waveform.
-        # At t=0.0, sine with 180.0 degree phase should be approximately 0.0.
+        # Verify that max phase (180.0 degrees) inverts the waveform. At t = 0.0, sine
+        # with 180.0 degree phase should be approximately 0.0.
         npt.assert_allclose(result, 0.0, rtol=1e-10, atol=1e-14)
 
     def test_oscillating_lin_at_time_static_parameters(self):
@@ -109,8 +109,8 @@ class TestOscillation(unittest.TestCase):
             time=0.0,
         )
 
-        # Verify that phase offset shifts the waveform.
-        # At t=0.0, triangular wave with 90.0 degree phase should be near maximum.
+        # Verify that phase offset shifts the waveform. At t = 0.0, triangular wave with
+        # 90.0 degree phase should be near maximum.
         self.assertGreater(result, 0.5 * self.phase_offset_amp)
 
     def test_oscillating_custom_at_time_static_parameters(self):

--- a/tests/unit/test_panel.py
+++ b/tests/unit/test_panel.py
@@ -123,8 +123,7 @@ class TestPanel(unittest.TestCase):
 
         Cpp_G_Cg = panel.Cpp_G_Cg
 
-        # Should be at 75% chord, midspan
-        # Expected: [0.75, 0.25, 0.0]
+        # Should be at 75% chord, midspan. Expected: [0.75, 0.25, 0.0].
         expected_Cpp_G_Cg = np.array([0.75, 0.25, 0.0])
         npt.assert_array_almost_equal(Cpp_G_Cg, expected_Cpp_G_Cg)
 
@@ -260,8 +259,8 @@ class TestPanel(unittest.TestCase):
 
         aspect_ratio = panel.aspect_ratio
 
-        # For basic panel: span = 0.5 m, chord = 1.0 m
-        # Aspect ratio = span / chord = 0.5
+        # For the basic Panel: span = 0.5 m, chord = 1.0 m. Aspect ratio = span / chord
+        # = 0.5.
         expected_aspect_ratio = 0.5
         self.assertAlmostEqual(aspect_ratio, expected_aspect_ratio, places=10)
 
@@ -295,8 +294,7 @@ class TestPanel(unittest.TestCase):
 
         aspect_ratio = panel.aspect_ratio
 
-        # For a panel with span = 4.0 m, chord = 1.0 m
-        # Aspect ratio = 4.0
+        # For a Panel with span = 4.0 m, chord = 1.0 m. Aspect ratio = 4.0.
         expected_aspect_ratio = 4.0
         self.assertAlmostEqual(aspect_ratio, expected_aspect_ratio, places=10)
 
@@ -428,8 +426,8 @@ class TestPanelGP1Properties(unittest.TestCase):
 
         unitNormal_GP1 = panel.unitNormal_GP1
 
-        # Should be same as local since it's a unit vector (rotation invariant for
-        # pure translation)
+        # Should be same as local since it's a unit vector (rotation invariant for pure
+        # translation).
         expected_unitNormal_GP1 = np.array([0.0, 0.0, 1.0])
         npt.assert_array_almost_equal(unitNormal_GP1, expected_unitNormal_GP1)
 
@@ -446,26 +444,27 @@ class TestPanelGP1Properties(unittest.TestCase):
         """Test GP1 properties when global position includes rotation effect."""
         panel = panel_fixtures.make_basic_panel_fixture()
 
-        # Simulate a -90 degree rotation about z-axis in global coordinates
-        # Rotation matrix for -90 degrees about z: [[0, 1, 0], [-1, 0, 0], [0, 0, 1]]
-        # Original: Frpp = [0, 0.5, 0] -> [0.5, 0, 0]
-        # Original: Flpp = [0, 0, 0] -> [0, 0, 0]
-        # Original: Blpp = [1, 0, 0] -> [0, -1, 0]
-        # Original: Brpp = [1, 0.5, 0] -> [0.5, -1, 0]
+        # Simulate a -90 degree rotation about the z axis in global coordinates. The
+        # rotation matrix for -90 degrees about the z axis is [[0, 1, 0], [-1, 0, 0],
+        # [0, 0, 1]]. The original Frpp is [0.0, 0.5, 0.0], which maps to [0.5, 0.0,
+        # 0.0]. The original Flpp is [0.0, 0.0, 0.0], which maps to [0.0, 0.0, 0.0]. The
+        # original Blpp is [1.0, 0.0, 0.0], which maps to [0.0, -1.0, 0.0]. The original
+        # Brpp is [1, 0.5, 0], which maps to [0.5, -1, 0].
+        # octowrap: on
         panel.Frpp_GP1_CgP1 = np.array([0.5, 0.0, 0.0])
         panel.Flpp_GP1_CgP1 = np.array([0.0, 0.0, 0.0])
         panel.Blpp_GP1_CgP1 = np.array([0.0, -1.0, 0.0])
         panel.Brpp_GP1_CgP1 = np.array([0.5, -1.0, 0.0])
 
-        # The leg vectors should now be rotated
-        # Original rightLeg_G = Frpp - Brpp = [0, 0.5, 0] - [1, 0.5, 0] = [-1, 0, 0]
-        # After -90 degree rotation: [0, 1, 0]
+        # The leg vectors should now be rotated. The original rightLeg_G is Frpp - Brpp
+        # = [0.0, 0.5, 0.0] - [1.0, 0.5, 0.0] = [-1.0, 0.0, 0.0]. After the -90 degree
+        # rotation, this becomes [0.0, 1.0, 0.0].
         rightLeg_GP1 = panel.rightLeg_GP1
         expected_rightLeg_GP1 = np.array([0.0, 1.0, 0.0])
         npt.assert_array_almost_equal(rightLeg_GP1, expected_rightLeg_GP1)
 
-        # Unit normal should still point in +z direction for flat panel (rotation
-        # around z axis preserves the z component of vectors in the xy plane)
+        # Unit normal should still point in +z direction for a flat Panel (rotation
+        # around the z axis preserves the z component of vectors in the xy plane).
         unitNormal_GP1 = panel.unitNormal_GP1
         expected_unitNormal_GP1 = np.array([0.0, 0.0, 1.0])
         npt.assert_array_almost_equal(unitNormal_GP1, expected_unitNormal_GP1)

--- a/tests/unit/test_problems.py
+++ b/tests/unit/test_problems.py
@@ -287,8 +287,7 @@ class TestUnsteadyProblem(unittest.TestCase):
 
     def test_initialization_only_final_results_true(self):
         """Test UnsteadyProblem initialization with only_final_results=True."""
-        # Test that UnsteadyProblem with only_final_results=True initializes
-        # correctly.
+        # Test that UnsteadyProblem with only_final_results=True initializes correctly.
         self.assertIsInstance(
             self.only_final_results_unsteady_problem,
             ps.problems.UnsteadyProblem,
@@ -366,8 +365,8 @@ class TestUnsteadyProblem(unittest.TestCase):
 
     def test_steady_problems_list_airplanes(self):
         """Test that each SteadyProblem has correct Airplanes."""
-        # Each SteadyProblem should have the same number of Airplanes as the
-        # Movement has AirplaneMovements.
+        # Each SteadyProblem should have the same number of Airplanes as the Movement
+        # has AirplaneMovements.
         num_airplanes = len(self.basic_unsteady_problem.movement.airplane_movements)
 
         for steady_problem in self.basic_unsteady_problem.steady_problems:

--- a/tests/unit/test_transformations.py
+++ b/tests/unit/test_transformations.py
@@ -959,17 +959,14 @@ class TestComposeTPas(unittest.TestCase):
         """
         # Goal: c_B_b, "the position of point c (in B axes, relative to point b)"
 
-        # Given:
-        # The position of point c (in A axes, relative to point a)
+        # Given: The position of point c (in A axes, relative to point a).
         c_A_a = np.array([0.5, -1.0, 2.0])
 
-        # Given:
-        # The position of point b (in A axes, relative to point a)
+        # Given: The position of point b (in A axes, relative to point a).
         b_A_a = np.array([1.0, 2.0, 0.5])
 
-        # Given:
-        # The orientation of B axes relative to A axes using an intrinsic zy'x"
-        # rotation
+        # Given: The orientation of B axes relative to A axes using an intrinsic zy'x"
+        # rotation.
         angles_A_to_B_izyx = np.array([0.0, 0.0, 90.0])
 
         T_rot_pas_A_to_B = _transformations.generate_rot_T(

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -70,8 +70,8 @@ class TestWing(unittest.TestCase):
 
     def test_symmetry_parameter_validation(self):
         """Test symmetry parameter validation logic."""
-        # Test that symmetric and mirror_only cannot both be True
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Test that symmetric and mirror_only cannot both be True. Create fresh fixtures
+        # since WingCrossSections can only be validated once.
         root_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
         tip_wcs = geometry_fixtures.make_tip_wing_cross_section_fixture()
         with self.assertRaises(ValueError):
@@ -359,8 +359,8 @@ class TestWing(unittest.TestCase):
 
         for spacing in spacing_options:
             with self.subTest(spacing=spacing):
-                # Create fresh fixtures for each iteration since WingCrossSections
-                # can only be validated once
+                # Create fresh fixtures for each iteration since WingCrossSections can
+                # only be validated once.
                 root_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
                 tip_wcs = geometry_fixtures.make_tip_wing_cross_section_fixture()
                 wing = ps.geometry.wing.Wing(
@@ -375,8 +375,8 @@ class TestWing(unittest.TestCase):
 
         for count in panel_counts:
             with self.subTest(count=count):
-                # Create fresh fixtures for each iteration since WingCrossSections
-                # can only be validated once
+                # Create fresh fixtures for each iteration since WingCrossSections can
+                # only be validated once.
                 root_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
                 tip_wcs = geometry_fixtures.make_tip_wing_cross_section_fixture()
                 wing = ps.geometry.wing.Wing(
@@ -387,8 +387,8 @@ class TestWing(unittest.TestCase):
 
     def test_wing_parameter_validation(self):
         """Test parameter validation for Wing initialization."""
-        # Test invalid Ler position
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Test invalid Ler position. Create fresh fixtures since WingCrossSections can
+        # only be validated once.
         root_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
         tip_wcs = geometry_fixtures.make_tip_wing_cross_section_fixture()
         with self.assertRaises(TypeError):
@@ -455,8 +455,8 @@ class TestWing(unittest.TestCase):
 
     def test_wing_name_validation(self):
         """Test Wing name parameter validation."""
-        # Test valid string name
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Test valid string name. Create fresh fixtures since WingCrossSections can only
+        # be validated once.
         root_wcs = geometry_fixtures.make_root_wing_cross_section_fixture()
         tip_wcs = geometry_fixtures.make_tip_wing_cross_section_fixture()
         wing = ps.geometry.wing.Wing(
@@ -515,13 +515,15 @@ class TestWing(unittest.TestCase):
 
     def test_invalid_middle_wing_cross_section_raises_error(self):
         """Test that Wing with invalid middle WingCrossSection raises ValueError."""
-        # Test that Wing with middle WingCrossSection having num_spanwise_panels=None fails
+        # Test that Wing with middle WingCrossSection having num_spanwise_panels=None
+        # fails.
         with self.assertRaises(ValueError):
             geometry_fixtures.make_invalid_three_section_wing_fixture()
 
     def test_invalid_root_wing_cross_section_raises_error(self):
         """Test that Wing with invalid root WingCrossSection raises ValueError."""
-        # Test that Wing with root WingCrossSection having num_spanwise_panels=None fails
+        # Test that Wing with root WingCrossSection having num_spanwise_panels=None
+        # fails.
         with self.assertRaises(ValueError):
             geometry_fixtures.make_invalid_root_wing_fixture()
 
@@ -616,8 +618,8 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected projected area: 4.5 square meters
-        # Trapezoid: (chord_root + chord_tip) / 2 * span = (2.0 + 1.0) / 2 * 3.0 = 4.5
+        # Expected projected area: 4.5 square meters. Trapezoid: (chord_root +
+        # chord_tip) / 2.0 * span = (2.0 + 1.0) / 2.0 * 3.0 = 4.5.
         expected_area = 4.5
         actual_area = wing.projected_area
 
@@ -630,8 +632,8 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
         wing.generate_mesh(4)
 
-        # Expected projected area: 7.5 square meters
-        # Rectangle: chord * span = 1.5 * 5.0 = 7.5
+        # Expected projected area: 7.5 square meters. Rectangle: chord * span = 1.5 *
+        # 5.0 = 7.5.
         expected_area = 7.5
         actual_area = wing.projected_area
 
@@ -643,10 +645,9 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected projected area: 8.0 square meters
-        # Section 1 (root to middle): (3.0 + 2.0) / 2 * 2.0 = 5.0
-        # Section 2 (middle to tip): (2.0 + 1.0) / 2 * 2.0 = 3.0
-        # Total: 5.0 + 3.0 = 8.0
+        # Expected projected area: 8.0 square meters. Section 1 (root to middle): (3.0 +
+        # 2.0) / 2.0 * 2.0 = 5.0. Section 2 (middle to tip): (2.0 + 1.0) / 2.0 * 2.0 =
+        # 3.0. Total: 5.0 + 3.0 = 8.0.
         expected_area = 8.0
         actual_area = wing.projected_area
 
@@ -892,7 +893,8 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_dihedral_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 3.0 meters (dihedral in z direction does not affect y extent in wing axes)
+        # Expected span: 3.0 meters (dihedral in z direction does not affect y extent in
+        # wing axes).
         expected_span = 3.0
 
         actual_span = wing.span
@@ -950,12 +952,12 @@ class TestWing(unittest.TestCase):
         average_aspect_ratio = wing.average_panel_aspect_ratio
         self.assertIsNotNone(average_aspect_ratio)
 
-        # For a rectangular wing with uniform spacing:
-        # Panel chord = wing_chord / num_chordwise_panels = 1.0 / 4 = 0.25
-        # Panel span = wing_span / num_spanwise_panels = 2.0 / 8 = 0.25
-        # Expected aspect ratio ~ 1.0 for roughly square panels.
-        # This is an approximate check since actual Panel aspect ratios depend on
-        # the meshing algorithm's implementation details.
+        # For a rectangular Wing with uniform spacing: Panel chord = wing_chord /
+        # num_chordwise_panels = 1.0 / 4 = 0.25 Panel span = wing_span /
+        # num_spanwise_panels = 2.0 / 8 = 0.25 The expected aspect ratio is
+        # approximately 1.0 for roughly square Panels. This is an approximate check
+        # since actual Panel aspect ratios depend on the meshing algorithm's
+        # implementation details.
         self.assertGreater(average_aspect_ratio, 0.0)
         self.assertLess(average_aspect_ratio, 100.0)
 

--- a/validation/validation_study.py
+++ b/validation/validation_study.py
@@ -30,16 +30,16 @@ chord = 0.072
 # Set the given forward flight velocity in meters per second.
 validation_velocity = 2.9
 
-# Set the given angle of attack in degrees. Note: If you analyze a different
-# operating point where this is not zero, you need to modify the code to rotate the
-# experimental lift into the wind axes.
+# Set the given angle of attack in degrees. Note: If you analyze a different operating
+# point where this is not zero, you need to modify the code to rotate the experimental
+# lift into the wind axes.
 validation_alpha = 0
 
 # Set the given flapping frequency in Hertz.
 validation_flapping_frequency = 3.3
 
-# This wing planform has a rounded tip so the outermost WingCrossSection needs to
-# be inset some amount. This value is in meters.
+# This wing planform has a rounded tip so the outermost WingCrossSection needs to be
+# inset some amount. This value is in meters.
 tip_inset = 0.005
 
 # A similar constraint is that Ptera Software requires symmetric, flapping Wings have
@@ -47,11 +47,11 @@ tip_inset = 0.005
 wing_midline_offset = 0.005
 
 # Import the extracted points from the paper's diagram of the planform. The resulting
-# array is of the form [spanwise coordinate, chordwise coordinate], and is ordered
-# from the leading edge root, to the tip, to the trailing edge root. The origin is
-# the trailing edge root point. The positive spanwise axis extends from root to tip
-# and the positive chordwise axis from trailing edge to leading edge. The values
-# are in millimeters. I'll call this the Yeo axis system.
+# array is of the form [spanwise coordinate, chordwise coordinate], and is ordered from
+# the leading edge root, to the tip, to the trailing edge root. The origin is the
+# trailing edge root point. The positive spanwise axis extends from root to tip and the
+# positive chordwise axis from trailing edge to leading edge. The values are in
+# millimeters. I'll call this the Yeo axis system.
 stackPlanformPointsMm_Yeo_Ter = np.genfromtxt(
     "extracted_planform_coordinates.csv", delimiter=","
 )
@@ -69,18 +69,18 @@ stackPlanformPoints_YeoXReversed_Ler = stackPlanformPoints_Yeo_Ler * np.array(
     [1, -1], dtype=float
 )
 
-# Swap the axes to the form [chordwise coordinate, spanwise coordinate]. The
-# coordinates are now in wing axes projected onto its xy-plane, and relative to the
-# leading edge root point.
+# Swap the axes to the form [chordwise coordinate, spanwise coordinate]. The coordinates
+# are now in wing axes projected onto its xy-plane, and relative to the leading edge
+# root point.
 stackPlanformPointsXY_Wn_Ler = stackPlanformPoints_YeoXReversed_Ler[:, [1, 0]]
 
 # Find the index of the point where the planform point's x component equals the half
 # span.
 tip_index = np.where(stackPlanformPointsXY_Wn_Ler[:, 1] == half_span)[0][0]
 
-# Using the tip index, split the points into two ndarrays of leading and trailing
-# edge points (in wing axes projected onto its xy-plane, relative to the leading edge
-# root point).
+# Using the tip index, split the points into two ndarrays of leading and trailing edge
+# points (in wing axes projected onto its xy-plane, relative to the leading edge root
+# point).
 stackLeadingPointsXY_Wn_Ler = stackPlanformPointsXY_Wn_Ler[:tip_index, :]
 stackTrailingPointsXY_Wn_Ler = np.flip(
     stackPlanformPointsXY_Wn_Ler[tip_index:, :], axis=0
@@ -97,16 +97,16 @@ num_chordwise_panels = 5
 # WingCrossSections per Wing half. The converged result is 18 spanwise sections.
 num_spanwise_sections = 18
 
-# Set the chordwise spacing scheme for the Panels. This is set to uniform,
-# as is standard for UVLM simulations.
+# Set the chordwise spacing scheme for the Panels. This is set to uniform, as is
+# standard for UVLM simulations.
 chordwise_spacing = "uniform"
 
 # Calculate the spanwise distance between the WingCrossSections.
 spanwise_step = (half_span - tip_inset) / num_spanwise_sections
 
 # Define four ndarrays to hold the leading and trailing points of each section's left
-# and right WingCrossSections (in wing axes projected onto its xy-plane, relative to
-# the leading edge root point).
+# and right WingCrossSections (in wing axes projected onto its xy plane, relative to the
+# leading edge root point).
 stackLeftLpsXY_Wn_Ler = np.zeros((num_spanwise_sections, 2), dtype=float)
 stackRightLpsXY_Wn_Ler = np.zeros((num_spanwise_sections, 2), dtype=float)
 stackLeftTpsXY_Wn_Ler = np.zeros((num_spanwise_sections, 2), dtype=float)
@@ -123,8 +123,8 @@ for spanwise_loc in range(num_spanwise_sections):
     stackRightLpsXY_Wn_Ler[spanwise_loc, 1] = (spanwise_loc + 1) * spanwise_step
     stackRightTpsXY_Wn_Ler[spanwise_loc, 1] = (spanwise_loc + 1) * spanwise_step
 
-    # Interpolate between the points to find their x components (in wing axes
-    # projected onto its xy-plane, relative to the leading edge root point).
+    # Interpolate between the points to find their x components (in wing axes projected
+    # onto its xy plane, relative to the leading edge root point).
     stackLeftLpsXY_Wn_Ler[spanwise_loc, 0] = np.interp(
         spanwise_loc * spanwise_step,
         stackLeadingPointsXY_Wn_Ler[:, 1],
@@ -179,8 +179,8 @@ for i in range(num_spanwise_sections):
     # Append this WingCrossSection to the list of WingCrossSections.
     validation_airplane_wing_cross_sections.append(this_wing_cross_section)
 
-    # If this is the last section, also create the right WingCrossSection and append
-    # it to the list.
+    # If this is the last section, also create the right WingCrossSection and append it
+    # to the list.
     if i == num_spanwise_sections - 1:
         thisLpY_Wcsp_Lpp = spanwise_step
         thisLpX_Wcsp_Lpp = (
@@ -374,8 +374,8 @@ del validation_airplane
 del main_wing_movement
 del reflected_main_wing_movement
 
-# Define an OperatingPoint and OperatingPointMovement corresponding to the conditions
-# of the validation study.
+# Define an OperatingPoint and OperatingPointMovement corresponding to the conditions of
+# the validation study.
 validation_operating_point = ps.operating_point.OperatingPoint(
     vCg__E=validation_velocity, alpha=validation_alpha
 )
@@ -412,8 +412,8 @@ validation_solver = (
 # Delete the extraneous pointer.
 del validation_problem
 
-# Define the position of the points of interest and the area of their rectangles.
-# These values were extracted by digitizing the figures in Yeo et al., 2011.
+# Define the position of the points of interest and the area of their rectangles. These
+# values were extracted by digitizing the figures in Yeo et al., 2011.
 blueTrailingPointsXY_Wn_Ler = [0.060, 0.036]
 blue_trailing_area = 0.072 * 0.024
 blueMiddlePointsXY_Wn_Ler = [0.036, 0.036]
@@ -448,8 +448,8 @@ times = np.linspace(
     endpoint=False,
 )
 
-# Discretize the time period of the final flap analyzed into 100 steps. Store this to
-# a ndarray.
+# Discretize the time period of the final flap analyzed into 100 steps. Store this to a
+# ndarray.
 final_flap_times = np.linspace(
     (num_flaps - 1) / validation_flapping_frequency,
     num_flaps / validation_flapping_frequency,
@@ -460,10 +460,9 @@ final_flap_times = np.linspace(
 # Discretize the normalized flap cycle times into 100 steps. Store this to a ndarray.
 normalized_times = np.linspace(0, 1, 100, endpoint=False)
 
-# Pull the experimental pressure vs. time histories from the digitized data. These
-# data sets are stored in CSV files in the same directory as this script. The
-# pressure units used are inAq and time units are normalized flap cycle times from 0
-# to 1.
+# Pull the experimental pressure vs. time histories from the digitized data. These data
+# sets are stored in CSV files in the same directory as this script. The pressure units
+# used are inAq and time units are normalized flap cycle times from 0 to 1.
 exp_blue_trailing_point_pressures = np.genfromtxt(
     "blue_trailing_point_experimental_pressures.csv", delimiter=","
 )
@@ -492,8 +491,8 @@ exp_green_leading_point_pressures = np.genfromtxt(
     "green_leading_point_experimental_pressures.csv", delimiter=","
 )
 
-# Interpolate the experimental pressure data to ensure that they all reference the
-# same normalized timescale.
+# Interpolate the experimental pressure data to ensure that they all reference the same
+# normalized timescale.
 exp_blue_trailing_point_pressures_norm = np.interp(
     normalized_times,
     exp_blue_trailing_point_pressures[:, 0],
@@ -569,8 +568,8 @@ exp_green_leading_normal_forces = (
     248.84 * exp_green_leading_point_pressures_norm * green_leading_area
 )
 
-# Convert each experimental panel's normal force time history to a time history of
-# the force's geometry axes' z-component.
+# Convert each experimental panel's normal force time history to a time history of the
+# force's z component in geometry axes.
 stackExpBlueTrailingForcesZ_G = exp_blue_trailing_normal_forces * np.cos(
     time_normalized_validation_geometry_sweep_function_rad(normalized_times)
 )
@@ -599,9 +598,9 @@ stackExpGreenLeadingForcesZ_G = exp_green_leading_normal_forces * np.cos(
     time_normalized_validation_geometry_sweep_function_rad(normalized_times)
 )
 
-# Calculate the net experimental force's geometry axes' z-component. This is
-# multiplied by two because the experimental panels only cover one of the symmetric
-# wing halves.
+# Calculate the net experimental force's z component in geometry axes. This is
+# multiplied by two because the experimental panels only cover one of the symmetric wing
+# halves.
 stackExpNetForcesZ_G = 2 * (
     stackExpBlueTrailingForcesZ_G
     + stackExpBlueMiddleForcesZ_G
@@ -617,9 +616,9 @@ stackExpNetForcesZ_G = 2 * (
 # Initialize a ndarray to hold the net force's wind axes' z-component.
 stackExpNetForcesZ_W = np.zeros(stackExpNetForcesZ_G.size, dtype=float)
 
-# Get the passive transformation matrix which maps in homogeneous coordinates from
-# the first Airplane's geometry axes relative to the first Airplane's CG to wind
-# axes relative to the first Airplane's CG.
+# Get the passive transformation matrix which maps in homogeneous coordinates from the
+# first Airplane's geometry axes relative to the first Airplane's CG to wind axes
+# relative to the first Airplane's CG.
 T_pas_GP1_CgP1_to_W_CgP1 = validation_operating_point.T_pas_GP1_CgP1_to_W_CgP1
 
 # Delete the extraneous pointer.
@@ -680,10 +679,10 @@ lift_axes.set_facecolor(figure_background_color)
 
 marker_spacing = 1.0 / num_markers
 
-# Plot the simulated lift values. The x-axis is set to the normalized times,
-# which may seem odd because we just interpolated to get them in terms of the
-# normalized final flap times. But, they are discretized in exactly the same way as
-# the normalized times, just horizontally shifted.
+# Plot the simulated lift values. The x axis is set to the normalized times, which may
+# seem odd because we just interpolated to get them in terms of the normalized final
+# flap times. But, they are discretized in exactly the same way as the normalized times,
+# just horizontally shifted.
 lift_axes.plot(
     normalized_times,
     final_flap_sim_lifts,
@@ -738,9 +737,9 @@ del stackSimForces_W
 del step
 
 # Calculate the lift mean absolute error (MAE). The experimental and simulated lift
-# comparison here is valid because, due to the interpolation steps, the experimental
-# and simulated lifts time histories are discretized so that they are with respect to
-# the same timescale.
+# comparison here is valid because, due to the interpolation steps, the experimental and
+# simulated lifts time histories are discretized so that they are with respect to the
+# same timescale.
 lift_absolute_errors = np.abs(final_flap_sim_lifts - exp_lifts)
 lift_mean_absolute_error = np.mean(lift_absolute_errors)
 


### PR DESCRIPTION
# Description

This adds `octowrap` as a development tool that reflows Python comments to the project's 88-character line length and applies it across the entire codebase. `octowrap` is wired in as a `local` `pre-commit` hook configured to run in `--check` mode, backed by a new `octowrap` GitHub Actions workflow, and pinned as a dev dependency. The bulk of the diff is the one-time reflow of existing comments in the `pterasoftware` package, the `tests` package, the `examples` scripts, `docs/website/conf.py`, and the `validation` and `scripts` directories. There aren't any code behavior changes. The change also codifies several new prose and comment conventions in `docs/WRITING_STYLE.md`.

## Motivation

Comment line wrapping was previously done by hand, so line lengths drifted and reflowing a comment after an edit was tedious and inconsistent. `black` formats code but deliberately leaves comments untouched, so nothing enforced a consistent comment width. Adopting `octowrap` makes comment wrapping automatic and reproducible, gives contributors the same local and CI enforcement they already get for `black`, `isort`, and the other hooks, and lets the one-time reflow bring the existing tree into a single consistent style. The reflow is purely textual, so runtime behavior and numerical results are unchanged.

## Relevant Issues

None.

## Changes

* Added an `octowrap` `local` hook to `.pre-commit-config.yaml` that runs `octowrap --check` on Python files, pinned via `additional_dependencies` to `octowrap==0.6.2`, with `require_serial: true` so the "Run: octowrap -i ." hint prints exactly once instead of once per parallel batch.
* Added the `.github/workflows/octowrap.yml` workflow, which runs on pull requests and pushes to `main`, checks out with `persist-credentials: false`, sets up Python 3.13, installs `pre-commit`, and runs `pre-commit run --all-files octowrap`.
* Added a `[tool.octowrap]` configuration table to `pyproject.toml` setting `line-length = 88`, `recursive`, `inline`, and `list-wrap` on, `todo` handling for `TODO:`, `FIXME:`, and `TEST:` patterns, and `extend-exclude` for the `private`, `.venv-wsl`, and `experimental` directories.
* Added `octowrap == 0.6.2` to `requirements_dev.txt`.
* Reflowed comments throughout the `pterasoftware` package, including large touch-ups in `unsteady_ring_vortex_lattice_method.py`, `output.py`, `steady_ring_vortex_lattice_method.py`, `problems.py`, `convergence.py`, and the `geometry` and `movements` subpackages.
* Reflowed comments across the `tests` package, the `examples` scripts, the `validation` and `scripts` directories, and `docs/website/conf.py`, with no functional changes.
* Updated `docs/WRITING_STYLE.md` with new conventions: lowercase "strip leading edge point" in prose, mandatory "V-tail" spelling, no semicolons in prose, spacing rules for division, equals signs, tuples, numerals and units, trailing ".0" for float-valued numerals, colon capitalization rules, and a stricter definition of a complete-sentence comment. Also reorganized its sections.

## Dependency Updates

* `octowrap == 0.6.2` added as a development dependency in `requirements_dev.txt` and pinned in the `pre-commit` hook's `additional_dependencies`.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
