### PR TITLE
[FEATURE] Render injected MuJoCo geometry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Requires Python 3.11, but active development is done in 3.14
     - `_output_rendering.py`: PyVista styling, geometry building, and scene assembly for the visualization functions
     - `_panel.py`: Panel class for discretized mesh elements
     - `_parameter_validation.py`: Input validation functions
+    - `_private_access.py`: Registration pattern that grants cross-module access to private attributes, currently a FreeFlightUnsteadyProblem's MuJoCoModel for the rendering layer
     - `_serialization.py`: JSON serialization and deserialization (save/load)
     - `_transformations.py`: Coordinate transformations and rotations
     - `aeroelastic_unsteady_ring_vortex_lattice_method.py`: Aeroelastic UVLM solver subclass with first-order structural deformation

--- a/docs/MUJOCO_CONVENTIONS.md
+++ b/docs/MUJOCO_CONVENTIONS.md
@@ -89,7 +89,7 @@ The generated model XML contains no geoms of its own, so every geom in the compi
 
 ### Informal Axes and Point IDs (geom, geomOrigin, parent, and parentOrigin)
 
-The geom arrays involve two systems that are MuJoCo-internal, so their variables take informal lowercase IDs rather than IDs registered in AXES_POINTS_AND_FRAMES.md. The axes ID geom denotes a geom's own local axes, and the point ID geomOrigin denotes the geom frame's origin. The axes ID parent denotes the axes of the geom's parent body's frame, and the point ID parentOrigin denotes that frame's origin. For a geom attached to the free-jointed body, parent axes are the first Airplane's body axes and parentOrigin is the first Airplane's CG, since the generated body frame's origin coincides with the CG. For a worldbody geom, parent axes are Earth axes and parentOrigin is the Earth origin. A single variable over the geom arrays spans both cases, which is why no registered ID can be pinned on it.
+The geom arrays involve two systems that are MuJoCo-internal, so their variables take informal lowercase IDs rather than IDs registered in AXES_POINTS_AND_FRAMES.md. The axes ID geom denotes a geom's own local axes, and the point ID geomOrigin denotes the geom origin, the point where MuJoCo anchors the geom's local coordinates. The axes ID parent denotes the parent body's axes, and the point ID parentOrigin denotes the parent origin, the point where MuJoCo anchors the parent body's coordinates. For a geom attached to the free-jointed body, parent axes are the first Airplane's body axes and the parent origin is the first Airplane's CG, since the generated body is anchored at the CG. For a worldbody geom, parent axes are Earth axes and the parent origin is the Earth origin. A single variable over the geom arrays spans both cases, which is why no registered ID can be pinned on it.
 
 ### Geom Ownership (geom_bodyid)
 
@@ -97,7 +97,7 @@ The geom arrays involve two systems that are MuJoCo-internal, so their variables
 
 ### Geom Pose (geom_pos and geom_quat)
 
-`geom_pos` and `geom_quat` give the pose of the geom's frame relative to its parent body's frame. `geom_pos` is geomOrigin_parent_parentOrigin, the position of the geom frame's origin (in parent axes, relative to the parent frame's origin). `geom_quat` is scalar first, [w, x, y, z], and `mju_quat2Mat` converts it to R_pas_geom_to_parent, the passive rotation matrix which maps from geom axes to parent axes. Together they build the passive transformation which maps in homogeneous coordinates from geom axes relative to the geom frame's origin to parent axes relative to the parent frame's origin:
+`geom_pos` and `geom_quat` give the geom's position and orientation relative to its parent body. `geom_pos` is geomOrigin_parent_parentOrigin, the position of the geom origin (in parent axes, relative to the parent origin). `geom_quat` is scalar first, [w, x, y, z], and `mju_quat2Mat` converts it to R_pas_geom_to_parent, the passive rotation matrix which maps from geom axes to parent axes. Together they build the passive transformation which maps in homogeneous coordinates from geom axes relative to the geom origin to parent axes relative to the parent origin:
 
 ```python
 R_pas_geom_to_parent = np.zeros(9, dtype=float)

--- a/docs/MUJOCO_CONVENTIONS.md
+++ b/docs/MUJOCO_CONVENTIONS.md
@@ -1,6 +1,6 @@
 # MuJoCo Conventions
 
-This document gives the definitive interpretation of MuJoCo's state variables and how they map onto Ptera Software's conventions for axes, points, frames, angle vectors, and transformations. Every interpretation below was verified empirically through systematic testing during the development of free flight. The mapping is implemented by MuJoCoModel in `pterasoftware/_mujoco_model.py`, which is the one place the package interfaces with MuJoCo.
+This document gives the definitive interpretation of MuJoCo's state variables and compiled geometry constants, and how they map onto Ptera Software's conventions for axes, points, frames, angle vectors, and transformations. Every interpretation below was verified empirically through systematic testing during the development of free flight. The mapping is implemented by MuJoCoModel in `pterasoftware/_mujoco_model.py`, which is the one place the package interfaces with MuJoCo.
 
 Free flight support is single-airplane for now, so this document describes the state of the one free-jointed body in terms of the first Airplane's body axes (BP1). We define MuJoCo's world coordinates to be identical to Ptera Software's Earth axes (E), so no transformation is needed between MuJoCo's world and our Earth axes.
 
@@ -82,6 +82,70 @@ xfrc_applied[body_id][3:6] = moments_E_CgP1
 ```
 
 Verification: a torque of [10, 0, 0] applied to a rotated body always produced angular acceleration about Earth +x, regardless of the body's orientation.
+
+## MuJoCo Geom and Mesh Arrays
+
+The generated model XML contains no geoms of its own, so every geom in the compiled model comes from `extra_xml`. MuJoCoModel.get_render_geometry rebuilds their renderable surfaces from the compiled model's constant arrays alone, using the interpretations below, rather than parsing XML fragments or asset bytes.
+
+### Informal Axes and Point IDs (geom, geomOrigin, parent, and parentOrigin)
+
+The geom arrays involve two systems that are MuJoCo-internal, so their variables take informal lowercase IDs rather than IDs registered in AXES_POINTS_AND_FRAMES.md. The axes ID geom denotes a geom's own local axes, and the point ID geomOrigin denotes the geom frame's origin. The axes ID parent denotes the axes of the geom's parent body's frame, and the point ID parentOrigin denotes that frame's origin. For a geom attached to the free-jointed body, parent axes are the first Airplane's body axes and parentOrigin is the first Airplane's CG, since the generated body frame's origin coincides with the CG. For a worldbody geom, parent axes are Earth axes and parentOrigin is the Earth origin. A single variable over the geom arrays spans both cases, which is why no registered ID can be pinned on it.
+
+### Geom Ownership (geom_bodyid)
+
+`geom_bodyid` gives the index of the body a geom is attached to. The worldbody is body 0, and the generated model contains exactly one other body, so a geom is attached to the free-jointed body exactly when its `geom_bodyid` equals that body's ID. Worldbody geoms are static in Earth axes (MuJoCo's world coordinates are Earth axes), while body geoms ride with the first Airplane's body axes.
+
+### Geom Pose (geom_pos and geom_quat)
+
+`geom_pos` and `geom_quat` give the pose of the geom's frame relative to its parent body's frame. `geom_pos` is geomOrigin_parent_parentOrigin, the position of the geom frame's origin (in parent axes, relative to the parent frame's origin). `geom_quat` is scalar first, [w, x, y, z], and `mju_quat2Mat` converts it to R_pas_geom_to_parent, the passive rotation matrix which maps from geom axes to parent axes. Together they build the passive transformation which maps in homogeneous coordinates from geom axes relative to the geom frame's origin to parent axes relative to the parent frame's origin:
+
+```python
+R_pas_geom_to_parent = np.zeros(9, dtype=float)
+mujoco.mju_quat2Mat(R_pas_geom_to_parent, model.geom_quat[geom_id])
+R_pas_geom_to_parent = R_pas_geom_to_parent.reshape(3, 3)
+
+T_pas_geom_geomOrigin_to_parent_geomOrigin = np.eye(4, dtype=float)
+T_pas_geom_geomOrigin_to_parent_geomOrigin[:3, :3] = R_pas_geom_to_parent
+
+geomOrigin_parent_parentOrigin = model.geom_pos[geom_id]
+T_pas_parent_geomOrigin_to_parent_parentOrigin = _transformations.generate_trans_T(
+    translations=-geomOrigin_parent_parentOrigin, passive=True
+)
+
+T_pas_geom_geomOrigin_to_parent_parentOrigin = _transformations.compose_T_pas(
+    T_pas_geom_geomOrigin_to_parent_geomOrigin,
+    T_pas_parent_geomOrigin_to_parent_parentOrigin,
+)
+stackPoints_parent_parentOrigin = _transformations.apply_T_to_vectors(
+    T_pas_geom_geomOrigin_to_parent_parentOrigin,
+    stackPoints_geom_geomOrigin,
+    is_position=True,
+)
+```
+
+Verification: a geom authored with euler="0 90 0" produced a matrix mapping local +z to parent +x, which is the 90 degree rotation about y applied to geom-local coordinates.
+
+### Geom Sizes (geom_size)
+
+`geom_size` holds three slots whose meaning depends on `geom_type`:
+
+- plane: the half-extents of the rendered rectangle in the local x and y directions, then the spacing of its rendered grid lines. A zero half-extent marks the plane as infinite in that direction.
+- sphere: the radius, then two unused slots.
+- capsule: the radius, then the half-length of the cylindrical section (the axis is the local z axis), then an unused slot.
+- ellipsoid: the three radii.
+- cylinder: the radius, then the half-length (the axis is the local z axis), then an unused slot.
+- box: the three half-extents.
+- mesh: derived bounding information that the rendering path does not use.
+
+### Mesh Data (geom_dataid, mesh_vert, mesh_face, and their address arrays)
+
+`geom_dataid` gives a mesh geom's index into the mesh arrays, and is -1 for every other geom type. `mesh_vertadr` and `mesh_vertnum` locate a mesh's block in `mesh_vert`, and `mesh_faceadr` and `mesh_facenum` locate its block in `mesh_face`. Each face's three vertex indices are local to the mesh's own vertex block, not global into `mesh_vert`. The compiler re-centers and re-orients each mesh's stored vertices and folds the offset into the owning geom's `geom_pos` and `geom_quat`, so `mesh_vert` does not hold the authored vertices, and composing the stored vertices with the compiled geom pose is what reconstructs the authored placement.
+
+Verification: a tetrahedron authored with known vertices and posed with pos="1 2 3" and euler="0 90 0" compiled to re-centered vertices and a different geom pose, and applying that pose to the stored vertices reproduced the authored vertices under the authored pose. In a model with two meshes, the second mesh's face indices began at 0, confirming that face indices are local.
+
+### Geom Colors (geom_rgba, geom_matid, and mat_rgba)
+
+`geom_rgba` holds the geom's own display color and defaults to (0.5, 0.5, 0.5, 1.0). `geom_matid` is the index of the geom's material in `mat_rgba`, or -1 when no material is assigned. When a material is assigned, its rgba is the geom's display color.
 
 ## Common Pitfalls
 

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -522,15 +522,15 @@ class MuJoCoModel:
             R_pas_geom_to_parent = R_pas_geom_to_parent.reshape(3, 3)
 
             # Lift the rotation into the transformation that maps from geom axes to
-            # parent axes while holding the reference point at the geom frame's origin.
+            # parent axes while holding the reference point at the geom origin.
             T_pas_geom_geomOrigin_to_parent_geomOrigin = np.eye(4, dtype=float)
             T_pas_geom_geomOrigin_to_parent_geomOrigin[:3, :3] = R_pas_geom_to_parent
 
             # The geom's stored position is geomOrigin_parent_parentOrigin, the position
