### PR TITLE
Lock window size in renders

### DIFF
--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -332,6 +332,11 @@ def draw(
     if not pv.OFF_SCREEN:
         render_window = plotter.ren_win
         assert render_window is not None
+        if plotter.iren is not None:
+            plotter.iren.add_observer(
+                "ConfigureEvent",
+                lambda *args: render_window.SetSize(window_width, window_height),
+            )
         render_window.Render()
         granted_width, granted_height = render_window.GetSize()
         if granted_width < window_width or granted_height < window_height:
@@ -646,6 +651,10 @@ def draw(
 
     # If saving, take a screenshot and save it as a WebP.
     if save:
+        # Re-assert the requested render window size before taking the screenshot.
+        assert plotter.ren_win is not None
+        plotter.ren_win.SetSize(window_width, window_height)
+        
         image = _output_rendering.screenshot_image(plotter)
 
         # webp annotates file_path as a str, so the Path is converted at the boundary.
@@ -860,6 +869,11 @@ def animate(
     if not pv.OFF_SCREEN:
         render_window = plotter.ren_win
         assert render_window is not None
+        if plotter.iren is not None:
+            plotter.iren.add_observer(
+                "ConfigureEvent",
+                lambda *args: render_window.SetSize(window_width, window_height),
+            )
         render_window.Render()
         granted_width, granted_height = render_window.GetSize()
         if granted_width < window_width or granted_height < window_height:
@@ -1171,6 +1185,10 @@ def animate(
             plotter.remove_actor(temporary_actor, render=False)
         plotter.camera.clipping_range = free_flight_clipping_range
 
+    # Re-assert the requested render window size before capturing the first frame.
+    assert plotter.ren_win is not None
+    plotter.ren_win.SetSize(window_width, window_height)
+
     # Start a list to hold a WebP Image of each frame, beginning with this first frame.
     images = [_output_rendering.screenshot_image(plotter)]
 
@@ -1269,6 +1287,10 @@ def animate(
         # is displayed, leaving the second of its two passes to the render below.
         if T_reflect is not None:
             _output_rendering.settle_scalar_bar_layout(plotter)
+
+        # Re-assert the requested render window size before rendering this frame.
+        assert plotter.ren_win is not None
+        plotter.ren_win.SetSize(window_width, window_height)
 
         # Render the assembled frame. Every add above is made with render=False, so
         # without this the frame would never reach the screen. Rendering once the frame

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -654,7 +654,7 @@ def draw(
         # Re-assert the requested render window size before taking the screenshot.
         assert plotter.ren_win is not None
         plotter.ren_win.SetSize(window_width, window_height)
-        
+
         image = _output_rendering.screenshot_image(plotter)
 
         # webp annotates file_path as a str, so the Path is converted at the boundary.


### PR DESCRIPTION
# Description

Locks the render window size in `draw` and `animate` through a two-layer strategy using a VTK `ConfigureEvent` observer during interactive phases and explicit `SetSize` re-assertions during non-interactive rendering passes.

## Motivation

Dragging, maximizing, or tile-snapping the render window after creation caused screenshots to capture at the resized live window dimensions while text sizes and line widths remained scaled to the initial requested `window_size`. Additionally, window resizes during the rendering loop of `animate` resulted in frames of varying dimensions, causing `webp.save_images` to fail deep in its CFFI layer with an `AttributeError: cdata 'struct WebPAnimEncoder *' points to an opaque type`. Enforcing the requested window size in both interactive and rendering phases guarantees that saved outputs consistently match the requested dimensions and styling scale.

## Relevant Issues

Fixes #265 

## Changes

* Added a `ConfigureEvent` observer to the interactor in `draw` and `animate` to snap the render window back to the requested dimensions via `SetSize` upon OS-level resizes.
* Re-asserted `SetSize` on the render window prior to taking the screenshot in `draw` and before rendering each frame in `animate`.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [ ] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [ ] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [ ] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [ ] This PR passes the `lint` job of the `CI` GitHub action.
* [ ] This PR passes the `test` jobs of the `CI` GitHub action.
