### PR TITLE
Capitalize remaining lowercase point IDs

### DIFF
--- a/pterasoftware/geometry/airfoil.py
+++ b/pterasoftware/geometry/airfoil.py
@@ -322,22 +322,22 @@ class Airfoil:
         flippedUpperOutlineHingePoint_A_Lp = preHingeFlippedUpperOutline_A_Lp[-1, :]
         lowerOutlineHingePoint_A_Lp = preHingeLowerOutline_A_Lp[-1, :]
 
-        flippedUpperOutlineHingePoint_Wcs_lp = np.hstack(
+        flippedUpperOutlineHingePoint_Wcs_Lp = np.hstack(
             [
                 flippedUpperOutlineHingePoint_A_Lp[0],
                 0.0,
                 flippedUpperOutlineHingePoint_A_Lp[1],
             ]
         )
-        lowerOutlineHingePoint_Wcs_lp = np.hstack(
+        lowerOutlineHingePoint_Wcs_Lp = np.hstack(
             [lowerOutlineHingePoint_A_Lp[0], 0.0, lowerOutlineHingePoint_A_Lp[1]]
         )
 
         flippedUpperOutlineToOrigin_T_act = _transformations.generate_trans_T(
-            -flippedUpperOutlineHingePoint_Wcs_lp, passive=False
+            -flippedUpperOutlineHingePoint_Wcs_Lp, passive=False
         )
         lowerOutlineToOrigin_T_act = _transformations.generate_trans_T(
-            -lowerOutlineHingePoint_Wcs_lp, passive=False
+            -lowerOutlineHingePoint_Wcs_Lp, passive=False
         )
 
         # Make the active rotational homogeneous transformation matrix that deflects the
@@ -356,10 +356,10 @@ class Airfoil:
         )
 
         flippedUpperOutlineBack_T_act = _transformations.generate_trans_T(
-            flippedUpperOutlineHingePoint_Wcs_lp, passive=False
+            flippedUpperOutlineHingePoint_Wcs_Lp, passive=False
         )
         lowerOutlineBack_T_act = _transformations.generate_trans_T(
-            lowerOutlineHingePoint_Wcs_lp, passive=False
+            lowerOutlineHingePoint_Wcs_Lp, passive=False
         )
 
         postHingeFlippedUpperOutline_T_act = _transformations.compose_T_act(
@@ -371,14 +371,14 @@ class Airfoil:
             lowerOutlineToOrigin_T_act, deflect_T_act, lowerOutlineBack_T_act
         )
 
-        postHingeFlippedUpperOutline_Wcs_lp = np.column_stack(
+        postHingeFlippedUpperOutline_Wcs_Lp = np.column_stack(
             [
                 postHingeFlippedUpperOutline_A_Lp[:, 0],
                 np.zeros_like(postHingeFlippedUpperOutline_A_Lp[:, 0]),
                 postHingeFlippedUpperOutline_A_Lp[:, 1],
             ]
         )
-        postHingeLowerOutline_Wcs_lp = np.column_stack(
+        postHingeLowerOutline_Wcs_Lp = np.column_stack(
             [
                 postHingeLowerOutline_A_Lp[:, 0],
                 np.zeros_like(postHingeLowerOutline_A_Lp[:, 0]),
@@ -389,13 +389,13 @@ class Airfoil:
         flappedPostHingeFlippedUpperOutline_A_Lp = (
             _transformations.apply_T_to_vectors(
                 postHingeFlippedUpperOutline_T_act,
-                postHingeFlippedUpperOutline_Wcs_lp,
+                postHingeFlippedUpperOutline_Wcs_Lp,
                 is_position=True,
             )
         )[:, [0, 2]]
         flappedPostHingeLowerOutline_A_Lp = _transformations.apply_T_to_vectors(
             postHingeLowerOutline_T_act,
-            postHingeLowerOutline_Wcs_lp,
+            postHingeLowerOutline_Wcs_Lp,
             is_position=True,
         )[:, [0, 2]]
 
@@ -503,8 +503,8 @@ class Airfoil:
             outlineYMin_A_Lp - y_padding, outlineYMax_A_Lp + y_padding
         )
 
-        airfoil_axes.set_xlabel("AX_lp")
-        airfoil_axes.set_ylabel("AY_lp")
+        airfoil_axes.set_xlabel("AX_Lp")
+        airfoil_axes.set_ylabel("AY_Lp")
         airfoil_axes.set_title(f"{self.name} Airfoil")
         airfoil_axes.legend(
             ["Outline", "Mean Camber Line (MCL)"],

--- a/pterasoftware/geometry/airplane.py
+++ b/pterasoftware/geometry/airplane.py
@@ -404,10 +404,10 @@ class Airplane:
             # generate_trans_T with passive=True expects the `translations` parameter to
             # be the position of the target reference point (CgP1) relative to the
             # source reference point (Cg). Using the notation from
-            # AXES_POINTS_AND_FRAMES.md: translations=CgP1_G_Cg. However, we have
+            # AXES_POINTS_AND_FRAMES.md: translations = CgP1_G_Cg. However, we have
             # Cg_GP1_CgP1 (position of Cg, in GP1 axes, relative to CgP1). Since
             # geometry axes G and GP1 are parallel (pure translation, no rotation):
-            # CgP1_G_Cg=-Cg_GP1_CgP1.
+            # CgP1_G_Cg = -Cg_GP1_CgP1.
             self._T_pas_G_Cg_to_GP1_CgP1 = _transformations.generate_trans_T(
                 translations=-self._Cg_GP1_CgP1, passive=True
             )
@@ -489,7 +489,7 @@ class Airplane:
         # Convert the Panel vertices and faces to PolyData.
         panel_surfaces = pv.PolyData(panel_vertices, panel_faces)
 
-        # Add the Panels to the plotter
+        # Add the Panels to the plotter.
         plotter.add_mesh(
             panel_surfaces,
             show_edges=True,
@@ -497,7 +497,7 @@ class Airplane:
             smooth_shading=False,
         )
 
-        # Set the plotter's background color
+        # Set the plotter's background color.
         plotter.set_background(color=plotter_background_color)  # type: ignore[call-arg]
 
         if not testing:
@@ -509,7 +509,7 @@ class Airplane:
                 auto_close=False,
             )
         else:
-            # Show the plotter for 1 second, then proceed automatically (for testing)
+            # Show the plotter for 1 second, then proceed automatically (for testing).
             plotter.show(
                 title=f"Airplane: {self._name}",
                 cpos=(-1, -1, 1),
@@ -519,7 +519,7 @@ class Airplane:
             )
             time.sleep(1)
 
-        # If the user wants to save the image, take a screenshot and save as WebP
+        # If the user wants to save the image, take a screenshot and save as WebP.
         if save:
             screenshot = plotter.screenshot(
                 filename=None,
@@ -536,7 +536,7 @@ class Airplane:
                 quality=quality,
             )
 
-        # Close all the plotters
+        # Close all the plotters.
         pv.close_all()
 
     def get_plottable_data(
@@ -566,20 +566,20 @@ class Airplane:
             plottable_data = wing.get_plottable_data(show=False)
 
             assert plottable_data is not None
-            [airfoilOutlines_Wn_ler, airfoilMcls_Wn_ler] = plottable_data
+            [airfoilOutlines_Wn_Ler, airfoilMcls_Wn_Ler] = plottable_data
 
             these_airfoilOutlines_G_Cg = []
             these_airfoilMcls_G_Cg = []
-            for airfoil_id in range(len(airfoilOutlines_Wn_ler)):
-                airfoilOutline_Wn_ler = airfoilOutlines_Wn_ler[airfoil_id]
-                airfoilMcl_Wn_ler = airfoilMcls_Wn_ler[airfoil_id]
+            for airfoil_id in range(len(airfoilOutlines_Wn_Ler)):
+                airfoilOutline_Wn_Ler = airfoilOutlines_Wn_Ler[airfoil_id]
+                airfoilMcl_Wn_Ler = airfoilMcls_Wn_Ler[airfoil_id]
 
                 assert wing.T_pas_Wn_Ler_to_G_Cg is not None
                 airfoilOutline_G_Cg = _transformations.apply_T_to_vectors(
-                    wing.T_pas_Wn_Ler_to_G_Cg, airfoilOutline_Wn_ler, is_position=True
+                    wing.T_pas_Wn_Ler_to_G_Cg, airfoilOutline_Wn_Ler, is_position=True
                 )
                 airfoilMcl_G_Cg = _transformations.apply_T_to_vectors(
-                    wing.T_pas_Wn_Ler_to_G_Cg, airfoilMcl_Wn_ler, is_position=True
+                    wing.T_pas_Wn_Ler_to_G_Cg, airfoilMcl_Wn_Ler, is_position=True
                 )
 
                 these_airfoilOutlines_G_Cg.append(airfoilOutline_G_Cg)
@@ -715,18 +715,18 @@ class Airplane:
                     plotter.add_actor(AxesWcsLp_G_Cg)
 
             if wing.panels is not None:
-                # Initialize empty arrays to hold the Panels' vertices and faces
+                # Initialize empty arrays to hold the Panels' vertices and faces.
                 panel_vertices = np.empty((0, 3), dtype=float)
                 panel_faces = np.empty(0, dtype=int)
 
                 # Initialize a variable to keep track of how many Panels' data has been
-                # added to the arrays
+                # added to the arrays.
                 panel_num = 0
 
-                # Unravel the Wing's Panel matrix and iterate through it
+                # Unravel the Wing's Panel matrix and iterate through it.
                 panels = np.ravel(wing.panels)
                 for panel in panels:
-                    # Stack this Panel's vertices and faces
+                    # Stack this Panel's vertices and faces.
                     panel_vertices_to_add = np.vstack(
                         (
                             panel.Flpp_G_Cg,
@@ -756,7 +756,7 @@ class Airplane:
                     # Convert the Panel vertices and faces to PolyData.
                     panel_surfaces = pv.PolyData(panel_vertices, panel_faces)
 
-                    # Add the Panels to the plotter
+                    # Add the Panels to the plotter.
                     plotter.add_mesh(
                         panel_surfaces,
                         show_edges=True,
@@ -879,25 +879,25 @@ class Airplane:
         if not wing.symmetric:
             if not wing.mirror_only:
                 # Type 1 Symmetry:
-                # symmetric=False, mirror_only=False
+                # symmetric = False, mirror_only = False
                 symmetry_type = 1
             else:
                 if coincident_symmetry_plane:
                     # Type 2 Symmetry:
-                    # symmetric=False, mirror_only=True, coincident_symmetry_plane=True
+                    # symmetric = False, mirror_only = True, coincident_symmetry_plane = True
                     symmetry_type = 2
                 else:
                     # Type 3 Symmetry:
-                    # symmetric=False, mirror_only=True, coincident_symmetry_plane=False
+                    # symmetric = False, mirror_only = True, coincident_symmetry_plane = False
                     symmetry_type = 3
         else:
             if coincident_symmetry_plane:
                 # Type 4 Symmetry:
-                # symmetric=True, coincident_symmetry_plane=True
+                # symmetric = True, coincident_symmetry_plane = True
                 symmetry_type = 4
             else:
                 # Type 5 Symmetry:
-                # symmetric=True, coincident_symmetry_plane=False
+                # symmetric = True, coincident_symmetry_plane = False
                 symmetry_type = 5
 
         # Based on the determined symmetry type, validate the Wing's WingCrossSections'
@@ -943,7 +943,7 @@ class Airplane:
                     "of a Wing with a coincident symmetry plane"
                 )
 
-        # Based on symmetry type, generate the mesh and return the wing(s).
+        # Based on symmetry type, generate the mesh and return the Wing(s).
         if symmetry_type in [1, 2, 3, 4]:
             wing.generate_mesh(symmetry_type)
             return [wing]

--- a/pterasoftware/geometry/wing.py
+++ b/pterasoftware/geometry/wing.py
@@ -1637,32 +1637,32 @@ class Wing:
         if self.symmetry_type is None:
             return None
 
-        airfoilOutlines_Wn_ler = []
-        airfoilMcls_Wn_ler = []
+        airfoilOutlines_Wn_Ler = []
+        airfoilMcls_Wn_Ler = []
         for wing_cross_section_id, wing_cross_section in enumerate(
             self.wing_cross_sections
         ):
             plottable_data = wing_cross_section.get_plottable_data(show=False)
             assert plottable_data is not None
 
-            [airfoilOutline_Wcs_lp, airfoilMcl_Wcs_lp] = plottable_data
+            [airfoilOutline_Wcs_Lp, airfoilMcl_Wcs_Lp] = plottable_data
 
             T_pas_Wcs_Lp_to_Wn_Ler = self.children_T_pas_Wcs_Lp_to_Wn_Ler[
                 wing_cross_section_id
             ]
 
-            airfoilOutline_Wn_ler = _transformations.apply_T_to_vectors(
-                T_pas_Wcs_Lp_to_Wn_Ler, airfoilOutline_Wcs_lp, is_position=True
+            airfoilOutline_Wn_Ler = _transformations.apply_T_to_vectors(
+                T_pas_Wcs_Lp_to_Wn_Ler, airfoilOutline_Wcs_Lp, is_position=True
             )
-            airfoilMcl_Wn_ler = _transformations.apply_T_to_vectors(
-                T_pas_Wcs_Lp_to_Wn_Ler, airfoilMcl_Wcs_lp, is_position=True
+            airfoilMcl_Wn_Ler = _transformations.apply_T_to_vectors(
+                T_pas_Wcs_Lp_to_Wn_Ler, airfoilMcl_Wcs_Lp, is_position=True
             )
 
-            airfoilOutlines_Wn_ler.append(airfoilOutline_Wn_ler)
-            airfoilMcls_Wn_ler.append(airfoilMcl_Wn_ler)
+            airfoilOutlines_Wn_Ler.append(airfoilOutline_Wn_Ler)
+            airfoilMcls_Wn_Ler.append(airfoilMcl_Wn_Ler)
 
         if not show:
-            return [airfoilOutlines_Wn_ler, airfoilMcls_Wn_ler]
+            return [airfoilOutlines_Wn_Ler, airfoilMcls_Wn_Ler]
 
         plotter = pv.Plotter()
 
@@ -1734,14 +1734,14 @@ class Wing:
         for wing_cross_section_id, wing_cross_section in enumerate(
             self.wing_cross_sections
         ):
-            airfoilOutline_Wn_ler = airfoilOutlines_Wn_ler[wing_cross_section_id]
-            airfoilMcl_Wn_ler = airfoilMcls_Wn_ler[wing_cross_section_id]
+            airfoilOutline_Wn_Ler = airfoilOutlines_Wn_Ler[wing_cross_section_id]
+            airfoilMcl_Wn_Ler = airfoilMcls_Wn_Ler[wing_cross_section_id]
 
             airfoilOutline_G_Cg = _transformations.apply_T_to_vectors(
-                _T_pas_Wn_Ler_to_G_Cg, airfoilOutline_Wn_ler, is_position=True
+                _T_pas_Wn_Ler_to_G_Cg, airfoilOutline_Wn_Ler, is_position=True
             )
             airfoilMcl_G_Cg = _transformations.apply_T_to_vectors(
-                _T_pas_Wn_Ler_to_G_Cg, airfoilMcl_Wn_ler, is_position=True
+                _T_pas_Wn_Ler_to_G_Cg, airfoilMcl_Wn_Ler, is_position=True
             )
 
             airfoilOutline_faces = np.hstack(

--- a/pterasoftware/geometry/wing_cross_section.py
+++ b/pterasoftware/geometry/wing_cross_section.py
@@ -528,14 +528,14 @@ class WingCrossSection:
         assert plottable_data is not None
         [airfoilOutline_A_Lp, airfoilMcl_A_Lp] = plottable_data
 
-        airfoilNonScaledOutline_Wcs_lp = np.column_stack(
+        airfoilNonScaledOutline_Wcs_Lp = np.column_stack(
             [
                 airfoilOutline_A_Lp[:, 0],
                 np.zeros_like(airfoilOutline_A_Lp[:, 0]),
                 airfoilOutline_A_Lp[:, 1],
             ]
         )
-        airfoilNonScaledMcl_Wcs_lp = np.column_stack(
+        airfoilNonScaledMcl_Wcs_Lp = np.column_stack(
             [
                 airfoilMcl_A_Lp[:, 0],
                 np.zeros_like(airfoilMcl_A_Lp[:, 0]),
@@ -552,26 +552,26 @@ class WingCrossSection:
             ]
         )
 
-        airfoilOutline_Wcs_lp = _transformations.apply_T_to_vectors(
-            airfoilScalingMatrix, airfoilNonScaledOutline_Wcs_lp, is_position=True
+        airfoilOutline_Wcs_Lp = _transformations.apply_T_to_vectors(
+            airfoilScalingMatrix, airfoilNonScaledOutline_Wcs_Lp, is_position=True
         )
-        airfoilMcl_Wcs_lp = _transformations.apply_T_to_vectors(
-            airfoilScalingMatrix, airfoilNonScaledMcl_Wcs_lp, is_position=True
+        airfoilMcl_Wcs_Lp = _transformations.apply_T_to_vectors(
+            airfoilScalingMatrix, airfoilNonScaledMcl_Wcs_Lp, is_position=True
         )
 
         if not show:
-            return [airfoilOutline_Wcs_lp, airfoilMcl_Wcs_lp]
+            return [airfoilOutline_Wcs_Lp, airfoilMcl_Wcs_Lp]
 
         plotter = pv.Plotter()
 
         _T_pas_Wcs_Lp_to_Wcsp_Lpp = self.T_pas_Wcs_Lp_to_Wcsp_Lpp
         assert _T_pas_Wcs_Lp_to_Wcsp_Lpp is not None
 
-        airfoilOutline_Wcsp_lpp = _transformations.apply_T_to_vectors(
-            _T_pas_Wcs_Lp_to_Wcsp_Lpp, airfoilOutline_Wcs_lp, is_position=True
+        airfoilOutline_Wcsp_Lpp = _transformations.apply_T_to_vectors(
+            _T_pas_Wcs_Lp_to_Wcsp_Lpp, airfoilOutline_Wcs_Lp, is_position=True
         )
-        airfoilMcl_Wcsp_lpp = _transformations.apply_T_to_vectors(
-            _T_pas_Wcs_Lp_to_Wcsp_Lpp, airfoilMcl_Wcs_lp, is_position=True
+        airfoilMcl_Wcsp_Lpp = _transformations.apply_T_to_vectors(
+            _T_pas_Wcs_Lp_to_Wcsp_Lpp, airfoilMcl_Wcs_Lp, is_position=True
         )
 
         if self.symmetry_type in (2, 3):
@@ -579,17 +579,17 @@ class WingCrossSection:
                 np.array([0.0, 0.0, 0.0]), np.array([0.0, 1.0, 0.0]), passive=False
             )
 
-            airfoilOutline_WcspReflectY_lpp = _transformations.apply_T_to_vectors(
-                UserMatrixAxesWcspLpp, airfoilOutline_Wcsp_lpp, is_position=True
+            airfoilOutline_WcspReflectY_Lpp = _transformations.apply_T_to_vectors(
+                UserMatrixAxesWcspLpp, airfoilOutline_Wcsp_Lpp, is_position=True
             )
-            airfoilMcl_WcspReflectY_lpp = _transformations.apply_T_to_vectors(
-                UserMatrixAxesWcspLpp, airfoilMcl_Wcsp_lpp, is_position=True
+            airfoilMcl_WcspReflectY_Lpp = _transformations.apply_T_to_vectors(
+                UserMatrixAxesWcspLpp, airfoilMcl_Wcsp_Lpp, is_position=True
             )
 
         else:
             UserMatrixAxesWcspLpp = np.eye(4, dtype=float)
-            airfoilOutline_WcspReflectY_lpp = airfoilOutline_Wcsp_lpp
-            airfoilMcl_WcspReflectY_lpp = airfoilMcl_Wcsp_lpp
+            airfoilOutline_WcspReflectY_Lpp = airfoilOutline_Wcsp_Lpp
+            airfoilMcl_WcspReflectY_Lpp = airfoilMcl_Wcsp_Lpp
 
         rot_T_act = _transformations.generate_rot_T(
             angles=self.angles_Wcsp_to_Wcs_ixyz,
@@ -610,18 +610,18 @@ class WingCrossSection:
 
         airfoilOutline_faces = np.hstack(
             [
-                airfoilOutline_WcspReflectY_lpp.shape[0],
-                np.arange(airfoilOutline_WcspReflectY_lpp.shape[0]),
+                airfoilOutline_WcspReflectY_Lpp.shape[0],
+                np.arange(airfoilOutline_WcspReflectY_Lpp.shape[0]),
             ]
         )
         airfoilOutline_mesh = pv.PolyData(
-            airfoilOutline_WcspReflectY_lpp, faces=airfoilOutline_faces
+            airfoilOutline_WcspReflectY_Lpp, faces=airfoilOutline_faces
         )
         plotter.add_mesh(airfoilOutline_mesh)
-        plotter.add_lines(airfoilMcl_WcspReflectY_lpp)
+        plotter.add_lines(airfoilMcl_WcspReflectY_Lpp)
 
         if np.allclose(UserMatrixAxesWcsLp_WcspLpp, UserMatrixAxesWcspLpp):
-            AxesWcsLpWcspLpp_Wcsp_lpp = pv.AxesAssembly(
+            AxesWcsLpWcspLpp_Wcsp_Lpp = pv.AxesAssembly(
                 x_label="WcsX@Lp/WcspX@Lpp",
                 y_label="WcsY@Lp/WcspY@Lpp",
                 z_label="WcsZ@Lp/WcspZ@Lpp",
@@ -647,9 +647,9 @@ class WingCrossSection:
                 tip_length=(0.2, 0.2, 0.2),
                 symmetric_bounds=False,
             )
-            plotter.add_actor(AxesWcsLpWcspLpp_Wcsp_lpp)
+            plotter.add_actor(AxesWcsLpWcspLpp_Wcsp_Lpp)
         else:
-            AxesWcsLp_Wcsp_lpp = pv.AxesAssembly(
+            AxesWcsLp_Wcsp_Lpp = pv.AxesAssembly(
                 x_label="WcsX@Lp",
                 y_label="WcsY@Lp",
                 z_label="WcsZ@Lp",
@@ -702,7 +702,7 @@ class WingCrossSection:
                 tip_length=(0.2, 0.2, 0.2),
                 symmetric_bounds=False,
             )
-            plotter.add_actor(AxesWcsLp_Wcsp_lpp)
+            plotter.add_actor(AxesWcsLp_Wcsp_Lpp)
             plotter.add_actor(AxesWcspLpp)
 
         plotter.enable_parallel_projection()  # type: ignore[call-arg]

--- a/tests/unit/test_airfoil.py
+++ b/tests/unit/test_airfoil.py
@@ -417,8 +417,8 @@ class TestAirfoil(unittest.TestCase):
 
         # After normalization, leading point should be at ~ [0.0, 0.0].
         Lp_index = int(np.argmin(airfoil.outline_A_Lp[:, 0]))
-        lp = airfoil.outline_A_Lp[Lp_index, :]
-        npt.assert_allclose(lp, [0.0, 0.0], atol=1e-6)
+        Lp_A_Lp = airfoil.outline_A_Lp[Lp_index, :]
+        npt.assert_allclose(Lp_A_Lp, [0.0, 0.0], atol=1e-6)
 
         # Trailing edge should be at ~ x = 1.0.
         self.assertAlmostEqual(airfoil.outline_A_Lp[0, 0], 1.0, places=5)
@@ -453,8 +453,8 @@ class TestAirfoil(unittest.TestCase):
 
         # After normalization, leading point should be at ~ [0.0, 0.0].
         Lp_index = int(np.argmin(airfoil.outline_A_Lp[:, 0]))
-        lp = airfoil.outline_A_Lp[Lp_index, :]
-        npt.assert_allclose(lp, [0.0, 0.0], atol=1e-6)
+        Lp_A_Lp = airfoil.outline_A_Lp[Lp_index, :]
+        npt.assert_allclose(Lp_A_Lp, [0.0, 0.0], atol=1e-6)
 
         # Trailing edge should be at ~ x = 1.0 (unit chord).
         self.assertAlmostEqual(airfoil.outline_A_Lp[0, 0], 1.0, places=5)

--- a/tests/unit/test_wing.py
+++ b/tests/unit/test_wing.py
@@ -15,21 +15,21 @@ class TestWing(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures for Wing tests."""
-        # Create fixtures for all Wing types
+        # Create fixtures for all Wing types.
         self.type_1_wing = geometry_fixtures.make_type_1_wing_fixture()
         self.type_2_wing = geometry_fixtures.make_type_2_wing_fixture()
         self.type_3_wing = geometry_fixtures.make_type_3_wing_fixture()
         self.type_4_wing = geometry_fixtures.make_type_4_wing_fixture()
         self.type_5_wing = geometry_fixtures.make_type_5_wing_fixture()
 
-        # Create additional test fixtures
+        # Create additional test fixtures.
         self.root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
 
     def test_initialization_valid_parameters(self):
         """Test Wing initialization with valid parameters for all types."""
-        # Test that all Wing types initialize correctly
+        # Test that all Wing types initialize correctly.
         wings_to_test = [
             (self.type_1_wing, "type 1"),
             (self.type_2_wing, "type 2"),
@@ -53,20 +53,20 @@ class TestWing(unittest.TestCase):
 
     def test_wing_cross_sections_validation(self):
         """Test that wing_cross_sections parameter validation works correctly."""
-        # Test empty list raises error
+        # Test empty list raises error.
         with self.assertRaises(ValueError):
             ps.geometry.wing.Wing(wing_cross_sections=[])
 
-        # Test non-list raises error
+        # Test non-list raises error.
         with self.assertRaises(TypeError):
             # noinspection PyTypeChecker
             ps.geometry.wing.Wing(wing_cross_sections="not a list")
 
-        # Test single WingCrossSection raises error (need at least 2)
+        # Test single WingCrossSection raises error (need at least 2).
         with self.assertRaises(ValueError):
             ps.geometry.wing.Wing(wing_cross_sections=[self.root_wing_cross_section])
 
-        # Test non-WingCrossSection objects raise error
+        # Test non-WingCrossSection objects raise error.
         with self.assertRaises(TypeError):
             ps.geometry.wing.Wing(
                 wing_cross_sections=[
@@ -92,7 +92,7 @@ class TestWing(unittest.TestCase):
                 symmetryPoint_G_Cg=[0.0, 0.0, 0.0],
             )
 
-        # Test that symmetry parameters must be None when no symmetry
+        # Test that symmetry parameters must be None when no symmetry.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -105,7 +105,7 @@ class TestWing(unittest.TestCase):
                 symmetryNormal_G=[0.0, 1.0, 0.0],
             )
 
-        # Test that symmetry parameters must be provided when symmetric=True
+        # Test that symmetry parameters must be provided when symmetric=True.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -122,20 +122,20 @@ class TestWing(unittest.TestCase):
         """Test type 1 wing (symmetric=False, mirror_only=False) properties."""
         wing = self.type_1_wing
 
-        # Test basic properties
+        # Test basic properties.
         self.assertFalse(wing.symmetric)
         self.assertFalse(wing.mirror_only)
         self.assertIsNone(wing.symmetryNormal_G)
         self.assertIsNone(wing.symmetryPoint_G_Cg)
 
-        # Test that symmetry_type is None before meshing
+        # Test that symmetry_type is None before meshing.
         self.assertIsNone(wing.symmetry_type)
 
     def test_wing_type_2_properties(self):
         """Test type 2 wing (mirror_only=True, coincident symmetry plane) properties."""
         wing = self.type_2_wing
 
-        # Test basic properties
+        # Test basic properties.
         self.assertFalse(wing.symmetric)
         self.assertTrue(wing.mirror_only)
         npt.assert_array_equal(wing.symmetryNormal_G, np.array([0.0, 1.0, 0.0]))
@@ -146,7 +146,7 @@ class TestWing(unittest.TestCase):
         properties."""
         wing = self.type_3_wing
 
-        # Test basic properties
+        # Test basic properties.
         self.assertFalse(wing.symmetric)
         self.assertTrue(wing.mirror_only)
         npt.assert_array_equal(wing.symmetryNormal_G, np.array([0.0, 1.0, 0.0]))
@@ -156,13 +156,13 @@ class TestWing(unittest.TestCase):
         """Test type 4 wing (symmetric=True, coincident symmetry plane) properties."""
         wing = self.type_4_wing
 
-        # Test basic properties
+        # Test basic properties.
         self.assertTrue(wing.symmetric)
         self.assertFalse(wing.mirror_only)
         npt.assert_array_equal(wing.symmetryNormal_G, np.array([0.0, 1.0, 0.0]))
         npt.assert_array_equal(wing.symmetryPoint_G_Cg, np.array([1.0, 0.0, 0.5]))
 
-        # Test that WingCrossSections have control surface symmetry types
+        # Test that WingCrossSections have control surface symmetry types.
         for wing_cross_section in wing.wing_cross_sections:
             self.assertEqual(
                 wing_cross_section.control_surface_symmetry_type, "symmetric"
@@ -173,7 +173,7 @@ class TestWing(unittest.TestCase):
         properties."""
         wing = self.type_5_wing
 
-        # Test basic properties (before Airplane processing)
+        # Test basic properties (before Airplane processing).
         self.assertTrue(wing.symmetric)
         self.assertFalse(wing.mirror_only)
         npt.assert_array_equal(
@@ -271,7 +271,7 @@ class TestWing(unittest.TestCase):
         """Test that transformation matrices are None before meshing."""
         wing = self.type_1_wing
 
-        # All transformation matrices should be None before meshing
+        # All transformation matrices should be None before meshing.
         self.assertIsNone(wing.T_pas_G_Cg_to_Wn_Ler)
         self.assertIsNone(wing.T_pas_Wn_Ler_to_G_Cg)
 
@@ -280,15 +280,15 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_type_1_wing_fixture()
         wing.generate_mesh(1)
 
-        # Transformation matrices should be available after meshing
+        # Transformation matrices should be available after meshing.
         self.assertIsNotNone(wing.T_pas_G_Cg_to_Wn_Ler)
         self.assertIsNotNone(wing.T_pas_Wn_Ler_to_G_Cg)
 
-        # Should be 4x4 matrices
+        # They should be 4 x 4 matrices.
         self.assertEqual(wing.T_pas_G_Cg_to_Wn_Ler.shape, (4, 4))
         self.assertEqual(wing.T_pas_Wn_Ler_to_G_Cg.shape, (4, 4))
 
-        # Should be inverses of each other
+        # They should be inverses of each other.
         identity = wing.T_pas_G_Cg_to_Wn_Ler @ wing.T_pas_Wn_Ler_to_G_Cg
         npt.assert_allclose(identity, np.eye(4), atol=1e-14)
 
@@ -297,22 +297,22 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_type_1_wing_fixture()
         wing.generate_mesh(1)
 
-        # Wing axes basis vectors should be available
+        # Wing axes basis vectors should be available.
         self.assertIsNotNone(wing.WnX_G)
         self.assertIsNotNone(wing.WnY_G)
         self.assertIsNotNone(wing.WnZ_G)
 
-        # Should be 3-element vectors
+        # They should be 3-element vectors.
         self.assertEqual(len(wing.WnX_G), 3)
         self.assertEqual(len(wing.WnY_G), 3)
         self.assertEqual(len(wing.WnZ_G), 3)
 
-        # Should form an orthonormal basis
+        # They should form an orthonormal basis.
         npt.assert_allclose(np.linalg.norm(wing.WnX_G), 1.0, atol=1e-14)
         npt.assert_allclose(np.linalg.norm(wing.WnY_G), 1.0, atol=1e-14)
         npt.assert_allclose(np.linalg.norm(wing.WnZ_G), 1.0, atol=1e-14)
 
-        # Should be orthogonal
+        # They should be orthogonal.
         npt.assert_allclose(np.dot(wing.WnX_G, wing.WnY_G), 0.0, atol=1e-14)
         npt.assert_allclose(wing.WnY_G @ wing.WnZ_G, 0.0, atol=1e-14)
         npt.assert_allclose(wing.WnZ_G @ wing.WnX_G, 0.0, atol=1e-14)
@@ -322,7 +322,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_type_1_wing_fixture()
         wing.generate_mesh(1)
 
-        # Should have transformation lists for each WingCrossSection
+        # It should have transformation lists for each WingCrossSection.
         num_wing_cross_sections = len(wing.wing_cross_sections)
         self.assertEqual(
             len(wing.children_T_pas_Wn_Ler_to_Wcs_Lp), num_wing_cross_sections
@@ -337,7 +337,7 @@ class TestWing(unittest.TestCase):
             len(wing.children_T_pas_Wcs_Lp_to_G_Cg), num_wing_cross_sections
         )
 
-        # Each transformation should be a 4x4 matrix
+        # Each transformation should be a 4 x 4 matrix.
         for i in range(num_wing_cross_sections):
             self.assertEqual(wing.children_T_pas_Wn_Ler_to_Wcs_Lp[i].shape, (4, 4))
             self.assertEqual(wing.children_T_pas_Wcs_Lp_to_Wn_Ler[i].shape, (4, 4))
@@ -349,14 +349,14 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_type_1_wing_fixture()
         wing.generate_mesh(1)
 
-        # Test that geometric properties are available and positive
+        # Test that geometric properties are available and positive.
         self.assertGreater(wing.projected_area, 0.0)
         self.assertGreater(wing.wetted_area, 0.0)
         self.assertGreater(wing.span, 0.0)
         self.assertGreater(wing.standard_mean_chord, 0.0)
         self.assertGreater(wing.mean_aerodynamic_chord, 0.0)
 
-        # Test that wetted area is greater than projected area (both sides)
+        # Test that wetted area is greater than projected area (both sides).
         self.assertGreaterEqual(wing.wetted_area, wing.projected_area)
 
     def test_geometric_properties_before_meshing_return_none(self):
@@ -437,7 +437,7 @@ class TestWing(unittest.TestCase):
                 Ler_Gs_Cgs="invalid",
             )
 
-        # Test invalid angles
+        # Test invalid angles.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -449,7 +449,7 @@ class TestWing(unittest.TestCase):
                 angles_Gs_to_Wn_ixyz="invalid",
             )
 
-        # Test invalid num_chordwise_panels
+        # Test invalid num_chordwise_panels.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -461,7 +461,7 @@ class TestWing(unittest.TestCase):
                 num_chordwise_panels=0,
             )
 
-        # Test invalid chordwise_spacing
+        # Test invalid chordwise_spacing.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -472,7 +472,7 @@ class TestWing(unittest.TestCase):
                 chordwise_spacing="invalid_spacing",
             )
 
-        # Test invalid symmetric
+        # Test invalid symmetric.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -484,7 +484,7 @@ class TestWing(unittest.TestCase):
                 symmetric="invalid",
             )
 
-        # Test invalid mirror_only
+        # Test invalid mirror_only.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -496,7 +496,7 @@ class TestWing(unittest.TestCase):
                 mirror_only="invalid",
             )
 
-        # Test invalid explode_into_strips
+        # Test invalid explode_into_strips.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -522,7 +522,7 @@ class TestWing(unittest.TestCase):
         )
         self.assertEqual(wing.name, "Test Wing Name")
 
-        # Test invalid name type
+        # Test invalid name type.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
@@ -536,12 +536,12 @@ class TestWing(unittest.TestCase):
 
     def test_symmetry_normal_normalization(self):
         """Test that symmetry normal vectors are properly normalized."""
-        # Create fresh fixtures since WingCrossSections can only be validated once
+        # Create fresh fixtures since WingCrossSections can only be validated once.
         root_wing_cross_section = (
             geometry_fixtures.make_root_wing_cross_section_fixture()
         )
         tip_wing_cross_section = geometry_fixtures.make_tip_wing_cross_section_fixture()
-        # Create Wing with non-unit normal vector
+        # Create Wing with non-unit normal vector.
         wing = ps.geometry.wing.Wing(
             wing_cross_sections=[root_wing_cross_section, tip_wing_cross_section],
             symmetric=False,
@@ -550,7 +550,7 @@ class TestWing(unittest.TestCase):
             symmetryPoint_G_Cg=[0.0, 0.0, 0.0],
         )
 
-        # Should be normalized to unit vector
+        # It should be normalized to unit vector.
         npt.assert_allclose(np.linalg.norm(wing.symmetryNormal_G), 1.0, atol=1e-14)
         npt.assert_allclose(
             wing.symmetryNormal_G, np.array([0.0, 1.0, 0.0]), atol=1e-14
@@ -558,23 +558,23 @@ class TestWing(unittest.TestCase):
 
     def test_three_section_wing_validation(self):
         """Test Wing with 3 WingCrossSections validates correctly."""
-        # Test that valid 3-WingCrossSection Wing initializes correctly
+        # Test that valid 3-WingCrossSection Wing initializes correctly.
         wing = geometry_fixtures.make_three_section_wing_fixture()
         self.assertIsInstance(wing, ps.geometry.wing.Wing)
         self.assertEqual(len(wing.wing_cross_sections), 3)
 
-        # Verify all WingCrossSections are validated
+        # Verify all WingCrossSections are validated.
         for wing_cross_section in wing.wing_cross_sections:
             self.assertTrue(wing_cross_section.validated)
 
     def test_four_section_wing_validation(self):
         """Test Wing with 4 WingCrossSections validates correctly."""
-        # Test that valid 4-WingCrossSection Wing initializes correctly
+        # Test that valid 4-WingCrossSection Wing initializes correctly.
         wing = geometry_fixtures.make_four_section_wing_fixture()
         self.assertIsInstance(wing, ps.geometry.wing.Wing)
         self.assertEqual(len(wing.wing_cross_sections), 4)
 
-        # Verify all WingCrossSections are validated
+        # Verify all WingCrossSections are validated.
         for wing_cross_section in wing.wing_cross_sections:
             self.assertTrue(wing_cross_section.validated)
 
@@ -627,7 +627,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 2.0 meters (from y=0 to y=2.0)
+        # Expected span: 2.0 meters (from y = 0.0 to y = 2.0).
         expected_span = 2.0
         actual_span = wing.span
 
@@ -639,7 +639,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 3.0 meters (from y=0 to y=3.0)
+        # Expected span: 3.0 meters (from y = 0.0 to y = 3.0).
         expected_span = 3.0
         actual_span = wing.span
 
@@ -651,7 +651,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
         wing.generate_mesh(4)
 
-        # Expected span: 5.0 meters (2 * 2.5, due to symmetry)
+        # Expected span: 5.0 meters (2.0 * 2.5, due to symmetry).
         expected_span = 5.0
         actual_span = wing.span
 
@@ -663,7 +663,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 4.0 meters (from y=0 to y=4.0)
+        # Expected span: 4.0 meters (from y = 0.0 to y = 4.0).
         expected_span = 4.0
         actual_span = wing.span
 
@@ -675,7 +675,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected projected area: 2.0 square meters (1.0 m chord * 2.0 m span)
+        # Expected projected area: 2.0 square meters (1.0 m chord * 2.0 m span).
         expected_area = 2.0
         actual_area = wing.projected_area
 
@@ -751,7 +751,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
         wing.generate_mesh(1)
 
-        # Standard mean chord = projected_area / span = 2.0 / 2.0 = 1.0
+        # Standard mean chord = projected_area / span = 2.0 / 2.0 = 1.0.
         expected_smc = 1.0
         actual_smc = wing.standard_mean_chord
 
@@ -763,7 +763,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Standard mean chord = projected_area / span = 4.5 / 3.0 = 1.5
+        # Standard mean chord = projected_area / span = 4.5 / 3.0 = 1.5.
         expected_smc = 1.5
         actual_smc = wing.standard_mean_chord
 
@@ -776,7 +776,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
         wing.generate_mesh(4)
 
-        # Standard mean chord = projected_area / span = 7.5 / 5.0 = 1.5
+        # Standard mean chord = projected_area / span = 7.5 / 5.0 = 1.5.
         expected_smc = 1.5
         actual_smc = wing.standard_mean_chord
 
@@ -788,7 +788,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_three_section_tapered_wing_fixture()
         wing.generate_mesh(1)
 
-        # Standard mean chord = projected_area / span = 8.0 / 4.0 = 2.0
+        # Standard mean chord = projected_area / span = 8.0 / 4.0 = 2.0.
         expected_smc = 2.0
         actual_smc = wing.standard_mean_chord
 
@@ -800,7 +800,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_simple_rectangular_wing_fixture()
         wing.generate_mesh(1)
 
-        # For a rectangular wing (constant chord), MAC = chord = 1.0
+        # For a rectangular wing (constant chord), MAC = chord = 1.0.
         expected_mac = 1.0
         actual_mac = wing.mean_aerodynamic_chord
 
@@ -813,10 +813,10 @@ class TestWing(unittest.TestCase):
         wing.generate_mesh(1)
 
         # For a linearly tapered wing:
-        # MAC = (2/3) * (c_root + c_tip - c_root * c_tip / (c_root + c_tip))
-        # With c_root=2.0, c_tip=1.0:
-        # MAC = (2/3) * (2.0 + 1.0 - 2.0 * 1.0 / (2.0 + 1.0))
-        # MAC = (2/3) * (3.0 - 2.0/3.0) = (2/3) * (7.0/3.0) = 14.0/9.0 = 1.555...
+        # MAC = (2.0 / 3.0) * (c_root + c_tip - c_root * c_tip / (c_root + c_tip))
+        # With c_root = 2.0, c_tip = 1.0:
+        # MAC = (2.0 / 3.0) * (2.0 + 1.0 - 2.0 * 1.0 / (2.0 + 1.0))
+        # MAC = (2.0 / 3.0) * (3.0 - 2.0 / 3.0) = (2.0 / 3.0) * (7.0 / 3.0) = 14.0 / 9.0 = 1.555...
         c_root = 2.0
         c_tip = 1.0
         expected_mac = (2.0 / 3.0) * (
@@ -834,7 +834,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_symmetric_continuous_rectangular_wing_fixture()
         wing.generate_mesh(4)
 
-        # For a rectangular wing (constant chord), MAC = chord = 1.5
+        # For a rectangular wing (constant chord), MAC = chord = 1.5.
         expected_mac = 1.5
         actual_mac = wing.mean_aerodynamic_chord
 
@@ -858,12 +858,12 @@ class TestWing(unittest.TestCase):
             with self.subTest(wing=wing.name):
                 wing.generate_mesh(symmetry_type)
 
-                # Get properties
+                # Get properties.
                 span = wing.span
                 projected_area = wing.projected_area
                 standard_mean_chord = wing.standard_mean_chord
 
-                # Verify consistency: projected_area = span * standard_mean_chord
+                # Verify consistency: projected_area = span * standard_mean_chord.
                 self.assertIsNotNone(span)
                 self.assertIsNotNone(projected_area)
                 self.assertIsNotNone(standard_mean_chord)
@@ -875,11 +875,11 @@ class TestWing(unittest.TestCase):
 
     def test_span_rotated_wing_x_axis(self):
         """Test span calculation invariance for Wing rotated about x axis."""
-        # Create a Wing rotated 45 degrees about x axis
+        # Create a Wing rotated 45.0 degrees about x axis.
         wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([45.0, 0.0, 0.0])
         wing.generate_mesh(1)
 
-        # Expected span: 2.0 meters (rotation about x axis does not affect y extent)
+        # Expected span: 2.0 meters (rotation about x axis does not affect y extent).
         expected_span = 2.0
 
         actual_span = wing.span
@@ -889,11 +889,11 @@ class TestWing(unittest.TestCase):
 
     def test_span_rotated_wing_y_axis(self):
         """Test span calculation invariance for Wing rotated about y axis."""
-        # Create a Wing rotated 30 degrees about y axis
+        # Create a Wing rotated 30.0 degrees about y axis.
         wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([0.0, 30.0, 0.0])
         wing.generate_mesh(1)
 
-        # Expected span: 2.0 meters (rotation about y axis does not affect y extent)
+        # Expected span: 2.0 meters (rotation about y axis does not affect y extent).
         expected_span = 2.0
 
         actual_span = wing.span
@@ -903,11 +903,11 @@ class TestWing(unittest.TestCase):
 
     def test_span_rotated_wing_z_axis(self):
         """Test span calculation invariance for Wing rotated about z axis."""
-        # Create a Wing rotated 60 degrees about z axis
+        # Create a Wing rotated 60.0 degrees about z axis.
         wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([0.0, 0.0, 60.0])
         wing.generate_mesh(1)
 
-        # Expected span: 2.0 meters (rotation about z axis does not affect y extent)
+        # Expected span: 2.0 meters (rotation about z axis does not affect y extent).
         expected_span = 2.0
 
         actual_span = wing.span
@@ -917,13 +917,13 @@ class TestWing(unittest.TestCase):
 
     def test_span_rotated_wing_combined_rotations(self):
         """Test span calculation invariance for Wing with combined rotations."""
-        # Create a Wing with combined rotations
+        # Create a Wing with combined rotations.
         wing = geometry_fixtures.make_rotated_rectangular_wing_fixture(
             [15.0, 25.0, 35.0]
         )
         wing.generate_mesh(1)
 
-        # Expected span: 2.0 meters (rotations do not affect y extent in wing axes)
+        # Expected span: 2.0 meters (rotations do not affect y extent in wing axes).
         expected_span = 2.0
 
         actual_span = wing.span
@@ -936,7 +936,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_wing_with_rotated_cross_sections_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 5.0 meters (rotation about y axis does not affect y position)
+        # Expected span: 5.0 meters (rotation about y axis does not affect y position).
         expected_span = 5.0
 
         actual_span = wing.span
@@ -949,7 +949,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_swept_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected span: 3.0 meters (sweep in x direction does not affect y extent)
+        # Expected span: 3.0 meters (sweep in x direction does not affect y extent).
         expected_span = 3.0
 
         actual_span = wing.span
@@ -973,11 +973,11 @@ class TestWing(unittest.TestCase):
 
     def test_standard_mean_chord_rotated_wing(self):
         """Test standard mean chord calculation for rotated Wing."""
-        # Create a Wing rotated 45 degrees about x axis
+        # Create a Wing rotated 45.0 degrees about x axis.
         wing = geometry_fixtures.make_rotated_rectangular_wing_fixture([45.0, 0.0, 0.0])
         wing.generate_mesh(1)
 
-        # Expected standard mean chord: 1.0 (projected_area / span = 2.0 / 2.0)
+        # Expected standard mean chord: 1.0 (projected_area / span = 2.0 / 2.0).
         expected_smc = 1.0
 
         actual_smc = wing.standard_mean_chord
@@ -990,7 +990,7 @@ class TestWing(unittest.TestCase):
         wing = geometry_fixtures.make_swept_wing_fixture()
         wing.generate_mesh(1)
 
-        # Expected standard mean chord: projected_area / span = 4.5 / 3.0 = 1.5
+        # Expected standard mean chord: projected_area / span = 4.5 / 3.0 = 1.5.
         expected_smc = 1.5
 
         actual_smc = wing.standard_mean_chord
@@ -1021,9 +1021,9 @@ class TestWing(unittest.TestCase):
         average_aspect_ratio = wing.average_panel_aspect_ratio
         self.assertIsNotNone(average_aspect_ratio)
 
-        # For a rectangular Wing with uniform spacing: Panel chord = wing_chord /
-        # num_chordwise_panels = 1.0 / 4 = 0.25 Panel span = wing_span /
-        # num_spanwise_panels = 2.0 / 8 = 0.25 The expected aspect ratio is
+        # For a rectangular wing with uniform spacing: Panel chord = wing_chord /
+        # num_chordwise_panels = 1.0 / 4 = 0.25. Panel span = wing_span /
+        # num_spanwise_panels = 2.0 / 8 = 0.25. The expected aspect ratio is
         # approximately 1.0 for roughly square Panels. This is an approximate check
         # since actual Panel aspect ratios depend on the meshing algorithm's
         # implementation details.
@@ -1446,15 +1446,15 @@ class TestWingDeepCopy(unittest.TestCase):
         original.generate_mesh(1)
 
         # Access cached properties to populate internal caches before deepcopy.
-        _wn_x = original.WnX_G
-        _wn_y = original.WnY_G
-        _wn_z = original.WnZ_G
+        _WnX_G = original.WnX_G
+        _WnY_G = original.WnY_G
+        _WnZ_G = original.WnZ_G
         _children_to_wing_cross_section = original.children_T_pas_Wn_Ler_to_Wcs_Lp
         _children_from_wing_cross_section = original.children_T_pas_Wcs_Lp_to_Wn_Ler
 
         copied = copy.deepcopy(original)
 
-        # Verify the copied wing has matching axis vectors.
+        # Verify the copied Wing has matching axis vectors.
         npt.assert_array_equal(copied.WnX_G, original.WnX_G)
         npt.assert_array_equal(copied.WnY_G, original.WnY_G)
         npt.assert_array_equal(copied.WnZ_G, original.WnZ_G)
@@ -1520,18 +1520,18 @@ class TestWingGetPlottableData(unittest.TestCase):
 
         num_wing_cross_sections = len(wing.wing_cross_sections)
 
-        # Should have one outline array per WingCrossSection.
+        # It should have one outline array per WingCrossSection.
         self.assertEqual(len(result[0]), num_wing_cross_sections)
-        # Should have one MCL array per WingCrossSection.
+        # It should have one MCL array per WingCrossSection.
         self.assertEqual(len(result[1]), num_wing_cross_sections)
 
         for outline in result[0]:
             self.assertIsInstance(outline, np.ndarray)
-            self.assertEqual(outline.shape[1], 3)  # 3D points
+            self.assertEqual(outline.shape[1], 3)  # These are 3D points.
 
         for mcl in result[1]:
             self.assertIsInstance(mcl, np.ndarray)
-            self.assertEqual(mcl.shape[1], 3)  # 3D points
+            self.assertEqual(mcl.shape[1], 3)  # These are 3D points.
 
     def test_get_plottable_data_three_section_wing(self):
         """Test get_plottable_data for Wing with 3 WingCrossSections."""
@@ -1540,7 +1540,7 @@ class TestWingGetPlottableData(unittest.TestCase):
 
         result = wing.get_plottable_data(show=False)
 
-        # Should have 3 outlines and 3 MCLs.
+        # It should have 3 outlines and 3 MCLs.
         self.assertEqual(len(result[0]), 3)
         self.assertEqual(len(result[1]), 3)
 
@@ -1560,7 +1560,7 @@ class TestWingGetPlottableData(unittest.TestCase):
         wing = geometry_fixtures.make_type_1_wing_fixture()
         wing.generate_mesh(1)
 
-        # Call without show parameter, should return data (not None).
+        # Call without a show parameter. It should return data (not None).
         result = wing.get_plottable_data()
 
         self.assertIsNotNone(result)
@@ -1819,7 +1819,7 @@ class TestExplodeIntoStripsMethods(unittest.TestCase):
         result = wing._interpolate_between_wing_cross_sections(
             self._make_root_wing_cross_section(), self._make_tip_wing_cross_section()
         )
-        # N=3 => 3 interpolated sections
+        # N = 3 => 3 interpolated sections
         self.assertEqual(len(result), 3)
 
     def test_interpolate_last_section_has_tip_chord(self):
@@ -1837,24 +1837,25 @@ class TestExplodeIntoStripsMethods(unittest.TestCase):
         result = wing._interpolate_between_wing_cross_sections(
             self._make_root_wing_cross_section(), self._make_tip_wing_cross_section()
         )
-        # N=3: the first section is at t=1/3
-        # chord at t=1/3: (1 - 1/3)*1.0 + (1/3)*0.5 = 5/6
+        # N = 3: the first section is at t = 1.0 / 3.0
+        # chord at t = 1.0 / 3.0: (1.0 - 1.0 / 3.0) * 1.0 + (1.0 / 3.0) * 0.5 = 5.0 /
+        # 6.0
         expected_first_interp = (1.0 - 1.0 / 3.0) * 1.0 + (1.0 / 3.0) * 0.5
         self.assertAlmostEqual(result[0].chord, expected_first_interp, places=10)
 
-    def test_interpolate_lp_y_divided_by_n(self):
+    def test_interpolate_Lp_y_divided_by_n(self):
         """Test that the Lp_Wcsp_Lpp y-component of each interpolated WingCrossSection is
         tip_Lp_y / N."""
         wing = self._make_plain_wing(explode_into_strips=False)
         result = wing._interpolate_between_wing_cross_sections(
             self._make_root_wing_cross_section(), self._make_tip_wing_cross_section()
         )
-        # tip has Lp_y = 0.5; N=3 => each section Lp_y = 0.5/3
-        expected_lp_y = 0.5 / 3.0
+        # tip has Lp_y = 0.5. N = 3 => each section Lp_y = 0.5 / 3.0.
+        expected_Lp_y = 0.5 / 3.0
         for wing_cross_section in result:
             with self.subTest(wing_cross_section=wing_cross_section):
                 self.assertAlmostEqual(
-                    float(wing_cross_section.Lp_Wcsp_Lpp[1]), expected_lp_y, places=10
+                    float(wing_cross_section.Lp_Wcsp_Lpp[1]), expected_Lp_y, places=10
                 )
 
     def test_explode_wing_with_two_wing_cross_sections_returns_correct_count(self):


### PR DESCRIPTION
# Description

This PR finishes the point-ID capitalization work that PR #237 started. That PR's sweep rules targeted the airfoil-axes name forms (`_A_lp`, `lpAi`, and their relatives), so lowercase point IDs paired with other axes survived it. A scan built from the full ID inventory in `docs/AXES_POINTS_AND_FRAMES.md` found the survivors, and this PR renames them all to the capitalized forms the conventions require. Every renamed name is a function local, a plot label string, or a test identifier, so nothing public, slotted, or serialized changes and no `_FORMAT_VERSION` bump is needed.

## Motivation

The missed names sat directly beside correctly capitalized ones, sometimes in the same expression: `wing.py` transformed `airfoilOutline_Wcs_lp` with `T_pas_Wcs_Lp_to_Wn_Ler`, spelling the same point ID two ways on one line. Leaving them would undercut the convention the airfoil rename just brought the code into line with, and the scan gives confidence this pass is exhaustive rather than another partial sweep: the only lowercase forms remaining in the tree are the three intentional `DeprecationWarning`-emitting aliases and their documentation.

## Relevant Issues

None.

## Changes

* Renamed the `_Wcs_lp` local-variable family to `_Wcs_Lp` across `Airfoil.add_control_surface` (the hinge-point locals), `WingCrossSection.get_plottable_data`, and `Wing.get_plottable_data`.
* Renamed the `_Wn_ler` local-variable family to `_Wn_Ler` in `Wing.get_plottable_data`, `Wing.draw` consumers, and `Airplane.get_plottable_data`.
* Renamed the `_Wcsp_lpp` and `_WcspReflectY_lpp` local-variable families to `_Wcsp_Lpp` and `_WcspReflectY_Lpp` in `WingCrossSection.get_plottable_data` and `WingCrossSection.draw`.
* Renamed the `Airfoil.draw` axis labels `"AX_lp"` and `"AY_lp"` to `"AX_Lp"` and `"AY_Lp"`.
* Renamed two test locals in `tests/unit/test_airfoil.py` from `lp` to `Lp_A_Lp`, matching the neighboring `Lp_index`.
* Renamed `test_interpolate_lp_y_divided_by_n` and its `expected_lp_y` local in `tests/unit/test_wing.py` to the `Lp_y` forms their own docstring and comments already use, and renamed the discard locals `_wn_x`, `_wn_y`, and `_wn_z` to `_WnX_G`, `_WnY_G`, and `_WnZ_G` to match the properties they capture.
* Added the missing trailing periods to the comments in `tests/unit/test_wing.py`.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