-            # of the geom frame's origin (in parent axes, relative to the parent frame's
-            # origin). For a passive translation, the parameter is the position of the
-            # final reference point (the parent frame's origin) relative to the initial
-            # one (the geom frame's origin), which is its negative.
+            # of the geom origin (in parent axes, relative to the parent origin). For a
+            # passive translation, the parameter is the position of the final reference
+            # point (the parent origin) relative to the initial one (the geom origin),
+            # which is its negative.
             geomOrigin_parent_parentOrigin = self._model.geom_pos[geom_id]
             T_pas_parent_geomOrigin_to_parent_parentOrigin = (
                 _transformations.generate_trans_T(
@@ -548,6 +548,15 @@ class MuJoCoModel:
                 T_pas_geom_geomOrigin_to_parent_parentOrigin,
                 geom_mesh.points,
                 is_position=True,
+            )
+
+            # Map the point normals as directions through the same transformation. A lit
+            # actor's shading reads the stored normals, so leaving them behind would
+            # light the geom as if it were unrotated.
+            geom_mesh.point_data["Normals"] = _transformations.apply_T_to_vectors(
+                T_pas_geom_geomOrigin_to_parent_parentOrigin,
+                np.asarray(geom_mesh.point_data["Normals"], dtype=float),
+                is_position=False,
             )
 
             # Take the display color from the geom's material when one is assigned and
@@ -570,8 +579,8 @@ class MuJoCoModel:
         return render_geoms
 
     def _get_local_geom_mesh(self, geom_id: int) -> pv.PolyData | None:
-        """Builds one geom's surface mesh (in geom axes, relative to the geom frame's
-        origin), or returns None for a geom with no finite surface to triangulate.
+        """Builds one geom's surface mesh (in geom axes, relative to the geom origin),
+        or returns None for a geom with no finite surface to triangulate.
 
         MuJoCo's geom_size semantics differ per geom type, so each supported type reads
         its own slots: a plane's first two sizes are the half-extents of its rendered
@@ -582,9 +591,9 @@ class MuJoCoModel:
         and face arrays instead.
 
         :param geom_id: The index of the geom in the compiled model's geom arrays.
-        :return: The geom's surface as a PolyData with its points (in geom axes,
-            relative to the geom frame's origin), or None for an infinite plane, a
-            heightfield, a signed distance field, or an unrecognized geom type.
+        :return: The geom's surface as a PolyData carrying point normals, with its
+            points (in geom axes, relative to the geom origin), or None for an infinite
+            plane, a heightfield, a signed distance field, or an unrecognized geom type.
         """
         geom_type = int(self._model.geom_type[geom_id])
         geom_size = self._model.geom_size[geom_id]
@@ -624,7 +633,10 @@ class MuJoCoModel:
             )
 
         if geom_type == mujoco.mjtGeom.mjGEOM_BOX:
-            return pv.Box(
+            # The box is the one primitive source that carries no point normals, so
+            # compute them here. Splitting the vertices keeps each face's normals its
+            # own, so the faces shade crisply instead of rounding over at the corners.
+            box_mesh: pv.PolyData = pv.Box(
                 bounds=(
                     -float(geom_size[0]),
                     float(geom_size[0]),
@@ -633,7 +645,8 @@ class MuJoCoModel:
                     -float(geom_size[2]),
                     float(geom_size[2]),
                 )
-            )
+            ).compute_normals(cell_normals=False, split_vertices=True)
+            return box_mesh
 
         if geom_type == mujoco.mjtGeom.mjGEOM_MESH:
             mesh_id = int(self._model.geom_dataid[geom_id])
@@ -653,7 +666,13 @@ class MuJoCoModel:
             ].astype(int)
             faces = np.hstack((np.full((face_count, 1), 3, dtype=int), triangles))
 
-            return pv.PolyData(vertices, faces.ravel())
+            # PyVista's primitive sources come with point normals, which the mesh geom's
+            # raw PolyData lacks, so compute them here to hold up get_render_geometry's
+            # guarantee that every returned mesh carries normals for lit rendering.
+            geom_mesh: pv.PolyData = pv.PolyData(
+                vertices, faces.ravel()
+            ).compute_normals(cell_normals=False)
+            return geom_mesh
 
         return None
 

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -502,9 +502,9 @@ class MuJoCoModel:
                 geom_label = f"'{geom_name}'" if geom_name else f"with ID {geom_id}"
                 _logger.warning(
                     _logging.indent()
-                    + "Not drawing the MuJoCo geom %s because it is %s, which has no "
-                    "finite surface to triangulate. The skipped shape still "
-                    "participates in the dynamics: it is just not drawn.",
+                    + "Not drawing the MuJoCo geom %s because it is %s, which this "
+                    "renderer does not support. The skipped shape still participates "
+                    "in the dynamics: it is just not drawn.",
                     geom_label,
                     shape_description,
                 )

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -550,14 +550,12 @@ class MuJoCoModel:
                 is_position=True,
             )
 
-            # Map the point normals as directions through the same transformation. A lit
-            # actor's shading reads the stored normals, so leaving them behind would
-            # light the geom as if it were unrotated.
-            geom_mesh.point_data["Normals"] = _transformations.apply_T_to_vectors(
-                T_pas_geom_geomOrigin_to_parent_parentOrigin,
-                np.asarray(geom_mesh.point_data["Normals"], dtype=float),
-                is_position=False,
-            )
+            # Drop any point normals the mesh's PyVista source attached. The rendering
+            # layer recomputes shading normals from the posed triangles when it adds
+            # each geom actor, so stored normals are never read, and ones left behind
+            # here would sit stale against the posed points.
+            if "Normals" in geom_mesh.point_data:
+                del geom_mesh.point_data["Normals"]
 
             # Take the display color from the geom's material when one is assigned and
             # from the geom's own rgba otherwise.
@@ -591,9 +589,9 @@ class MuJoCoModel:
         and face arrays instead.
 
         :param geom_id: The index of the geom in the compiled model's geom arrays.
-        :return: The geom's surface as a PolyData carrying point normals, with its
-            points (in geom axes, relative to the geom origin), or None for an infinite
-            plane, a heightfield, a signed distance field, or an unrecognized geom type.
+        :return: The geom's surface as a PolyData with its points (in geom axes,
+            relative to the geom origin), or None for an infinite plane, a heightfield,
+            a signed distance field, or an unrecognized geom type.
         """
         geom_type = int(self._model.geom_type[geom_id])
         geom_size = self._model.geom_size[geom_id]
@@ -633,10 +631,7 @@ class MuJoCoModel:
             )
 
         if geom_type == mujoco.mjtGeom.mjGEOM_BOX:
-            # The box is the one primitive source that carries no point normals, so
-            # compute them here. Splitting the vertices keeps each face's normals its
-            # own, so the faces shade crisply instead of rounding over at the corners.
-            box_mesh: pv.PolyData = pv.Box(
+            return pv.Box(
                 bounds=(
                     -float(geom_size[0]),
                     float(geom_size[0]),
@@ -645,8 +640,7 @@ class MuJoCoModel:
                     -float(geom_size[2]),
                     float(geom_size[2]),
                 )
-            ).compute_normals(cell_normals=False, split_vertices=True)
-            return box_mesh
+            )
 
         if geom_type == mujoco.mjtGeom.mjGEOM_MESH:
             mesh_id = int(self._model.geom_dataid[geom_id])
@@ -666,13 +660,7 @@ class MuJoCoModel:
             ].astype(int)
             faces = np.hstack((np.full((face_count, 1), 3, dtype=int), triangles))
 
-            # PyVista's primitive sources come with point normals, which the mesh geom's
-            # raw PolyData lacks, so compute them here to hold up get_render_geometry's
-            # guarantee that every returned mesh carries normals for lit rendering.
-            geom_mesh: pv.PolyData = pv.PolyData(
-                vertices, faces.ravel()
-            ).compute_normals(cell_normals=False)
-            return geom_mesh
+            return pv.PolyData(vertices, faces.ravel())
 
         return None
 

--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import NamedTuple, TypedDict
 
 import mujoco
 import numpy as np
+import pyvista as pv
 
-from . import _transformations
+from . import _logging, _transformations
+
+_logger = _logging.get_logger("_mujoco_model")
 
 
 class MuJoCoState(TypedDict):
@@ -18,6 +21,23 @@ class MuJoCoState(TypedDict):
     velocity_E__E: np.ndarray
     omegas_BP1__E: np.ndarray
     time: float
+
+
+class RenderGeom(NamedTuple):
+    """One geom's renderable form, extracted from the compiled MuJoCo model by
+    MuJoCoModel.get_render_geometry.
+
+    mesh holds the geom's surface with its points posed in the axes of the geom's
+    parent: the first Airplane's body axes (relative to the first Airplane's CG) when
+    body_attached is True, and Earth axes (relative to the Earth origin) when it is
+    False. rgba holds the geom's display color as a (4,) ndarray of floats in the range
+    [0.0, 1.0], taken from the geom's material when one is assigned and from the geom's
+    own rgba otherwise.
+    """
+
+    mesh: pv.PolyData
+    rgba: np.ndarray
+    body_attached: bool
 
 
 class MuJoCoModel:
@@ -38,6 +58,9 @@ class MuJoCoModel:
     save_state: Saves and returns a snapshot of the model's current integration state.
 
     restore_state: Restores the model to a previously saved integration state.
+
+    get_render_geometry: Extracts the renderable geometry of every geom in the compiled
+    model.
 
     **Notes:**
 
@@ -431,6 +454,208 @@ class MuJoCoModel:
 
         # Run forward kinematics to update dependent quantities.
         mujoco.mj_forward(self._model, self._data)
+
+    def get_render_geometry(self) -> list[RenderGeom]:
+        """Extracts the renderable geometry of every geom in the compiled model.
+
+        **Notes:**
+
+        The generated model XML contains no geoms of its own, so every geom in the
+        compiled model comes from the extra_xml fragments, and any mesh assets have
+        already been decoded by MuJoCo's compiler into flat vertex and face arrays. The
+        returned meshes are therefore rebuilt from the compiled model alone, without
+        parsing XML or re-reading asset bytes.
+
+        Each geom's points are posed in the axes of its parent. For geoms attached to
+        the body, that is the first Airplane's body axes, relative to the first
+        Airplane's CG. For geoms attached to the worldbody, that is Earth axes, relative
+        to the Earth origin, since MuJoCo's world coordinates are defined to be
+        identical to Earth axes.
+
+        Infinite planes, heightfields, and signed distance field geoms have no finite
+        surface to triangulate, so they are skipped with a logged warning. A skipped
+        geom still participates in the dynamics: it is just not drawn.
+
+        :return: A list of RenderGeoms, one per drawable geom, in the compiled model's
+            geom order.
+        """
+        render_geoms: list[RenderGeom] = []
+        for geom_id in range(self._model.ngeom):
+            geom_mesh = self._get_local_geom_mesh(geom_id)
+
+            if geom_mesh is None:
+                geom_type = int(self._model.geom_type[geom_id])
+                if geom_type == mujoco.mjtGeom.mjGEOM_PLANE:
+                    shape_description = "an infinite plane"
+                elif geom_type == mujoco.mjtGeom.mjGEOM_HFIELD:
+                    shape_description = "a heightfield"
+                elif geom_type == mujoco.mjtGeom.mjGEOM_SDF:
+                    shape_description = "a signed distance field"
+                else:
+                    shape_description = "an unsupported geom type"
+
+                # Describe the skipped geom by its name when it has one and by its ID
+                # otherwise.
+                geom_name = mujoco.mj_id2name(
+                    self._model, mujoco.mjtObj.mjOBJ_GEOM, geom_id
+                )
+                geom_label = f"'{geom_name}'" if geom_name else f"with ID {geom_id}"
+                _logger.warning(
+                    _logging.indent()
+                    + "Not drawing the MuJoCo geom %s because it is %s, which has no "
+                    "finite surface to triangulate. The skipped shape still "
+                    "participates in the dynamics: it is just not drawn.",
+                    geom_label,
+                    shape_description,
+                )
+                continue
+
+            # The geom's stored orientation quaternion (scalar first) encodes
+            # R_pas_geom_to_parent, the passive rotation from the geom's local axes to
+            # the axes of its parent. MUJOCO_CONVENTIONS.md declares the informal geom,
+            # geomOrigin, parent, and parentOrigin IDs used here. For a mesh geom, the
+            # compiler has already folded the mesh's re-centering and re-orientation
+            # into the stored pose, so applying it to the stored vertices reconstructs
+            # the authored placement.
+            R_pas_geom_to_parent: np.ndarray = np.zeros(9, dtype=float)
+            mujoco.mju_quat2Mat(R_pas_geom_to_parent, self._model.geom_quat[geom_id])
+            R_pas_geom_to_parent = R_pas_geom_to_parent.reshape(3, 3)
+
+            # Lift the rotation into the transformation that maps from geom axes to
+            # parent axes while holding the reference point at the geom frame's origin.
+            T_pas_geom_geomOrigin_to_parent_geomOrigin = np.eye(4, dtype=float)
+            T_pas_geom_geomOrigin_to_parent_geomOrigin[:3, :3] = R_pas_geom_to_parent
+
+            # The geom's stored position is geomOrigin_parent_parentOrigin, the position
+            # of the geom frame's origin (in parent axes, relative to the parent frame's
+            # origin). For a passive translation, the parameter is the position of the
+            # final reference point (the parent frame's origin) relative to the initial
+            # one (the geom frame's origin), which is its negative.
+            geomOrigin_parent_parentOrigin = self._model.geom_pos[geom_id]
+            T_pas_parent_geomOrigin_to_parent_parentOrigin = (
+                _transformations.generate_trans_T(
+                    translations=-geomOrigin_parent_parentOrigin, passive=True
+                )
+            )
+
+            T_pas_geom_geomOrigin_to_parent_parentOrigin = (
+                _transformations.compose_T_pas(
+                    T_pas_geom_geomOrigin_to_parent_geomOrigin,
+                    T_pas_parent_geomOrigin_to_parent_parentOrigin,
+                )
+            )
+            geom_mesh.points = _transformations.apply_T_to_vectors(
+                T_pas_geom_geomOrigin_to_parent_parentOrigin,
+                geom_mesh.points,
+                is_position=True,
+            )
+
+            # Take the display color from the geom's material when one is assigned and
+            # from the geom's own rgba otherwise.
+            mat_id = int(self._model.geom_matid[geom_id])
+            if mat_id >= 0:
+                rgba = self._model.mat_rgba[mat_id].astype(float)
+            else:
+                rgba = self._model.geom_rgba[geom_id].astype(float)
+
+            render_geoms.append(
+                RenderGeom(
+                    mesh=geom_mesh,
+                    rgba=rgba,
+                    body_attached=int(self._model.geom_bodyid[geom_id])
+                    == self._body_id,
+                )
+            )
+
+        return render_geoms
+
+    def _get_local_geom_mesh(self, geom_id: int) -> pv.PolyData | None:
+        """Builds one geom's surface mesh (in geom axes, relative to the geom frame's
+        origin), or returns None for a geom with no finite surface to triangulate.
+
+        MuJoCo's geom_size semantics differ per geom type, so each supported type reads
+        its own slots: a plane's first two sizes are the half-extents of its rendered
+        rectangle (zero meaning infinite), a sphere's first size is its radius, a
+        capsule's and a cylinder's are their radius and half-length (with their axis
+        along the local z axis), an ellipsoid's are its three radii, and a box's are its
+        three half-extents. A mesh geom ignores geom_size and reads the compiled vertex
+        and face arrays instead.
+
+        :param geom_id: The index of the geom in the compiled model's geom arrays.
+        :return: The geom's surface as a PolyData with its points (in geom axes,
+            relative to the geom frame's origin), or None for an infinite plane, a
+            heightfield, a signed distance field, or an unrecognized geom type.
+        """
+        geom_type = int(self._model.geom_type[geom_id])
+        geom_size = self._model.geom_size[geom_id]
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_PLANE:
+            # A zero half-extent marks the plane as infinite in that direction.
+            if geom_size[0] <= 0.0 or geom_size[1] <= 0.0:
+                return None
+            return pv.Plane(
+                direction=(0.0, 0.0, 1.0),
+                i_size=2.0 * float(geom_size[0]),
+                j_size=2.0 * float(geom_size[1]),
+            )
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_SPHERE:
+            return pv.Sphere(radius=float(geom_size[0]))
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_CAPSULE:
+            return pv.Capsule(
+                direction=(0.0, 0.0, 1.0),
+                radius=float(geom_size[0]),
+                cylinder_length=2.0 * float(geom_size[1]),
+            )
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_ELLIPSOID:
+            return pv.ParametricEllipsoid(
+                xradius=float(geom_size[0]),
+                yradius=float(geom_size[1]),
+                zradius=float(geom_size[2]),
+            )
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_CYLINDER:
+            return pv.Cylinder(
+                direction=(0.0, 0.0, 1.0),
+                radius=float(geom_size[0]),
+                height=2.0 * float(geom_size[1]),
+            )
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_BOX:
+            return pv.Box(
+                bounds=(
+                    -float(geom_size[0]),
+                    float(geom_size[0]),
+                    -float(geom_size[1]),
+                    float(geom_size[1]),
+                    -float(geom_size[2]),
+                    float(geom_size[2]),
+                )
+            )
+
+        if geom_type == mujoco.mjtGeom.mjGEOM_MESH:
+            mesh_id = int(self._model.geom_dataid[geom_id])
+            vert_start = int(self._model.mesh_vertadr[mesh_id])
+            vert_count = int(self._model.mesh_vertnum[mesh_id])
+            face_start = int(self._model.mesh_faceadr[mesh_id])
+            face_count = int(self._model.mesh_facenum[mesh_id])
+            vertices = self._model.mesh_vert[
+                vert_start : vert_start + vert_count
+            ].astype(float)
+
+            # The compiled face array holds each triangle's three vertex indices, local
+            # to the mesh's own vertex block. VTK's flat cell format prefixes each face
+            # with its point count.
+            triangles = self._model.mesh_face[
+                face_start : face_start + face_count
+            ].astype(int)
+            faces = np.hstack((np.full((face_count, 1), 3, dtype=int), triangles))
+
+            return pv.PolyData(vertices, faces.ravel())
+
+        return None
 
     def _rebuild_engine(self) -> None:
         """Rebuilds the native MuJoCo model and data objects from the stored XML string.

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -661,10 +661,6 @@ def transform_mesh(
     """Returns a copy of a PolyData mesh with its points mapped through a passive
     transformation.
 
