### PR TITLE
Prepare the v5.1.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use Ptera Software in your research, please cite it using the metadata in this file."
+title: Ptera Software
+type: software
+authors:
+  - family-names: Urban
+    given-names: Cameron
+    email: camerongurban@gmail.com
+  - name: "The Ptera Software contributors"
+repository-code: "https://github.com/camUrban/PteraSoftware"
+url: "https://docs.pterasoftware.com"
+license: MIT
+version: 5.1.0
+date-released: "2026-07-14"
+# This is the Zenodo concept DOI. It always resolves to the latest release, so it is
+# the right identifier for a citation that should follow the project across versions.
+# Do not replace it with a per-version DOI.
+doi: 10.5281/zenodo.19229119

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ Requires Python 3.11, but active development is done in 3.13
 - `.gitignore`: Git ignore file
 - `.pre-commit-config.yaml`: Pre-commit configuration file
 - `.readthedocs.yaml`: Read the Docs build configuration
+- `CITATION.cff`: Citation metadata for the project (powers GitHub's cite-this-repository feature and the Zenodo release record)
 - `codecov.yml`: Codecov configuration for test coverage reporting
 - `CONTRIBUTING.md`: Contribution guidelines for developers
 - `MANIFEST.in`: Manifest file for packaging

--- a/pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/_coupled_unsteady_ring_vortex_lattice_method.py
@@ -42,6 +42,12 @@ class CoupledUnsteadyRingVortexLatticeMethodSolver(
 
     __slots__ = ()
 
+    # _CoupledUnsteadyProblem is deliberately given a private class name inside the
+    # public problems module so it stays out of the user-facing API. Referencing it from
+    # this in-package solver is the intended design, so silence PyCharm's cross-module
+    # protected-member inspection on the signature and the isinstance guard below.
+
+    # noinspection PyProtectedMember
     def __init__(self, unsteady_problem: problems._CoupledUnsteadyProblem) -> None:
         """The initialization method.
 
@@ -52,6 +58,10 @@ class CoupledUnsteadyRingVortexLatticeMethodSolver(
             raise TypeError("unsteady_problem must be a _CoupledUnsteadyProblem.")
         super().__init__(unsteady_problem)
 
+    # As in __init__, the reference to the deliberately private _CoupledUnsteadyProblem
+    # is by design; silence the cross-module protected-member inspection.
+
+    # noinspection PyProtectedMember
     @property
     def _coupled_unsteady_problem(self) -> problems._CoupledUnsteadyProblem:
         """Type narrowed view of the inherited unsteady_problem attribute.

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -438,6 +438,9 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
     I_BP1_CgP1: The inertia matrix of the Airplane (in the first Airplane's body axes,
     relative to the first Airplane's CG) in kilogram square meters.
 
+    k_max: The maximum number of strongly coupled sub-iterations per free-flight time
+    step.
+
     external_loads_fn: A callable that computes additional forces and moments to apply
     to the Airplane during the simulation, or None.
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = PteraSoftware
-version = 5.0.0
+version = 5.1.0
 author = Cameron Urban
 author_email = camerongurban@gmail.com
 license = MIT


### PR DESCRIPTION
# Description

This pull request collects the final in-repo release-preparation work for v5.1.0: the package version bump, a new citation metadata file, and two small code-hygiene fixes swept in along the way. Every change is backward compatible. The only behavioral surface touched is package metadata, and the code changes are limited to a docstring line and IDE-directive comments.

## Motivation

With the v5.1.0 feature and cleanup work already merged to `main`, the release is ready to tag, and this gathers the last pieces that belong in the repository before the tag. The `CITATION.cff` gives the project a deliberate, curated author list: without it, the Zenodo release record auto-generates authorship from the GitHub contributor graph ordered by commit count, which does not reflect actual authorship. The remaining two changes resolve small inconsistencies noticed during the prep pass: the `k_max` property was missing from `FreeFlightUnsteadyProblem`'s class docstring listing, and the coupled solver drew IDE protected-member warnings for referencing an intentionally private class.

## Relevant Issues

None.

## Changes

* Bumped `version` in `setup.cfg` from `5.0.0` to `5.1.0`. A full sweep confirmed this is the single source of truth for the package version, with no version literal in `pyproject.toml`, any `__init__.py`, or the Sphinx configuration.
* Added a `CITATION.cff` at the repository root. It credits `Cameron Urban` and a `The Ptera Software contributors` entity, and targets the Zenodo concept DOI `10.5281/zenodo.19229119` (the same DOI the `README.md` badge references) so a citation follows the project across releases rather than pinning to one version, with a comment guarding against a later swap to a per-version DOI.
* Registered `CITATION.cff` in the `CLAUDE.md` file registry.
* Added the `k_max` property to the class docstring listing of `FreeFlightUnsteadyProblem` in `problems.py`, which had omitted it.
* Suppressed the IDE protected-member inspection on the four `_CoupledUnsteadyProblem` references in `_coupled_unsteady_ring_vortex_lattice_method.py` (the `__init__` annotation, the `isinstance` guard, the property return annotation, and the `cast`) with two method-level `# noinspection PyProtectedMember` pragmas, each carrying an inline rationale. These references are the intended split-naming design, and the inspection does not distinguish intra-package private references.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
