### PR TITLE
Make CITATION.cff version-agnostic

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,6 @@ authors:
 repository-code: "https://github.com/camUrban/PteraSoftware"
 url: "https://docs.pterasoftware.com"
 license: MIT
-version: 5.1.0
-date-released: "2026-07-14"
 # This is the Zenodo concept DOI. It always resolves to the latest release, so it is
 # the right identifier for a citation that should follow the project across versions.
 # Do not replace it with a per-version DOI.


### PR DESCRIPTION
# Description

Removes the `version` and `date-released` fields from `CITATION.cff` so the file matches its concept DOI, which spans all releases.

## Motivation

Pinning a version next to a version-agnostic concept DOI was contradictory, duplicated the version outside `setup.cfg`, and forced a per-release edit. Zenodo takes the record's version from the release tag regardless.

## Relevant Issues

None.

## Changes

* Deleted the `version` and `date-released` lines from `CITATION.cff`.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