-    Any point normals the mesh carries are mapped as directions through the same
-    transformation. A lit actor's shading reads the stored normals, so leaving them
-    behind would light a transformed mesh as if it still sat in its original pose.
-
     :param mesh: The PolyData mesh to transform.
     :param T_pas: A (4,4) ndarray of floats representing the passive transformation to
         apply to the mesh's points.
@@ -676,12 +672,6 @@ def transform_mesh(
         mesh.points,
         is_position=True,
     )
-    if "Normals" in transformed.point_data:
-        transformed.point_data["Normals"] = _transformations.apply_T_to_vectors(
-            T_pas,
-            np.asarray(mesh.point_data["Normals"], dtype=float),
-            is_position=False,
-        )
     return transformed
 
 
@@ -1283,21 +1273,32 @@ def add_mujoco_geometry(
     for posed_mesh, rgba in posed_meshes:
         color = (float(rgba[0]), float(rgba[1]), float(rgba[2]))
         opacity = float(rgba[3])
+
+        # Split the sharp edges so the shading stays crisp across creases. The split
+        # duplicates the points along edges sharper than PyVista's feature angle,
+        # letting each face shade with its own normal, where plain smooth shading would
+        # average one normal across the crease and smear it.
         plotter.add_mesh(
             posed_mesh,
             color=color,
             opacity=opacity,
             smooth_shading=True,
+            split_sharp_edges=True,
             ambient=_MUJOCO_GEOMETRY_AMBIENT,
             diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
             render=False,
         )
         if T_reflect is not None:
+            # Splitting the sharp edges recomputes the normals from the triangle
+            # winding, and a reflection inverts the winding's outward sense. Flip the
+            # reflected copy's faces so the recomputed normals point outward again
+            # instead of inverting the shading.
             plotter.add_mesh(
-                _reflect_mesh(posed_mesh, T_reflect),
+                _reflect_mesh(posed_mesh, T_reflect).flip_faces(),
                 color=mute_color(color, IMAGE_REFLECTION_MUTE_FACTOR),
                 opacity=opacity,
                 smooth_shading=True,
+                split_sharp_edges=True,
                 ambient=_MUJOCO_GEOMETRY_AMBIENT,
                 diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
                 render=False,

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -4,16 +4,27 @@ visualizations with PyVista."""
 from __future__ import annotations
 
 import math
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
 import matplotlib.colors
 import numpy as np
 import pyvista as pv
 import webp
 
-from . import _colormaps, _logging, _transformations, geometry
+from . import (
+    _colormaps,
+    _logging,
+    _mujoco_model,
+    _private_access,
+    _transformations,
+    free_flight_unsteady_ring_vortex_lattice_method,
+    geometry,
+)
 from . import operating_point as operating_point_mod
-from . import unsteady_ring_vortex_lattice_method
+from . import (
+    problems,
+    unsteady_ring_vortex_lattice_method,
+)
 
 _logger = _logging.get_logger("output")
 
@@ -33,6 +44,16 @@ _IMAGE_SURFACE_COLOR_B = np.array([80, 80, 80], dtype=np.uint8)
 TEXT_COLOR = (129, 129, 129)
 TEXT_COLOR_SURFACE = (220, 220, 220)
 PLOTTER_BACKGROUND_COLOR = "black"
+
+# Define the shading coefficients for the MuJoCo geom actors, which are the only lit
+# actors in any scene. Every other actor is added with lighting disabled, so the
+# headlight that add_mujoco_geometry brings into a scene shades the geoms alone, and a
+# scene without MuJoCo geoms never carries a light at all. An actor with lighting
+# disabled renders identically whether or not the scene holds a light, so the geoms'
+# shading leaves every other actor's appearance untouched. The ambient floor keeps the
+# faces the headlight misses from going black.
+_MUJOCO_GEOMETRY_AMBIENT = 0.3
+_MUJOCO_GEOMETRY_DIFFUSE = 0.7
 
 # Define the window length used to measure the largest window a window manager will
 # grant. X11 window dimensions are 16 bit, so this is the largest a window can ask to be
@@ -574,12 +595,75 @@ def get_free_flight_transformation(
     )
 
 
+def get_free_flight_body_transformation(
+    this_operating_point: operating_point_mod.OperatingPoint,
+) -> np.ndarray:
+    """Returns the passive transformation from the first Airplane's body axes, relative
+    to the first Airplane's CG, to Earth axes, relative to the Earth origin.
+
+    Body-attached MuJoCo geoms are rigid in the first Airplane's body axes, so posing
+    them for a time step chains the constant body axes to geometry axes rotation with
+    the same geometry axes to Earth axes transformation that the Panel meshes are mapped
+    through.
+
+    :param this_operating_point: The OperatingPoint whose Earth-frame position and
+        orientation define the transformation.
+    :return: A (4,4) ndarray of floats representing the passive transformation from the
+        first Airplane's body axes, relative to the first Airplane's CG, to Earth axes,
+        relative to the Earth origin.
+    """
+    return _transformations.compose_T_pas(
+        this_operating_point.T_pas_BP1_CgP1_to_GP1_CgP1,
+        get_free_flight_transformation(this_operating_point),
+    )
+
+
+def get_mujoco_render_geometry(
+    free_flight_solver: free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
+) -> tuple[list[_mujoco_model.RenderGeom], list[_mujoco_model.RenderGeom]]:
+    """Returns a free flight solver's MuJoCo render geometry, split into worldbody geoms
+    and body geoms.
+
+    The geometry comes from the compiled MuJoCo model held by the solver's
+    FreeFlightUnsteadyProblem, reached through the registration pattern in
+    _private_access.
+
+    :param free_flight_solver: The FreeFlightUnsteadyRingVortexLatticeMethodSolver whose
+        MuJoCo geometry will be returned.
+    :return: A tuple of two lists of RenderGeoms. The first holds the worldbody geoms,
+        whose meshes are in Earth axes, relative to the Earth origin. The second holds
+        the body geoms, whose meshes are in the first Airplane's body axes, relative to
+        the first Airplane's CG.
+    """
+    # The solver stores its problem widened to the core type, and its initialization
+    # validates that the problem is a FreeFlightUnsteadyProblem, so the cast narrows
+    # without a runtime check.
+    free_flight_unsteady_problem = cast(
+        problems.FreeFlightUnsteadyProblem, free_flight_solver.unsteady_problem
+    )
+    render_geoms = _private_access.get_mujoco_model(
+        free_flight_unsteady_problem
+    ).get_render_geometry()
+
+    worldbody_geoms = [
+        render_geom for render_geom in render_geoms if not render_geom.body_attached
+    ]
+    body_geoms = [
+        render_geom for render_geom in render_geoms if render_geom.body_attached
+    ]
+    return worldbody_geoms, body_geoms
+
+
 def transform_mesh(
     mesh: pv.PolyData,
     T_pas: np.ndarray,
 ) -> pv.PolyData:
     """Returns a copy of a PolyData mesh with its points mapped through a passive
     transformation.
+
+    Any point normals the mesh carries are mapped as directions through the same
+    transformation. A lit actor's shading reads the stored normals, so leaving them
+    behind would light a transformed mesh as if it still sat in its original pose.
 
     :param mesh: The PolyData mesh to transform.
     :param T_pas: A (4,4) ndarray of floats representing the passive transformation to
@@ -592,6 +676,12 @@ def transform_mesh(
         mesh.points,
         is_position=True,
     )
+    if "Normals" in transformed.point_data:
+        transformed.point_data["Normals"] = _transformations.apply_T_to_vectors(
+            T_pas,
+            np.asarray(mesh.point_data["Normals"], dtype=float),
+            is_position=False,
+        )
     return transformed
 
 
@@ -971,6 +1061,7 @@ def _plot_scalars(
         scalars=these_scalars,
         smooth_shading=False,
         scalar_bar_args=scalar_bar_args,  # type: ignore[arg-type]
+        lighting=False,
         render=False,
     )
 
@@ -1057,6 +1148,7 @@ def add_frame_geometry(
             line_width=_WAKE_VORTEX_EDGE_LINE_WIDTH * window_scale,
             smooth_shading=False,
             color=_WAKE_VORTEX_COLOR,
+            lighting=False,
             render=False,
         )
 
@@ -1082,6 +1174,7 @@ def add_frame_geometry(
             line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
             color=_PANEL_COLOR,
             smooth_shading=False,
+            lighting=False,
             render=False,
         )
 
@@ -1106,6 +1199,7 @@ def add_frame_geometry(
             scalars=coloring.scalars,
             smooth_shading=False,
             show_scalar_bar=False,
+            lighting=False,
             render=False,
         )
     else:
@@ -1116,6 +1210,7 @@ def add_frame_geometry(
             edge_color=muted_edge_color,
             color=mute_color(_PANEL_COLOR, mute),
             smooth_shading=False,
+            lighting=False,
             render=False,
         )
 
@@ -1128,5 +1223,82 @@ def add_frame_geometry(
             edge_color=muted_edge_color,
             smooth_shading=False,
             color=mute_color(_WAKE_VORTEX_COLOR, mute),
+            lighting=False,
             render=False,
         )
+
+
+def add_mujoco_geometry(
+    plotter: pv.Plotter,
+    worldbody_geoms: list[_mujoco_model.RenderGeom],
+    body_geoms: list[_mujoco_model.RenderGeom],
+    T_pas_BP1_CgP1_to_E_Eo: np.ndarray,
+    T_reflect: np.ndarray | None,
+) -> None:
+    """Adds one frame's MuJoCo geometry to a Plotter, alongside muted reflected copies
+    when an image surface is defined.
+
+    Worldbody geoms arrive with their meshes already in Earth axes, relative to the
+    Earth origin, where MuJoCo holds them static, so they are added as they are. Body
+    geoms arrive rigid in the first Airplane's body axes, relative to the first
+    Airplane's CG, so each frame maps them through that time step's transformation to
+    fly them along with the Panel meshes. The reflected copies are muted toward gray,
+    matching the Panel treatment, so they read as reflections rather than as more
+    geometry.
+
+    The geom actors are the only lit actors in any scene. When there is geometry to add,
+    a headlight comes with it, and every other actor disables its lighting, which
+    renders identically with or without a light present, so the shading reaches the
+    geoms alone and every scene without MuJoCo geometry stays free of lights entirely.
+
+    :param plotter: The Plotter to add the geometry to.
+    :param worldbody_geoms: The RenderGeoms attached to the worldbody.
+    :param body_geoms: The RenderGeoms attached to the body.
+    :param T_pas_BP1_CgP1_to_E_Eo: A (4,4) ndarray of floats representing the passive
+        transformation from the first Airplane's body axes, relative to the first
+        Airplane's CG, to Earth axes, relative to the Earth origin, at the frame's time
+        step.
+    :param T_reflect: A (4,4) ndarray of floats representing the active transformation
+        (in Earth axes) that reflects geometry across the image surface, or None when no
+        image surface is defined, in which case no reflected copies are added.
+    :return: None
+    """
+    posed_meshes = [
+        (render_geom.mesh, render_geom.rgba) for render_geom in worldbody_geoms
+    ] + [
+        (transform_mesh(render_geom.mesh, T_pas_BP1_CgP1_to_E_Eo), render_geom.rgba)
+        for render_geom in body_geoms
+    ]
+    if not posed_meshes:
+        return
+
+    # Add the headlight that shades the geom actors, which follows the camera so the
+    # geoms stay legible from any orientation the user chooses. Every non-geom actor is
+    # added with lighting disabled, which renders identically with or without a light in
+    # the scene, so the headlight changes nothing else. An animation clears the
+    # Plotter's lights along with its actors between frames, so the light is added here,
+    # once per assembled frame.
+    plotter.add_light(pv.Light(light_type="headlight"))
+
+    for posed_mesh, rgba in posed_meshes:
+        color = (float(rgba[0]), float(rgba[1]), float(rgba[2]))
+        opacity = float(rgba[3])
+        plotter.add_mesh(
+            posed_mesh,
+            color=color,
+            opacity=opacity,
+            smooth_shading=True,
+            ambient=_MUJOCO_GEOMETRY_AMBIENT,
+            diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
+            render=False,
+        )
+        if T_reflect is not None:
+            plotter.add_mesh(
+                _reflect_mesh(posed_mesh, T_reflect),
+                color=mute_color(color, IMAGE_REFLECTION_MUTE_FACTOR),
+                opacity=opacity,
+                smooth_shading=True,
+                ambient=_MUJOCO_GEOMETRY_AMBIENT,
+                diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
+                render=False,
+            )

--- a/pterasoftware/_private_access.py
+++ b/pterasoftware/_private_access.py
@@ -1,0 +1,49 @@
+"""Contains the registration pattern that grants cross-module access to private
+attributes, currently a FreeFlightUnsteadyProblem's MuJoCoModel for the rendering
+layer."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import _mujoco_model, problems
+
+# The getter that problems.py registers at import time. It is module private, so no
+# other module reads or writes it directly.
+_mujoco_model_getter: (
+    Callable[[problems.FreeFlightUnsteadyProblem], _mujoco_model.MuJoCoModel] | None
+) = None
+
+
+def register_mujoco_model_getter(
+    getter: Callable[[problems.FreeFlightUnsteadyProblem], _mujoco_model.MuJoCoModel],
+) -> None:
+    """Registers the getter that maps a FreeFlightUnsteadyProblem to its MuJoCoModel.
+
+    problems.py calls this once at import time with a getter defined there, which keeps
+    the read of the FreeFlightUnsteadyProblem's private slot inside the module that owns
+    it while letting the rendering layer reach the MuJoCoModel through get_mujoco_model.
+
+    :param getter: A callable that takes a FreeFlightUnsteadyProblem and returns its
+        MuJoCoModel.
+    :return: None
+    """
+    global _mujoco_model_getter
+    _mujoco_model_getter = getter
+
+
+def get_mujoco_model(
+    problem: problems.FreeFlightUnsteadyProblem,
+) -> _mujoco_model.MuJoCoModel:
+    """Returns a FreeFlightUnsteadyProblem's MuJoCoModel.
+
+    :param problem: The FreeFlightUnsteadyProblem whose MuJoCoModel will be returned.
+    :return: The FreeFlightUnsteadyProblem's MuJoCoModel.
+    """
+    # Constructing the FreeFlightUnsteadyProblem passed in requires importing
+    # problems.py, and that import registers the getter, so an unregistered getter is a
+    # programming error rather than a reachable state.
+    assert _mujoco_model_getter is not None
+    return _mujoco_model_getter(problem)

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -161,6 +161,7 @@ def draw(
     scalar_type: str | None = None,
     show_streamlines: bool | np.bool_ = False,
     show_wake_vortices: bool | np.bool_ = False,
+    show_mujoco_geometry: bool | np.bool_ = False,
     window_size: Sequence[int] = (1024, 768),
     save: bool | np.bool_ = False,
     path: str | Path = "draw.webp",
@@ -200,6 +201,12 @@ def draw(
         the solver must be an UnsteadyRingVortexLatticeMethodSolver and must have
         already been run. Can be a bool or a numpy bool and will be converted internally
         to a bool. The default is False.
+    :param show_mujoco_geometry: Set this to True to show the MuJoCo geometry that
+        extra_xml and mujoco_assets inject into the solver's model, with body geoms
+        posed at the drawn time step and worldbody geoms static in Earth axes. If True,
+        the solver must be a FreeFlightUnsteadyRingVortexLatticeMethodSolver. Can be a
+        bool or a numpy bool and will be converted internally to a bool. The default is
+        False.
     :param window_size: The width and height, in pixels, of the render window. This also
         sets the resolution of the saved WebP. It must be a sequence of two positive
         ints, and, when rendering on screen, must fit within the area the window manager
@@ -275,6 +282,18 @@ def draw(
     if show_wake_vortices and not solver.ran:
         raise RuntimeError(
             "solver must have run before drawing with show_wake_vortices set to True."
+        )
+
+    show_mujoco_geometry = _parameter_validation.boolLike_return_bool(
+        show_mujoco_geometry, "show_mujoco_geometry"
+    )
+    if show_mujoco_geometry and not isinstance(
+        solver,
+        free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
+    ):
+        raise ValueError(
+            "show_mujoco_geometry can only be True when drawing a "
+            "FreeFlightUnsteadyRingVortexLatticeMethodSolver."
         )
 
     if not isinstance(window_size, Sequence) or len(window_size) != 2:
@@ -422,13 +441,13 @@ def draw(
         window_scale,
     )
 
-    # For a free flight solver, gather the MuJoCo geometry that extra_xml injects. The
-    # geom actors are added later, between the camera's framing fit and its clipping
-    # fit, so the body geoms can join the framing bounds while the worldbody geoms join
-    # only the clipping range.
+    # If showing MuJoCo geometry, gather the geoms that extra_xml injects. The geom
+    # actors are added later, between the camera's framing fit and its clipping fit, so
+    # the body geoms can join the framing bounds while the worldbody geoms join only the
+    # clipping range.
     worldbody_geoms: list[_mujoco_model.RenderGeom] = []
     body_geoms: list[_mujoco_model.RenderGeom] = []
-    if is_free_flight:
+    if show_mujoco_geometry:
         assert isinstance(
             solver,
             free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
@@ -640,6 +659,7 @@ def animate(
     unsteady_solver: unsteady_ring_vortex_lattice_method.UnsteadyRingVortexLatticeMethodSolver,
     scalar_type: str | None = None,
     show_wake_vortices: bool | np.bool_ = False,
+    show_mujoco_geometry: bool | np.bool_ = False,
     window_size: Sequence[int] = (1024, 768),
     save: bool | np.bool_ = False,
     path: str | Path = "animate.webp",
@@ -666,6 +686,12 @@ def animate(
     :param show_wake_vortices: Set this to True to show any wake ring vortices. If True,
         the solver must have already been run. Can be a bool or a numpy bool and will be
         converted internally to a bool. The default is False.
+    :param show_mujoco_geometry: Set this to True to show the MuJoCo geometry that
+        extra_xml and mujoco_assets inject into the solver's model, with body geoms re-
+        posed every time step and worldbody geoms static in Earth axes. If True, the
+        unsteady_solver must be a FreeFlightUnsteadyRingVortexLatticeMethodSolver. Can
+        be a bool or a numpy bool and will be converted internally to a bool. The
+        default is False.
     :param window_size: The width and height, in pixels, of the render window. This also
         sets the resolution of the saved WebP. It must be a sequence of two positive
         ints, and, when rendering on screen, must fit within the area the window manager
@@ -730,6 +756,18 @@ def animate(
             " to True."
         )
 
+    show_mujoco_geometry = _parameter_validation.boolLike_return_bool(
+        show_mujoco_geometry, "show_mujoco_geometry"
+    )
+    if show_mujoco_geometry and not isinstance(
+        unsteady_solver,
+        free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
+    ):
+        raise ValueError(
+            "show_mujoco_geometry can only be True when animating a "
+            "FreeFlightUnsteadyRingVortexLatticeMethodSolver."
+        )
+
     if not isinstance(window_size, Sequence) or len(window_size) != 2:
         raise ValueError("window_size must be a sequence of two ints.")
     window_width = _parameter_validation.int_in_range_return_int(
@@ -777,13 +815,13 @@ def animate(
             for steady_problem in unsteady_solver.steady_problems
         ]
 
-    # For a free flight solver, gather the MuJoCo geometry that extra_xml injects, along
-    # with each time step's body axes to Earth axes transformation. The worldbody geoms
-    # stay fixed in Earth axes while the body geoms are re-posed every frame.
+    # If showing MuJoCo geometry, gather the geoms that extra_xml injects, along with
+    # each time step's body axes to Earth axes transformation. The worldbody geoms stay
+    # fixed in Earth axes while the body geoms are re-posed every frame.
     worldbody_geoms: list[_mujoco_model.RenderGeom] = []
     body_geoms: list[_mujoco_model.RenderGeom] = []
     step_body_transforms: list[np.ndarray] = []
-    if is_free_flight:
+    if show_mujoco_geometry:
         assert isinstance(
             unsteady_solver,
             free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
@@ -1034,8 +1072,8 @@ def animate(
         plotter, panel_surfaces, None, coloring, T_reflect, window_scale
     )
 
-    # For a free flight solver, add the MuJoCo geometry at the first time step's pose.
-    if is_free_flight:
+    # If showing MuJoCo geometry, add it at the first time step's pose.
+    if show_mujoco_geometry:
         _output_rendering.add_mujoco_geometry(
             plotter, worldbody_geoms, body_geoms, step_body_transforms[0], T_reflect
         )
@@ -1205,8 +1243,8 @@ def animate(
             window_scale,
         )
 
-        # For a free flight solver, add the MuJoCo geometry at this time step's pose.
-        if is_free_flight:
+        # If showing MuJoCo geometry, add it at this time step's pose.
+        if show_mujoco_geometry:
             _output_rendering.add_mujoco_geometry(
                 plotter,
                 worldbody_geoms,

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -422,8 +422,12 @@ def draw(
         window_scale,
     )
 
-    # For a free flight solver, add the MuJoCo geometry that extra_xml injects, with the
-    # body geoms posed at the drawn time step.
+    # For a free flight solver, gather the MuJoCo geometry that extra_xml injects. The
+    # geom actors are added later, between the camera's framing fit and its clipping
+    # fit, so the body geoms can join the framing bounds while the worldbody geoms join
+    # only the clipping range.
+    worldbody_geoms: list[_mujoco_model.RenderGeom] = []
+    body_geoms: list[_mujoco_model.RenderGeom] = []
     if is_free_flight:
         assert isinstance(
             solver,
@@ -431,13 +435,6 @@ def draw(
         )
         worldbody_geoms, body_geoms = _output_rendering.get_mujoco_render_geometry(
             solver
-        )
-        _output_rendering.add_mujoco_geometry(
-            plotter,
-            worldbody_geoms,
-            body_geoms,
-            _output_rendering.get_free_flight_body_transformation(draw_operating_point),
-            T_reflect,
         )
 
     # If showing streamlines, plot them.
@@ -545,7 +542,56 @@ def draw(
             center_E_Eo + 3.0 * airplane_diagonal * _freeFlightViewDirection_E
         )
         plotter.camera.up = _freeFlightViewUp_E
-        plotter.reset_camera()  # type: ignore[call-arg]
+
+        if worldbody_geoms or body_geoms:
+            # Fit the camera to explicit framing bounds: every actor already present,
+            # plus the body geoms posed at the drawn time step, plus their reflections
+            # when an image surface is defined. The fit re-centers the focal point on
+            # those bounds and keeps the view direction and up set above.
+            T_pas_BP1_CgP1_to_E_Eo = (
+                _output_rendering.get_free_flight_body_transformation(
+                    draw_operating_point
+                )
+            )
+            posed_body_geom_meshes = [
+                _output_rendering.transform_mesh(
+                    render_geom.mesh, T_pas_BP1_CgP1_to_E_Eo
+                )
+                for render_geom in body_geoms
+            ]
+            if T_reflect is not None:
+                posed_body_geom_meshes += [
+                    _output_rendering.transform_mesh(posed_body_geom_mesh, T_reflect)
+                    for posed_body_geom_mesh in posed_body_geom_meshes
+                ]
+            all_bounds = np.array(
+                [plotter.bounds]
+                + [
+                    posed_body_geom_mesh.bounds
+                    for posed_body_geom_mesh in posed_body_geom_meshes
+                ],
+                dtype=float,
+            )
+            framing_bounds = np.empty(6, dtype=float)
+            framing_bounds[0::2] = all_bounds[:, 0::2].min(axis=0)
+            framing_bounds[1::2] = all_bounds[:, 1::2].max(axis=0)
+            plotter.reset_camera(bounds=tuple(framing_bounds))  # type: ignore[call-arg]
+
+            # Add the geom actors only now, so the worldbody geoms stay out of the
+            # framing fit and a worldbody geom that is much larger than the body, like a
+            # ground plane, cannot dominate it. Then re-fit only the clipping range to
+            # all actors, which keeps the fitted framing while ensuring the worldbody
+            # geoms are not cut off.
+            _output_rendering.add_mujoco_geometry(
+                plotter,
+                worldbody_geoms,
+                body_geoms,
+                T_pas_BP1_CgP1_to_E_Eo,
+                T_reflect,
+            )
+            plotter.reset_camera_clipping_range()
+        else:
+            plotter.reset_camera()  # type: ignore[call-arg]
         draw_cpos = None
     elif image_surface_mesh is None:
         draw_cpos = (-1, -1, 1)
@@ -912,6 +958,27 @@ def animate(
             if last_step_wake_surfaces.n_points > 0:
                 framing_meshes.append(last_step_wake_surfaces)
                 free_flight_clip_meshes.append(last_step_wake_surfaces)
+
+        # The body geoms fly with the body, so they join the framing fit posed at both
+        # ends of the trajectory, keeping a geom that extends past the Panel surfaces
+        # from being cropped. Only the last time step's posed copies join the clipping
+        # meshes, since the first time step's geom actors are already present when the
+        # clipping range is sized. The worldbody geoms join neither: their actors are
+        # also present when the clipping range is sized, which keeps them visible
+        # without letting a worldbody geom that is much larger than the body, like a
+        # ground plane, dominate the framing fit.
+        first_step_body_geom_meshes = [
+            _output_rendering.transform_mesh(render_geom.mesh, step_body_transforms[0])
+            for render_geom in body_geoms
+        ]
+        last_step_body_geom_meshes = [
+            _output_rendering.transform_mesh(
+                render_geom.mesh, step_body_transforms[last_step]
+            )
+            for render_geom in body_geoms
+        ]
+        framing_meshes += first_step_body_geom_meshes + last_step_body_geom_meshes
+        free_flight_clip_meshes += last_step_body_geom_meshes
 
         # Fit the parallel scale (half the viewport height in world units, since the
         # projection is parallel) to the projected extent of that geometry about the

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -37,6 +37,7 @@ import webp
 from . import (
     _colormaps,
     _logging,
+    _mujoco_model,
     _output_plotting,
     _output_rendering,
     _parameter_validation,
@@ -421,6 +422,24 @@ def draw(
         window_scale,
     )
 
+    # For a free flight solver, add the MuJoCo geometry that extra_xml injects, with the
+    # body geoms posed at the drawn time step.
+    if is_free_flight:
+        assert isinstance(
+            solver,
+            free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
+        )
+        worldbody_geoms, body_geoms = _output_rendering.get_mujoco_render_geometry(
+            solver
+        )
+        _output_rendering.add_mujoco_geometry(
+            plotter,
+            worldbody_geoms,
+            body_geoms,
+            _output_rendering.get_free_flight_body_transformation(draw_operating_point),
+            T_reflect,
+        )
+
     # If showing streamlines, plot them.
     if show_streamlines:
         streamline_surfaces = _output_rendering.get_streamline_surfaces(
@@ -439,6 +458,7 @@ def draw(
             color=_STREAMLINE_COLOR,
             line_width=_STREAMLINE_LINE_WIDTH * window_scale,
             smooth_shading=False,
+            lighting=False,
             render=False,
         )
 
@@ -453,6 +473,7 @@ def draw(
                 ),
                 line_width=_STREAMLINE_LINE_WIDTH * window_scale,
                 smooth_shading=False,
+                lighting=False,
                 render=False,
             )
 
@@ -490,6 +511,7 @@ def draw(
             texture=image_surface_texture,
             opacity=_IMAGE_SURFACE_OPACITY,
             smooth_shading=True,
+            lighting=False,
             render=False,
         )
 
@@ -704,6 +726,27 @@ def animate(
     if is_free_flight:
         step_transforms = [
             _output_rendering.get_free_flight_transformation(
+                steady_problem.operating_point
+            )
+            for steady_problem in unsteady_solver.steady_problems
+        ]
+
+    # For a free flight solver, gather the MuJoCo geometry that extra_xml injects, along
+    # with each time step's body axes to Earth axes transformation. The worldbody geoms
+    # stay fixed in Earth axes while the body geoms are re-posed every frame.
+    worldbody_geoms: list[_mujoco_model.RenderGeom] = []
+    body_geoms: list[_mujoco_model.RenderGeom] = []
+    step_body_transforms: list[np.ndarray] = []
+    if is_free_flight:
+        assert isinstance(
+            unsteady_solver,
+            free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver,
+        )
+        worldbody_geoms, body_geoms = _output_rendering.get_mujoco_render_geometry(
+            unsteady_solver
+        )
+        step_body_transforms = [
+            _output_rendering.get_free_flight_body_transformation(
                 steady_problem.operating_point
             )
             for steady_problem in unsteady_solver.steady_problems
@@ -924,6 +967,12 @@ def animate(
         plotter, panel_surfaces, None, coloring, T_reflect, window_scale
     )
 
+    # For a free flight solver, add the MuJoCo geometry at the first time step's pose.
+    if is_free_flight:
+        _output_rendering.add_mujoco_geometry(
+            plotter, worldbody_geoms, body_geoms, step_body_transforms[0], T_reflect
+        )
+
     # If an image surface is defined, plot the pre-computed plane, set the camera
     # direction, and fit the camera to the last time step's geometry bounds so the view
     # is not dominated by the much larger image surface plane. When an image surface is
@@ -938,6 +987,7 @@ def animate(
             texture=image_surface_texture,
             opacity=_IMAGE_SURFACE_OPACITY,
             smooth_shading=True,
+            lighting=False,
             render=False,
         )
 
@@ -1007,7 +1057,7 @@ def animate(
     # would clip later frames.
     if is_free_flight:
         temporary_actors = [
-            plotter.add_mesh(clip_mesh, render=False)
+            plotter.add_mesh(clip_mesh, lighting=False, render=False)
             for clip_mesh in free_flight_clip_meshes
         ]
         plotter.reset_camera_clipping_range()
@@ -1088,6 +1138,16 @@ def animate(
             window_scale,
         )
 
+        # For a free flight solver, add the MuJoCo geometry at this time step's pose.
+        if is_free_flight:
+            _output_rendering.add_mujoco_geometry(
+                plotter,
+                worldbody_geoms,
+                body_geoms,
+                step_body_transforms[current_step],
+                T_reflect,
+            )
+
         # If an image surface is defined, add the pre-computed image surface plane.
         if T_reflect is not None:
             assert image_surface_mesh is not None
@@ -1096,6 +1156,7 @@ def animate(
                 texture=image_surface_texture,
                 opacity=_IMAGE_SURFACE_OPACITY,
                 smooth_shading=True,
+                lighting=False,
                 render=False,
             )
 

--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -33,6 +33,7 @@ from . import (
     _logging,
     _mujoco_model,
     _parameter_validation,
+    _private_access,
     _transformations,
     geometry,
     movements,
@@ -2218,3 +2219,24 @@ class AeroelasticUnsteadyProblem(_CoupledUnsteadyProblem):
         final_theta_derivative_rad = float(sol.y[1][-1])
 
         return final_theta_rad, final_theta_derivative_rad
+
+
+def _get_mujoco_model(
+    problem: FreeFlightUnsteadyProblem,
+) -> _mujoco_model.MuJoCoModel:
+    """Returns a FreeFlightUnsteadyProblem's MuJoCoModel.
+
+    Defined here so the read of the FreeFlightUnsteadyProblem's private slot stays
+    inside the module that owns it. Registering it with _private_access at import time
+    lets the rendering layer reach the MuJoCoModel without any cross-module private
+    access.
+
+    :param problem: The FreeFlightUnsteadyProblem whose MuJoCoModel will be returned.
+    :return: The FreeFlightUnsteadyProblem's MuJoCoModel.
+    """
+    return problem._mujoco_model
+
+
+# Register the getter at import time so the rendering layer can look up a
+# FreeFlightUnsteadyProblem's MuJoCoModel through _private_access.
+_private_access.register_mujoco_model_getter(_get_mujoco_model)

--- a/tests/integration/fixtures/problem_fixtures.py
+++ b/tests/integration/fixtures/problem_fixtures.py
@@ -302,7 +302,9 @@ def make_surface_effect_free_air_unsteady_problem() -> ps.problems.UnsteadyProbl
     return free_air_unsteady_problem
 
 
-def make_simple_glider_free_flight_problem() -> ps.problems.FreeFlightUnsteadyProblem:
+def make_simple_glider_free_flight_problem(
+    extra_xml: dict[str, str] | None = None,
+) -> ps.problems.FreeFlightUnsteadyProblem:
     """This function creates the simple glider's FreeFlightUnsteadyProblem to be used as
     a fixture.
 
@@ -313,6 +315,9 @@ def make_simple_glider_free_flight_problem() -> ps.problems.FreeFlightUnsteadyPr
     loads are applied, so the glider flies an unpowered glide driven only by its
     aerodynamics, gravity, and inertia.
 
+    :param extra_xml: dict or None A dict mapping injection point names to XML fragment
+        strings to inject into the FreeFlightUnsteadyProblem's generated MuJoCo XML. If
+        None, no extra XML is injected. The default is None.
     :return simple_glider_free_flight_problem: FreeFlightUnsteadyProblem This is the
         simple glider FreeFlightUnsteadyProblem fixture.
     """
@@ -345,6 +350,7 @@ def make_simple_glider_free_flight_problem() -> ps.problems.FreeFlightUnsteadyPr
         mass=mass,
         I_BP1_CgP1=I_BP1_CgP1,
         external_loads_fn=None,
+        extra_xml=extra_xml,
     )
 
     return simple_glider_free_flight_problem

--- a/tests/integration/fixtures/solver_fixtures.py
+++ b/tests/integration/fixtures/solver_fixtures.py
@@ -286,18 +286,23 @@ def make_unsteady_ring_vortex_lattice_method_free_air_solver() -> (
     return solver
 
 
-def make_simple_glider_free_flight_solver() -> (
+def make_simple_glider_free_flight_solver(
+    extra_xml: dict[str, str] | None = None,
+) -> (
     ps.free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver
 ):
     """This function creates the simple glider's free flight solver to be used as a
     fixture.
 
+    :param extra_xml: dict or None A dict mapping injection point names to XML fragment
+        strings to inject into the FreeFlightUnsteadyProblem's generated MuJoCo XML. If
+        None, no extra XML is injected. The default is None.
     :return simple_glider_free_flight_solver:
         FreeFlightUnsteadyRingVortexLatticeMethodSolver This is the simple glider
         FreeFlightUnsteadyRingVortexLatticeMethodSolver fixture.
     """
     simple_glider_free_flight_problem = (
-        problem_fixtures.make_simple_glider_free_flight_problem()
+        problem_fixtures.make_simple_glider_free_flight_problem(extra_xml=extra_xml)
     )
 
     simple_glider_free_flight_solver = ps.free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver(

--- a/tests/integration/test_output.py
+++ b/tests/integration/test_output.py
@@ -244,6 +244,9 @@ class TestFreeFlightOutput(unittest.TestCase):
     free_flight_solver: (
         ps.free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver
     )
+    mujoco_geometry_solver: (
+        ps.free_flight_unsteady_ring_vortex_lattice_method.FreeFlightUnsteadyRingVortexLatticeMethodSolver
+    )
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -253,6 +256,28 @@ class TestFreeFlightOutput(unittest.TestCase):
         """
         cls.free_flight_solver = solver_fixtures.make_simple_glider_free_flight_solver()
         cls.free_flight_solver.run(show_progress=False)
+
+        # This solver's problem injects a worldbody ground plane and two body geoms, so
+        # the tests can exercise the MuJoCo geometry rendering. The plane sits 50 meters
+        # below the glide with its contact side facing up, so it never touches the body
+        # geoms during the short simulation.
+        cls.mujoco_geometry_solver = (
+            solver_fixtures.make_simple_glider_free_flight_solver(
+                extra_xml={
+                    "worldbody": (
+                        '<geom name="ground" type="plane" size="50 50 1" pos="0 0 50" '
+                        'euler="180 0 0" rgba="0.6 0.5 0.3 1"/>'
+                    ),
+                    "body": (
+                        '<geom name="fuselage" type="box" size="0.2 0.05 0.05" '
+                        'rgba="0.2 0.4 0.8 1"/>'
+                        '<geom name="nose" type="sphere" size="0.06" pos="0.2 0 0" '
+                        'rgba="0.8 0.1 0.1 1"/>'
+                    ),
+                }
+            )
+        )
+        cls.mujoco_geometry_solver.run(show_progress=False)
 
     def test_draw_does_not_throw(self) -> None:
         """This method tests that the draw function does not throw any errors for a free
@@ -282,6 +307,21 @@ class TestFreeFlightOutput(unittest.TestCase):
             testing=True,
         )
 
+    def test_draw_with_mujoco_geometry_does_not_throw(self) -> None:
+        """This method tests that the draw function does not throw any errors for a free
+        flight solver when MuJoCo geometry is shown.
+
+        :return: None
+        """
+        ps.output.draw(
+            solver=self.mujoco_geometry_solver,
+            scalar_type=None,
+            show_wake_vortices=False,
+            show_streamlines=False,
+            show_mujoco_geometry=True,
+            testing=True,
+        )
+
     def test_animate_does_not_throw(self) -> None:
         """This method tests that the animate function does not throw any errors for a
         free flight solver.
@@ -306,6 +346,21 @@ class TestFreeFlightOutput(unittest.TestCase):
             unsteady_solver=self.free_flight_solver,
             scalar_type=None,
             show_wake_vortices=True,
+            save=False,
+            testing=True,
+        )
+
+    def test_animate_with_mujoco_geometry_does_not_throw(self) -> None:
+        """This method tests that the animate function does not throw any errors for a
+        free flight solver when MuJoCo geometry is shown.
+
+        :return: None
+        """
+        ps.output.animate(
+            unsteady_solver=self.mujoco_geometry_solver,
+            scalar_type=None,
+            show_wake_vortices=False,
+            show_mujoco_geometry=True,
             save=False,
             testing=True,
         )

--- a/tests/unit/fixtures/mujoco_model_fixtures.py
+++ b/tests/unit/fixtures/mujoco_model_fixtures.py
@@ -1,5 +1,6 @@
 """This module contains functions to create MuJoCoModels for use in tests."""
 
+import struct
 from collections.abc import Sequence
 
 import numpy as np
@@ -89,6 +90,99 @@ def make_pitched_mujoco_model_fixture(
     )
 
     return pitched_mujoco_model_fixture
+
+
+def make_tetrahedron_vertices_fixture() -> np.ndarray:
+    """This method makes a fixture that is the authored vertices of the tetrahedron
+    whose STL bytes make_tetrahedron_stl_bytes_fixture returns.
+
+    :return tetrahedron_vertices_fixture: ndarray This is a (4,3) ndarray of floats
+        representing the tetrahedron's vertices (in the mesh file's axes, relative to
+        the mesh file's origin).
+    """
+    return np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+
+
+def make_tetrahedron_stl_bytes_fixture() -> bytes:
+    """This method makes a fixture that is the binary STL contents of a tetrahedron.
+
+    The tetrahedron's vertices are those returned by make_tetrahedron_vertices_fixture.
+    MuJoCo requires a mesh to have at least four vertices, so a tetrahedron is the
+    smallest mesh a model can carry.
+
+    :return tetrahedron_stl_bytes_fixture: bytes This is the binary STL contents of the
+        tetrahedron.
+    """
+    vertices = make_tetrahedron_vertices_fixture()
+    faces = [(0, 2, 1), (0, 1, 3), (0, 3, 2), (1, 2, 3)]
+
+    header = b"\0" * 80
+    triangles = b""
+    for i0, i1, i2 in faces:
+        normal = struct.pack("<fff", 0.0, 0.0, 0.0)
+        triangle = b"".join(struct.pack("<fff", *vertices[i]) for i in (i0, i1, i2))
+        triangles += normal + triangle + struct.pack("<H", 0)
+
+    return header + struct.pack("<I", len(faces)) + triangles
+
+
+def make_render_geometry_mujoco_model_fixture() -> _mujoco_model.MuJoCoModel:
+    """This method makes a fixture that is a MuJoCoModel whose extra_xml injects one
+    geom of every drawable type.
+
+    The worldbody carries a finite plane, and the body carries a box, a sphere with a
+    red material, a capsule, a cylinder, an ellipsoid, and a tetrahedron mesh loaded
+    from mujoco_assets. The compiled model's geom order follows the document order, so
+    get_render_geometry returns the geoms in the order just listed. The box declares its
+    own rgba, the sphere takes its color from its material, and the mesh geom is posed
+    with a translation and a 90 degree rotation about its parent's y axis.
+
+    :return render_geometry_mujoco_model_fixture: MuJoCoModel This is the MuJoCoModel
+        with one geom of every drawable type.
+    """
+    extra_xml = {
+        "asset": (
+            "<asset>"
+            '<mesh name="tetrahedron" file="tetrahedron.stl"/>'
+            '<material name="red_material" rgba="1 0 0 1"/>'
+            "</asset>"
+        ),
+        "worldbody": '<geom name="ground" type="plane" size="5 4 0.1" pos="0 0 2"/>',
+        "body": (
+            '<geom name="box_geom" type="box" size="0.1 0.2 0.3" pos="1 2 3" '
+            'rgba="0.1 0.2 0.3 0.4"/>'
+            '<geom name="sphere_geom" type="sphere" size="0.5" '
+            'material="red_material"/>'
+            '<geom name="capsule_geom" type="capsule" size="0.1 0.4"/>'
+            '<geom name="cylinder_geom" type="cylinder" size="0.2 0.5"/>'
+            '<geom name="ellipsoid_geom" type="ellipsoid" size="0.1 0.2 0.3"/>'
+            '<geom name="mesh_geom" type="mesh" mesh="tetrahedron" pos="1 2 3" '
+            'euler="0 90 0"/>'
+        ),
+    }
+    mujoco_assets = {"tetrahedron.stl": make_tetrahedron_stl_bytes_fixture()}
+
+    render_geometry_mujoco_model_fixture = _mujoco_model.MuJoCoModel(
+        name="render_geometry_airplane",
+        mass=1.0,
+        omegas_BP1__E=np.array((0.0, 0.0, 0.0)),
+        T_pas_BP1_CgP1_to_E_CgP1=np.eye(4, dtype=float),
+        vCg_E__E=np.array((10.0, 0.0, 0.0)),
+        I_BP1_CgP1=np.eye(3, dtype=float),
+        delta_time=0.01,
+        extra_xml=extra_xml,
+        mujoco_assets=mujoco_assets,
+    )
+
+    return render_geometry_mujoco_model_fixture
 
 
 def make_basic_mujoco_model_name_fixture() -> str:

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -217,6 +217,7 @@ def make_basic_free_flight_unsteady_problem_fixture(
         | None
     ) = None,
     mujoco_assets: dict[str, bytes] | None = None,
+    extra_xml: dict[str, str] | None = None,
 ) -> ps.problems.FreeFlightUnsteadyProblem:
     """This method makes a fixture that is a FreeFlightUnsteadyProblem for general
     testing.
@@ -230,6 +231,9 @@ def make_basic_free_flight_unsteady_problem_fixture(
     :param mujoco_assets: dict or None A dict mapping virtual filenames to their binary
         contents for the MuJoCo model. If None, no extra assets are provided. The
         default is None.
+    :param extra_xml: dict or None A dict mapping injection point names to XML fragment
+        strings to inject into the generated MuJoCo XML. If None, no extra XML is
+        injected. The default is None.
     :return basic_free_flight_unsteady_problem_fixture: FreeFlightUnsteadyProblem This
         is the FreeFlightUnsteadyProblem configured for general testing.
     """
@@ -303,6 +307,7 @@ def make_basic_free_flight_unsteady_problem_fixture(
         I_BP1_CgP1=np.diag([1.0, 1.0, 1.0]),
         external_loads_fn=external_loads_fn,
         mujoco_assets=mujoco_assets,
+        extra_xml=extra_xml,
     )
 
     return basic_free_flight_unsteady_problem_fixture

--- a/tests/unit/fixtures/solver_fixtures.py
+++ b/tests/unit/fixtures/solver_fixtures.py
@@ -108,17 +108,22 @@ def make_coupled_unsteady_ring_solver_fixture() -> (
     return solver
 
 
-def make_free_flight_unsteady_ring_solver_fixture() -> (
-    FreeFlightUnsteadyRingVortexLatticeMethodSolver
-):
+def make_free_flight_unsteady_ring_solver_fixture(
+    extra_xml: dict[str, str] | None = None,
+) -> FreeFlightUnsteadyRingVortexLatticeMethodSolver:
     """This method makes a fixture that is a
     FreeFlightUnsteadyRingVortexLatticeMethodSolver for general testing.
 
+    :param extra_xml: dict or None A dict mapping injection point names to XML fragment
+        strings to inject into the FreeFlightUnsteadyProblem's generated MuJoCo XML. If
+        None, no extra XML is injected. The default is None.
     :return solver: FreeFlightUnsteadyRingVortexLatticeMethodSolver This is the
         FreeFlightUnsteadyRingVortexLatticeMethodSolver fixture.
     """
     free_flight_unsteady_problem = (
-        problem_fixtures.make_basic_free_flight_unsteady_problem_fixture()
+        problem_fixtures.make_basic_free_flight_unsteady_problem_fixture(
+            extra_xml=extra_xml
+        )
     )
 
     solver = FreeFlightUnsteadyRingVortexLatticeMethodSolver(

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -776,6 +776,16 @@ class TestMuJoCoModelGetRenderGeometry(unittest.TestCase):
         for render_geom in self.render_geoms:
             self.assertIsInstance(render_geom.mesh, pv.PolyData)
 
+    def test_meshes_carry_point_normals(self) -> None:
+        """Test that every RenderGeom's mesh carries point normals.
+
+        The rendering layer lights the geom actors, and a lit actor's shading reads the
+        stored normals, so every returned mesh must carry them, including the
+        tetrahedron mesh, whose compiled vertex and face arrays hold none.
+        """
+        for render_geom in self.render_geoms:
+            self.assertIn("Normals", render_geom.mesh.point_data)
+
     def test_model_without_extra_geometry_returns_empty_list(self) -> None:
         """Test that a model with no extra_xml geoms returns an empty list."""
         model = mujoco_model_fixtures.make_basic_mujoco_model_fixture()

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -6,9 +6,10 @@ import unittest
 import mujoco
 import numpy as np
 import numpy.testing as npt
+import pyvista as pv
 
 # noinspection PyProtectedMember
-from pterasoftware import _mujoco_model
+from pterasoftware import _mujoco_model, _transformations
 from tests.unit.fixtures import mujoco_model_fixtures
 
 
@@ -743,3 +744,209 @@ class TestMuJoCoModelConventions(unittest.TestCase):
         self.assertGreater(velocity_E__E[0], 0.0)
         self.assertGreater(abs(velocity_E__E[0]), 10.0 * abs(velocity_E__E[1]))
         self.assertGreater(abs(velocity_E__E[0]), 10.0 * abs(velocity_E__E[2]))
+
+
+class TestMuJoCoModelGetRenderGeometry(unittest.TestCase):
+    """This class contains methods for testing MuJoCoModel.get_render_geometry.
+
+    The shared fixture's geoms arrive in document order: the worldbody plane, then the
+    body's box, sphere, capsule, cylinder, ellipsoid, and tetrahedron mesh. The
+    tessellated primitives (the sphere, capsule, cylinder, and ellipsoid) inscribe their
+    ideal surfaces, so their bounds are compared with a loose tolerance, while the box,
+    plane, and mesh vertices are exact.
+    """
+
+    render_geoms: list[_mujoco_model.RenderGeom]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up the shared test fixtures."""
+        cls.render_geoms = (
+            mujoco_model_fixtures.make_render_geometry_mujoco_model_fixture()
+        ).get_render_geometry()
+
+    def test_returns_one_render_geom_per_drawable_geom(self) -> None:
+        """Test that every drawable geom produces one RenderGeom."""
+        self.assertEqual(len(self.render_geoms), 7)
+        for render_geom in self.render_geoms:
+            self.assertIsInstance(render_geom, _mujoco_model.RenderGeom)
+
+    def test_meshes_are_polydata(self) -> None:
+        """Test that every RenderGeom's mesh is a PolyData."""
+        for render_geom in self.render_geoms:
+            self.assertIsInstance(render_geom.mesh, pv.PolyData)
+
+    def test_model_without_extra_geometry_returns_empty_list(self) -> None:
+        """Test that a model with no extra_xml geoms returns an empty list."""
+        model = mujoco_model_fixtures.make_basic_mujoco_model_fixture()
+        self.assertEqual(model.get_render_geometry(), [])
+
+    def test_worldbody_geoms_are_not_body_attached(self) -> None:
+        """Test that a worldbody geom's body_attached flag is False."""
+        self.assertFalse(self.render_geoms[0].body_attached)
+
+    def test_body_geoms_are_body_attached(self) -> None:
+        """Test that every body geom's body_attached flag is True."""
+        for render_geom in self.render_geoms[1:]:
+            self.assertTrue(render_geom.body_attached)
+
+    def test_rgba_defaults_to_the_geoms_rgba(self) -> None:
+        """Test that a geom without a material takes its own rgba."""
+        npt.assert_allclose(
+            self.render_geoms[1].rgba, np.array([0.1, 0.2, 0.3, 0.4]), atol=1e-6
+        )
+
+    def test_rgba_uses_the_material_when_assigned(self) -> None:
+        """Test that a geom with a material takes the material's rgba."""
+        npt.assert_allclose(
+            self.render_geoms[2].rgba, np.array([1.0, 0.0, 0.0, 1.0]), atol=1e-6
+        )
+
+    def test_plane_quad_matches_half_extents_and_position(self) -> None:
+        """Test that a finite plane becomes a quad spanning its half-extents at its
+        authored position."""
+        npt.assert_allclose(
+            self.render_geoms[0].mesh.bounds,
+            (-5.0, 5.0, -4.0, 4.0, 2.0, 2.0),
+            atol=1e-6,
+        )
+
+    def test_box_bounds_match_half_extents_and_position(self) -> None:
+        """Test that a box's bounds span its half-extents about its authored
+        position."""
+        npt.assert_allclose(
+            self.render_geoms[1].mesh.bounds,
+            (0.9, 1.1, 1.8, 2.2, 2.7, 3.3),
+            atol=1e-6,
+        )
+
+    def test_sphere_bounds_match_radius(self) -> None:
+        """Test that a sphere's bounds span its radius."""
+        npt.assert_allclose(
+            self.render_geoms[2].mesh.bounds,
+            (-0.5, 0.5, -0.5, 0.5, -0.5, 0.5),
+            atol=1e-2,
+        )
+
+    def test_capsule_bounds_match_radius_and_half_length(self) -> None:
+        """Test that a capsule's axis is the local z axis, with bounds spanning its
+        radius laterally and its half-length plus its radius axially."""
+        npt.assert_allclose(
+            self.render_geoms[3].mesh.bounds,
+            (-0.1, 0.1, -0.1, 0.1, -0.5, 0.5),
+            atol=1e-2,
+        )
+
+    def test_cylinder_bounds_match_radius_and_half_length(self) -> None:
+        """Test that a cylinder's axis is the local z axis, with bounds spanning its
+        radius laterally and its half-length axially."""
+        npt.assert_allclose(
+            self.render_geoms[4].mesh.bounds,
+            (-0.2, 0.2, -0.2, 0.2, -0.5, 0.5),
+            atol=1e-2,
+        )
+
+    def test_ellipsoid_bounds_match_radii(self) -> None:
+        """Test that an ellipsoid's bounds span its three radii."""
+        npt.assert_allclose(
+            self.render_geoms[5].mesh.bounds,
+            (-0.1, 0.1, -0.2, 0.2, -0.3, 0.3),
+            atol=1e-2,
+        )
+
+    def test_mesh_geom_reconstructs_the_authored_placement(self) -> None:
+        """Test that a mesh geom's points match the authored vertices under the authored
+        pose.
+
+        The compiler re-centers and re-orients a mesh's stored vertices and folds the
+        offset into the geom's position and orientation, so recovering the authored
+        placement proves that get_render_geometry composes the stored vertices with the
+        compiled pose correctly. The fixture poses the tetrahedron with a 90 degree
+        rotation about its parent's y axis followed by a translation of (1.0, 2.0, 3.0),
+        and the mesh geom is attached to the body, so the expected points are in the
+        first Airplane's body axes, relative to the first Airplane's CG.
+        """
+        rotate_T_act = _transformations.generate_rot_T(
+            angles=np.array([0.0, 90.0, 0.0]),
+            passive=False,
+            intrinsic=False,
+            order="xyz",
+        )
+        translate_T_act = _transformations.generate_trans_T(
+            translations=np.array([1.0, 2.0, 3.0]), passive=False
+        )
+        pose_T_act = _transformations.compose_T_act(rotate_T_act, translate_T_act)
+        stackExpectedPoints_BP1_CgP1 = _transformations.apply_T_to_vectors(
+            pose_T_act,
+            mujoco_model_fixtures.make_tetrahedron_vertices_fixture(),
+            is_position=True,
+        )
+
+        stackRebuiltPoints_BP1_CgP1 = np.asarray(
+            self.render_geoms[6].mesh.points, dtype=float
+        )
+
+        # The compiler may reorder the vertices, so match each authored vertex to its
+        # nearest rebuilt point rather than comparing row by row. The authored vertices
+        # are pairwise distinct, so requiring every one of them to sit within tolerance
+        # of a rebuilt point, with the counts equal, proves the two sets match.
+        self.assertEqual(
+            len(stackRebuiltPoints_BP1_CgP1), len(stackExpectedPoints_BP1_CgP1)
+        )
+        for expectedPoint_BP1_CgP1 in stackExpectedPoints_BP1_CgP1:
+            distances = np.linalg.norm(
+                stackRebuiltPoints_BP1_CgP1 - expectedPoint_BP1_CgP1, axis=1
+            )
+            self.assertLess(float(distances.min()), 1e-6)
+
+    def test_skips_infinite_plane_with_warning(self) -> None:
+        """Test that an infinite plane is skipped with a warning naming the geom and
+        stating that it still participates in the dynamics."""
+        model = _mujoco_model.MuJoCoModel(
+            name="infinite_plane_airplane",
+            mass=1.0,
+            omegas_BP1__E=np.array((0.0, 0.0, 0.0)),
+            T_pas_BP1_CgP1_to_E_CgP1=np.eye(4, dtype=float),
+            vCg_E__E=np.array((10.0, 0.0, 0.0)),
+            I_BP1_CgP1=np.eye(3, dtype=float),
+            delta_time=0.01,
+            extra_xml={"worldbody": '<geom name="endless" type="plane" size="0 0 1"/>'},
+        )
+
+        with self.assertLogs("pterasoftware._mujoco_model", level="WARNING") as logs:
+            render_geoms = model.get_render_geometry()
+
+        self.assertEqual(render_geoms, [])
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("'endless'", logs.output[0])
+        self.assertIn("an infinite plane", logs.output[0])
+        self.assertIn("still participates in the dynamics", logs.output[0])
+
+    def test_skips_heightfield_with_warning(self) -> None:
+        """Test that a heightfield is skipped with a warning naming the geom and stating
+        that it still participates in the dynamics."""
+        model = _mujoco_model.MuJoCoModel(
+            name="heightfield_airplane",
+            mass=1.0,
+            omegas_BP1__E=np.array((0.0, 0.0, 0.0)),
+            T_pas_BP1_CgP1_to_E_CgP1=np.eye(4, dtype=float),
+            vCg_E__E=np.array((10.0, 0.0, 0.0)),
+            I_BP1_CgP1=np.eye(3, dtype=float),
+            delta_time=0.01,
+            extra_xml={
+                "asset": (
+                    '<asset><hfield name="terrain" nrow="2" ncol="2" '
+                    'size="1 1 0.1 0.01"/></asset>'
+                ),
+                "worldbody": '<geom name="rough" type="hfield" hfield="terrain"/>',
+            },
+        )
+
+        with self.assertLogs("pterasoftware._mujoco_model", level="WARNING") as logs:
+            render_geoms = model.get_render_geometry()
+
+        self.assertEqual(render_geoms, [])
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("'rough'", logs.output[0])
+        self.assertIn("a heightfield", logs.output[0])
+        self.assertIn("still participates in the dynamics", logs.output[0])

--- a/tests/unit/test_mujoco_model.py
+++ b/tests/unit/test_mujoco_model.py
@@ -776,15 +776,15 @@ class TestMuJoCoModelGetRenderGeometry(unittest.TestCase):
         for render_geom in self.render_geoms:
             self.assertIsInstance(render_geom.mesh, pv.PolyData)
 
-    def test_meshes_carry_point_normals(self) -> None:
-        """Test that every RenderGeom's mesh carries point normals.
+    def test_meshes_carry_no_point_normals(self) -> None:
+        """Test that no RenderGeom's mesh carries stored point normals.
 
-        The rendering layer lights the geom actors, and a lit actor's shading reads the
-        stored normals, so every returned mesh must carry them, including the
-        tetrahedron mesh, whose compiled vertex and face arrays hold none.
+        The rendering layer recomputes shading normals from the posed triangles when it
+        adds each geom actor, so stored normals are never read, and ones left behind by
+        a PyVista primitive source would sit stale against the posed points.
         """
         for render_geom in self.render_geoms:
-            self.assertIn("Normals", render_geom.mesh.point_data)
+            self.assertNotIn("Normals", render_geom.mesh.point_data)
 
     def test_model_without_extra_geometry_returns_empty_list(self) -> None:
         """Test that a model with no extra_xml geoms returns an empty list."""

--- a/tests/unit/test_output_rendering.py
+++ b/tests/unit/test_output_rendering.py
@@ -17,7 +17,11 @@ import pterasoftware as ps
 
 # noinspection PyProtectedMember
 from pterasoftware import _colormaps, _output_rendering, _transformations
-from tests.unit.fixtures import operating_point_fixtures, output_rendering_fixtures
+from tests.unit.fixtures import (
+    operating_point_fixtures,
+    output_rendering_fixtures,
+    solver_fixtures,
+)
 
 
 class TestGetWindowScale(unittest.TestCase):
@@ -256,6 +260,100 @@ class TestGetFreeFlightTransformation(unittest.TestCase):
         )
 
 
+class TestGetFreeFlightBodyTransformation(unittest.TestCase):
+    """This class contains methods for testing
+    _output_rendering.get_free_flight_body_transformation."""
+
+    def test_maps_the_cg_onto_its_earth_position(self) -> None:
+        """Test that the first Airplane's CG lands at its position in Earth axes.
+
+        The CG is the origin of the body axes the transformation maps out of, so
+        wherever the first Airplane has flown to, the CG maps onto that position.
+        """
+        operating_point = (
+            operating_point_fixtures.make_with_cg_position_operating_point_fixture()
+        )
+        T_pas = _output_rendering.get_free_flight_body_transformation(operating_point)
+        Cg_E_Eo = _transformations.apply_T_to_vectors(
+            T_pas, np.zeros(3, dtype=float), is_position=True
+        )
+        npt.assert_allclose(Cg_E_Eo, operating_point.CgP1_E_Eo, atol=1e-12)
+
+    def test_aligns_body_axes_with_earth_axes_at_zero_body_angles(self) -> None:
+        """Test that the transformation is the identity for a first Airplane at the
+        Earth origin with zero body angles.
+
+        At zero body angles, the geometry axes to Earth axes rotation is the same 180
+        degree rotation about the y axis as the constant body axes to geometry axes
+        rotation, so chaining the two cancels them and the body axes coincide with Earth
+        axes.
+        """
+        operating_point = operating_point_fixtures.make_basic_operating_point_fixture()
+        npt.assert_allclose(
+            _output_rendering.get_free_flight_body_transformation(operating_point),
+            np.eye(4, dtype=float),
+            atol=1e-12,
+        )
+
+    def test_leaves_directions_untranslated(self) -> None:
+        """Test that the translation reaches positions alone.
+
+        A direction has no reference point, so mapping one through this transformation
+        must give what chaining the body axes to geometry axes and geometry axes to
+        Earth axes rotations alone gives.
+        """
+        operating_point = (
+            operating_point_fixtures.make_with_cg_position_operating_point_fixture()
+        )
+        direction_BP1 = np.array([1.0, 2.0, 3.0], dtype=float)
+        direction_GP1 = _transformations.apply_T_to_vectors(
+            operating_point.T_pas_BP1_CgP1_to_GP1_CgP1,
+            direction_BP1,
+            is_position=False,
+        )
+        npt.assert_allclose(
+            _transformations.apply_T_to_vectors(
+                _output_rendering.get_free_flight_body_transformation(operating_point),
+                direction_BP1,
+                is_position=False,
+            ),
+            _transformations.apply_T_to_vectors(
+                operating_point.T_pas_GP1_CgP1_to_E_CgP1,
+                direction_GP1,
+                is_position=False,
+            ),
+            atol=1e-12,
+        )
+
+
+class TestGetMuJoCoRenderGeometry(unittest.TestCase):
+    """This class contains methods for testing
+    _output_rendering.get_mujoco_render_geometry."""
+
+    def test_splits_worldbody_and_body_geoms(self) -> None:
+        """Test that worldbody geoms and body geoms land in their own lists."""
+        solver = solver_fixtures.make_free_flight_unsteady_ring_solver_fixture(
+            extra_xml={
+                "worldbody": '<geom name="ground" type="plane" size="5 4 0.1"/>',
+                "body": '<geom name="box_geom" type="box" size="0.1 0.2 0.3"/>',
+            }
+        )
+        worldbody_geoms, body_geoms = _output_rendering.get_mujoco_render_geometry(
+            solver
+        )
+
+        self.assertEqual(len(worldbody_geoms), 1)
+        self.assertFalse(worldbody_geoms[0].body_attached)
+        self.assertEqual(len(body_geoms), 1)
+        self.assertTrue(body_geoms[0].body_attached)
+
+    def test_returns_empty_lists_without_extra_geometry(self) -> None:
+        """Test that a solver whose model carries no extra geoms returns two empty
+        lists."""
+        solver = solver_fixtures.make_free_flight_unsteady_ring_solver_fixture()
+        self.assertEqual(_output_rendering.get_mujoco_render_geometry(solver), ([], []))
+
+
 class TestGetPanelSurfaces(unittest.TestCase):
     """This class contains methods for testing _output_rendering.get_panel_surfaces."""
 
@@ -456,6 +554,34 @@ class TestTransformMesh(unittest.TestCase):
         mesh = output_rendering_fixtures.make_cube_mesh_fixture()
         transformed = _output_rendering.transform_mesh(mesh, np.eye(4, dtype=float))
         npt.assert_array_equal(transformed.faces, mesh.faces)
+
+    def test_maps_the_normals_as_directions(self) -> None:
+        """Test that point normals rotate with the mesh and ignore the translation.
+
+        A lit actor's shading reads the stored normals, so a mesh whose normals stayed
+        behind would be lit as if it still sat in its original pose. A direction has no
+        reference point, so the translation must not reach the normals.
+        """
+        mesh = pv.Plane(direction=(0.0, 0.0, 1.0), i_size=2.0, j_size=2.0)
+        rotate_T_pas = _transformations.generate_rot_T(
+            angles=np.array([180.0, 0.0, 0.0]),
+            passive=True,
+            intrinsic=False,
+            order="xyz",
+        )
+        translate_T_pas = _transformations.generate_trans_T(
+            translations=np.array([1.0, 2.0, 3.0], dtype=float), passive=True
+        )
+        T_pas = _transformations.compose_T_pas(rotate_T_pas, translate_T_pas)
+
+        transformed = _output_rendering.transform_mesh(mesh, T_pas)
+
+        expected_normals = np.tile(
+            np.array([0.0, 0.0, -1.0], dtype=float), (mesh.n_points, 1)
+        )
+        npt.assert_allclose(
+            transformed.point_data["Normals"], expected_normals, atol=1e-12
+        )
 
 
 class TestGetFreeFlightFitParallelScale(unittest.TestCase):

--- a/tests/unit/test_output_rendering.py
+++ b/tests/unit/test_output_rendering.py
@@ -555,34 +555,6 @@ class TestTransformMesh(unittest.TestCase):
         transformed = _output_rendering.transform_mesh(mesh, np.eye(4, dtype=float))
         npt.assert_array_equal(transformed.faces, mesh.faces)
 
-    def test_maps_the_normals_as_directions(self) -> None:
-        """Test that point normals rotate with the mesh and ignore the translation.
-
-        A lit actor's shading reads the stored normals, so a mesh whose normals stayed
-        behind would be lit as if it still sat in its original pose. A direction has no
-        reference point, so the translation must not reach the normals.
-        """
-        mesh = pv.Plane(direction=(0.0, 0.0, 1.0), i_size=2.0, j_size=2.0)
-        rotate_T_pas = _transformations.generate_rot_T(
-            angles=np.array([180.0, 0.0, 0.0]),
-            passive=True,
-            intrinsic=False,
-            order="xyz",
-        )
-        translate_T_pas = _transformations.generate_trans_T(
-            translations=np.array([1.0, 2.0, 3.0], dtype=float), passive=True
-        )
-        T_pas = _transformations.compose_T_pas(rotate_T_pas, translate_T_pas)
-
-        transformed = _output_rendering.transform_mesh(mesh, T_pas)
-
-        expected_normals = np.tile(
-            np.array([0.0, 0.0, -1.0], dtype=float), (mesh.n_points, 1)
-        )
-        npt.assert_allclose(
-            transformed.point_data["Normals"], expected_normals, atol=1e-12
-        )
-
 
 class TestGetFreeFlightFitParallelScale(unittest.TestCase):
     """This class contains methods for testing

--- a/tests/unit/test_private_access.py
+++ b/tests/unit/test_private_access.py
@@ -1,0 +1,70 @@
+"""This module contains classes to test the private access registration functions."""
+
+import unittest
+from typing import Any
+
+import pterasoftware as ps
+
+# noinspection PyProtectedMember
+from pterasoftware import _mujoco_model, _private_access
+from tests.unit.fixtures import problem_fixtures
+
+
+class TestRegisterMuJoCoModelGetter(unittest.TestCase):
+    """This class contains methods for testing
+    _private_access.register_mujoco_model_getter."""
+
+    def test_importing_problems_registers_a_getter(self) -> None:
+        """Test that importing problems.py registers a getter at import time."""
+        # noinspection PyProtectedMember
+        self.assertIsNotNone(_private_access._mujoco_model_getter)
+
+    def test_register_replaces_the_getter(self) -> None:
+        """Test that registering a new getter replaces the previously registered one."""
+        # Save the registered getter and restore it after the test, since the
+        # replacement below would otherwise leak into the rest of the suite.
+        # noinspection PyProtectedMember
+        original_getter = _private_access._mujoco_model_getter
+        assert original_getter is not None
+        self.addCleanup(_private_access.register_mujoco_model_getter, original_getter)
+
+        sentinel_model: Any = object()
+        recorded_problems: list[ps.problems.FreeFlightUnsteadyProblem] = []
+
+        def stub_getter(
+            problem: ps.problems.FreeFlightUnsteadyProblem,
+        ) -> Any:
+            """Records the FreeFlightUnsteadyProblem and returns the sentinel."""
+            recorded_problems.append(problem)
+            return sentinel_model
+
+        _private_access.register_mujoco_model_getter(stub_getter)
+
+        sentinel_problem: Any = object()
+        self.assertIs(
+            _private_access.get_mujoco_model(sentinel_problem), sentinel_model
+        )
+        self.assertEqual(recorded_problems, [sentinel_problem])
+
+
+class TestGetMuJoCoModel(unittest.TestCase):
+    """This class contains methods for testing _private_access.get_mujoco_model."""
+
+    basic_free_flight_unsteady_problem: ps.problems.FreeFlightUnsteadyProblem
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up the shared test fixtures."""
+        cls.basic_free_flight_unsteady_problem = (
+            problem_fixtures.make_basic_free_flight_unsteady_problem_fixture()
+        )
+
+    def test_returns_the_problems_mujoco_model(self) -> None:
+        """Test that the accessor returns the FreeFlightUnsteadyProblem's own
+        MuJoCoModel."""
+        model = _private_access.get_mujoco_model(
+            self.basic_free_flight_unsteady_problem
+        )
+        self.assertIsInstance(model, _mujoco_model.MuJoCoModel)
+        # noinspection PyProtectedMember
+        self.assertIs(model, self.basic_free_flight_unsteady_problem._mujoco_model)


### PR DESCRIPTION
# Description

This pull request makes the MuJoCo geometry that a `FreeFlightUnsteadyProblem` injects through `extra_xml` and `mujoco_assets` visible in `draw` and `animate`. The renderable surfaces are rebuilt from the compiled `MjModel`'s constant arrays rather than by parsing XML fragments or asset bytes, so every supported geom type (mesh, sphere, box, cylinder, ellipsoid, capsule, and sized planes as finite quads) renders exactly as MuJoCo compiled it. Worldbody geoms are drawn static in Earth axes, body geoms fly with the first `Airplane`, and both gain muted reflected copies when an image surface is present, matching the `Panel` treatment.

The rendering is gated behind a new `show_mujoco_geometry` parameter on `draw` and `animate` that defaults to `False`, and the lighting design guarantees that scenes without MuJoCo geometry render exactly as they did before this change, so the feature is fully backward compatible. Infinite planes, heightfields, and signed distance fields are not drawn. Each is skipped with a logged warning stating that the shape still participates in the dynamics.

## Motivation

A free flight simulation can carry MuJoCo geometry beyond the point mass the solver requires, and that geometry participates in the dynamics: contact is active in the generated model, so a body geom can strike an injected ground plane mid-simulation. Before this change, `draw` and `animate` rendered only the `Panel` mesh, the wake, the streamlines, and the image surface, so an animation could show the aircraft bouncing off nothing. Rendering the injected geometry makes those interactions legible and lets a scene's static surroundings, like a ground plane, give the trajectory visual context.

## Relevant Issues

Closes #270.

## Changes

* Added `MuJoCoModel.get_render_geometry` to `_mujoco_model.py`, which walks the compiled model's geom arrays and returns a list of `RenderGeom` named tuples, each holding a `pyvista.PolyData` surface with point normals, an RGBA color (from `mat_rgba` when a material is assigned, otherwise `geom_rgba`), and a body-attached flag. It supports the mesh, sphere, box, cylinder, ellipsoid, capsule, and sized plane geom types, and skips infinite planes, heightfields, and signed distance fields with a logged warning naming the geom and stating that it still participates in the dynamics.
* Added `_private_access.py`, a registration pattern that grants the rendering layer access to a `FreeFlightUnsteadyProblem`'s `MuJoCoModel` without cross-module private access: `problems.py` registers a same-module getter at import time and the rendering layer calls the clean-named accessor.
* Added `get_free_flight_body_transformation`, `get_mujoco_render_geometry`, and `add_mujoco_geometry` to `_output_rendering.py`. The first composes the constant body axes to geometry axes rotation with a time step's `get_free_flight_transformation`, the second splits the geoms into worldbody and body lists, and the third adds one frame's posed geom actors along with muted reflected copies when an image surface is defined.
* Shaded the geom actors with a camera-following headlight that is added only when there is geometry to draw, while every other actor now passes `lighting=False`, which renders identically with or without a light in the scene. Scenes without MuJoCo geometry therefore stay free of lights and render exactly as before, which was verified with a zero-pixel screenshot comparison.
* Extended `transform_mesh` in `_output_rendering.py` to map stored point normals as directions through the same passive transformation as the points, so posed and reflected lit actors shade correctly.
* Settled the framing rules in `output.py`. In `draw`, the free flight camera now fits explicit bounds that union every actor present with the body geoms posed at the drawn time step (plus their reflections), and the geom actors are added between that fit and a clipping-range-only refit, so worldbody geoms stay out of the framing but remain visible. In `animate`, the body geoms join `framing_meshes` posed at both ends of the trajectory and the last time step's copies join the clipping meshes, while worldbody geoms join the clipping range through their actors.
* Gated the rendering behind a `show_mujoco_geometry` parameter on `draw` and `animate` that defaults to `False` and raises a `ValueError` when set to `True` for anything but a `FreeFlightUnsteadyRingVortexLatticeMethodSolver`.
* Documented the compiled geom and mesh array semantics in `docs/MUJOCO_CONVENTIONS.md`, including the informal geom and parent axes and point IDs, the geom pose reconstruction through the `_transformations` helpers, the per-type `geom_size` slots, the re-centered mesh vertex blocks, and the color precedence, each with its empirical verification.
* Added unit tests: 17 for `get_render_geometry` (including a mesh round-trip that rebuilds authored tetrahedron vertices from the compiled arrays), 3 for `_private_access`, and 6 for the new `_output_rendering` functions, plus `extra_xml` passthroughs on the unit and integration fixtures.
* Added two integration tests to `tests/integration/test_output.py` that `draw` and `animate` a glider whose problem injects a worldbody ground plane and two body geoms with `show_mujoco_geometry` set to `True`.
* Listed `_private_access.py` in `CLAUDE.md`'s module overview.

## Dependency Updates

None.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `black`, `codespell`, `docformatter`, `isort`, `octowrap`, and `pre-commit-hooks` GitHub actions.
* [x] This PR passes the `mypy` GitHub action.
* [x] This PR passes all the `tests` GitHub actions.
