### PR TITLE
[FEATURE] Add a ghost preview to animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Before contributing, make sure to read through the [Contributing Guidelines](CON
 * Cameron Hendrikse ([MonoChromatical](https://github.com/MonoChromatical))
 * Abdullah Imran ([codexabdullah](https://github.com/codexabdullah))
 * [w3lld1](https://github.com/w3lld1)
+* Shaziya Hussain ([ShaziyaHussain](https://github.com/ShaziyaHussain))
 
 ### Supporters
 

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -1003,7 +1003,7 @@ def _plot_scalars(
     panel_surfaces: pv.PolyData,
     window_scale: float,
     text_color: tuple[int, int, int] = TEXT_COLOR,
-) -> None:
+) -> list[pv.Actor]:
     """Plots a scalar bar, the surfaces of a set of Panels with particular scalars, and
     labels for the minimum and maximum scalar values.
 
@@ -1022,7 +1022,7 @@ def _plot_scalars(
         get_window_scale.
     :param text_color: The color used for the scalar bar and label text. The default is
         TEXT_COLOR.
-    :return: None
+    :return: A list of the actors added to the plotter.
     """
     scalar_bar_args = dict(
         title=scalar_type.title() + " Coefficient",
@@ -1042,7 +1042,7 @@ def _plot_scalars(
         # once whole, which reads on screen as the scalar bar and the labels flashing.
         render=False,
     )
-    plotter.add_mesh(
+    panel_actor = plotter.add_mesh(
         panel_surfaces,
         show_edges=True,
         line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
@@ -1054,6 +1054,7 @@ def _plot_scalars(
         lighting=False,
         render=False,
     )
+
 
     max_label = plotter.add_text(
         text=f"Max: {max_scalar:#.3G}",
@@ -1073,6 +1074,8 @@ def _plot_scalars(
     )
     for label in (max_label, min_label):
         label.prop.justification_horizontal = "right"
+
+    return [panel_actor, max_label, min_label]
 
 
 class ScalarColoring(NamedTuple):
@@ -1104,7 +1107,7 @@ def add_frame_geometry(
     coloring: ScalarColoring | None,
     T_reflect: np.ndarray | None,
     window_scale: float,
-) -> None:
+) -> list[pv.Actor]:
     """Adds one frame's geometry to a Plotter, which is the wake, the Panels, and, when
     an image surface is defined, a muted reflected copy of both.
 
@@ -1128,48 +1131,55 @@ def add_frame_geometry(
         is defined, in which case no reflected geometry is added.
     :param window_scale: The factor by which to scale the scalar bar and label font
         sizes, as returned by get_window_scale.
-    :return: None
+    :return: A list of the actors added to the plotter.
     """
+    actors: list[pv.Actor] = []
     # Add the wake ring vortex surfaces if they are being shown.
     if wake_surfaces is not None:
-        plotter.add_mesh(
-            wake_surfaces,
-            show_edges=True,
-            line_width=_WAKE_VORTEX_EDGE_LINE_WIDTH * window_scale,
-            smooth_shading=False,
-            color=_WAKE_VORTEX_COLOR,
-            lighting=False,
-            render=False,
+        actors.append(
+            plotter.add_mesh(
+                wake_surfaces,
+                show_edges=True,
+                line_width=_WAKE_VORTEX_EDGE_LINE_WIDTH * window_scale,
+                smooth_shading=False,
+                color=_WAKE_VORTEX_COLOR,
+                lighting=False,
+                render=False,
+            )
         )
 
     # Plot the Panels either with scalar coloring or with a uniform color.
     if coloring is not None:
-        _plot_scalars(
-            plotter,
-            coloring.scalars,
-            coloring.scalar_type,
-            coloring.min_scalar,
-            coloring.max_scalar,
-            coloring.color_map,
-            coloring.c_min,
-            coloring.c_max,
-            panel_surfaces,
-            window_scale,
-            text_color=TEXT_COLOR_SURFACE if T_reflect is not None else TEXT_COLOR,
+        actors.extend(
+            _plot_scalars(
+                plotter,
+                coloring.scalars,
+                coloring.scalar_type,
+                coloring.min_scalar,
+                coloring.max_scalar,
+                coloring.color_map,
+                coloring.c_min,
+                coloring.c_max,
+                panel_surfaces,
+                window_scale,
+                text_color=TEXT_COLOR_SURFACE if T_reflect is not None else TEXT_COLOR,
+            )
         )
     else:
-        plotter.add_mesh(
-            panel_surfaces,
-            show_edges=True,
-            line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
-            color=_PANEL_COLOR,
-            smooth_shading=False,
-            lighting=False,
-            render=False,
+        actors.append(
+            plotter.add_mesh(
+                panel_surfaces,
+                show_edges=True,
+                line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
+                color=_PANEL_COLOR,
+                smooth_shading=False,
+                lighting=False,
+                render=False,
+            )
         )
 
     if T_reflect is None:
-        return
+        return actors
 
     # An image surface is defined, so add the reflected geometry. It is muted toward
     # gray so that it reads as a reflection rather than as more geometry.
@@ -1179,43 +1189,52 @@ def add_frame_geometry(
     # Add reflected Panel surfaces with muted coloring.
     reflected_panel_surfaces = _reflect_mesh(panel_surfaces, T_reflect)
     if coloring is not None:
-        plotter.add_mesh(
-            reflected_panel_surfaces,
-            show_edges=True,
-            line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
-            edge_color=muted_edge_color,
-            cmap=coloring.muted_color_map,
-            clim=[coloring.c_min, coloring.c_max],
-            scalars=coloring.scalars,
-            smooth_shading=False,
-            show_scalar_bar=False,
-            lighting=False,
-            render=False,
+        actors.append(
+            plotter.add_mesh(
+                reflected_panel_surfaces,
+                show_edges=True,
+                line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
+                edge_color=muted_edge_color,
+                cmap=coloring.muted_color_map,
+                clim=[coloring.c_min, coloring.c_max],
+                scalars=coloring.scalars,
+                smooth_shading=False,
+                show_scalar_bar=False,
+                lighting=False,
+                render=False,
+            )
         )
+
     else:
-        plotter.add_mesh(
-            reflected_panel_surfaces,
-            show_edges=True,
-            line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
-            edge_color=muted_edge_color,
-            color=mute_color(_PANEL_COLOR, mute),
-            smooth_shading=False,
-            lighting=False,
-            render=False,
+        actors.append(
+            plotter.add_mesh(
+                reflected_panel_surfaces,
+                show_edges=True,
+                line_width=_PANEL_EDGE_LINE_WIDTH * window_scale,
+                edge_color=muted_edge_color,
+                color=mute_color(_PANEL_COLOR, mute),
+                smooth_shading=False,
+                lighting=False,
+                render=False,
+            )
         )
 
     # Add reflected wake ring vortex surfaces if they are being shown.
     if wake_surfaces is not None:
-        plotter.add_mesh(
-            _reflect_mesh(wake_surfaces, T_reflect),
-            show_edges=True,
-            line_width=_WAKE_VORTEX_EDGE_LINE_WIDTH * window_scale,
-            edge_color=muted_edge_color,
-            smooth_shading=False,
-            color=mute_color(_WAKE_VORTEX_COLOR, mute),
-            lighting=False,
-            render=False,
+        actors.append(
+            plotter.add_mesh(
+                _reflect_mesh(wake_surfaces, T_reflect),
+                show_edges=True,
+                line_width=_WAKE_VORTEX_EDGE_LINE_WIDTH * window_scale,
+                edge_color=muted_edge_color,
+                smooth_shading=False,
+                color=mute_color(_WAKE_VORTEX_COLOR, mute),
+                lighting=False,
+                render=False,
+            )
         )
+    return actors
+
 
 
 def add_mujoco_geometry(
@@ -1224,7 +1243,7 @@ def add_mujoco_geometry(
     body_geoms: list[_mujoco_model.RenderGeom],
     T_pas_BP1_CgP1_to_E_Eo: np.ndarray,
     T_reflect: np.ndarray | None,
-) -> None:
+) -> list[pv.Actor]:
     """Adds one frame's MuJoCo geometry to a Plotter, alongside muted reflected copies
     when an image surface is defined.
 
@@ -1251,8 +1270,10 @@ def add_mujoco_geometry(
     :param T_reflect: A (4,4) ndarray of floats representing the active transformation
         (in Earth axes) that reflects geometry across the image surface, or None when no
         image surface is defined, in which case no reflected copies are added.
-    :return: None
+    :return: A list of the actors added to the plotter.
     """
+
+    actors: list[pv.Actor] = []
     posed_meshes = [
         (render_geom.mesh, render_geom.rgba) for render_geom in worldbody_geoms
     ] + [
@@ -1260,7 +1281,7 @@ def add_mujoco_geometry(
         for render_geom in body_geoms
     ]
     if not posed_meshes:
-        return
+        return actors
 
     # Add the headlight that shades the geom actors, which follows the camera so the
     # geoms stay legible from any orientation the user chooses. Every non-geom actor is
@@ -1278,7 +1299,7 @@ def add_mujoco_geometry(
         # duplicates the points along edges sharper than PyVista's feature angle,
         # letting each face shade with its own normal, where plain smooth shading would
         # average one normal across the crease and smear it.
-        plotter.add_mesh(
+        actor = plotter.add_mesh(
             posed_mesh,
             color=color,
             opacity=opacity,
@@ -1288,12 +1309,13 @@ def add_mujoco_geometry(
             diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
             render=False,
         )
+        actors.append(actor)
         if T_reflect is not None:
             # Splitting the sharp edges recomputes the normals from the triangle
             # winding, and a reflection inverts the winding's outward sense. Flip the
             # reflected copy's faces so the recomputed normals point outward again
             # instead of inverting the shading.
-            plotter.add_mesh(
+            actor = plotter.add_mesh(
                 _reflect_mesh(posed_mesh, T_reflect).flip_faces(),
                 color=mute_color(color, IMAGE_REFLECTION_MUTE_FACTOR),
                 opacity=opacity,
@@ -1303,3 +1325,5 @@ def add_mujoco_geometry(
                 diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
                 render=False,
             )
+            actors.append(actor)
+    return actors

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -1286,7 +1286,8 @@ def add_mujoco_geometry(
     # the scene, so the headlight changes nothing else. An animation clears the
     # Plotter's lights along with its actors between frames, so the light is added here,
     # once per assembled frame.
-    plotter.add_light(pv.Light(light_type="headlight"))
+    if not plotter.renderer.lights:
+        plotter.add_light(pv.Light(light_type="headlight"))
 
     for posed_mesh, rgba in posed_meshes:
         color = (float(rgba[0]), float(rgba[1]), float(rgba[2]))

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -1055,7 +1055,6 @@ def _plot_scalars(
         render=False,
     )
 
-
     max_label = plotter.add_text(
         text=f"Max: {max_scalar:#.3G}",
         position=_TEXT_MAX_POSITION,
@@ -1236,7 +1235,6 @@ def add_frame_geometry(
     return actors
 
 
-
 def add_mujoco_geometry(
     plotter: pv.Plotter,
     worldbody_geoms: list[_mujoco_model.RenderGeom],
@@ -1272,7 +1270,6 @@ def add_mujoco_geometry(
         image surface is defined, in which case no reflected copies are added.
     :return: A list of the actors added to the plotter.
     """
-
     actors: list[pv.Actor] = []
     posed_meshes = [
         (render_geom.mesh, render_geom.rgba) for render_geom in worldbody_geoms

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -67,13 +67,6 @@ _ANIMATE_PREVIEW_LAST_OPACITY = 0.35
 # visualizations pin it rather than take the default.
 _MULTI_SAMPLES = 4
 
-
-def _set_preview_opacity(actors: list[pv.Actor], opacity: float) -> None:
-    """Sets the opacity of temporary animation-preview actors."""
-    for actor in actors:
-        actor.prop.opacity = opacity
-
-
 # Define the colors of the series in the results plots.
 [
     _ALPHA_COLOR,
@@ -159,6 +152,18 @@ _freeFlightViewDirection_E = np.array([1.0, -1.0, -1.0], dtype=float)
 _freeFlightViewDirection_E = _freeFlightViewDirection_E / np.linalg.norm(
     _freeFlightViewDirection_E
 )
+
+
+def _set_preview_opacity(actors: list[pv.Actor], opacity: float) -> None:
+    """Sets the opacity of temporary animation-preview actors.
+
+    :param actors: The actors whose opacity should be changed.
+    :param opacity: The opacity to apply to the actors.
+    :return: None.
+    """
+    for actor in actors:
+        if isinstance(actor, pv.Actor):
+            actor.prop.opacity = opacity
 
 
 def draw(
@@ -648,6 +653,7 @@ def draw(
         # Show the Plotter for 1 second, then proceed automatically. This is useful for
         # testing.
         plotter.show(
+            title="Testing. Please wait.",
             cpos=draw_cpos,
             full_screen=False,
             interactive=False,
@@ -1062,6 +1068,10 @@ def animate(
             first_panel_surfaces, step_transforms[0]
         )
 
+    plotter.enable_depth_peeling(
+        number_of_peels=8, occlusion_ratio=0.0
+    )  # type: ignore[call-arg]
+
     first_preview_actors = _output_rendering.add_frame_geometry(
         plotter,
         first_panel_surfaces,
@@ -1099,11 +1109,29 @@ def animate(
                     last_wake_surfaces, step_transforms[last_step]
                 )
 
+        last_coloring: _output_rendering.ScalarColoring | None = None
+        if scalar_type is not None:
+            assert color_map is not None
+            assert muted_color_map is not None
+            last_coloring = _output_rendering.ScalarColoring(
+                _output_rendering.get_scalars(
+                    step_airplanes[last_step],
+                    scalar_type,
+                    unsteady_solver.steady_problems[last_step].operating_point.qInf__E,
+                ),
+                scalar_type,
+                min_scalar,
+                max_scalar,
+                color_map,
+                muted_color_map,
+                c_min,
+                c_max,
+            )
         last_preview_actors = _output_rendering.add_frame_geometry(
             plotter,
             last_panel_surfaces,
             last_wake_surfaces,
-            None,
+            last_coloring,
             T_reflect,
             window_scale,
         )
@@ -1181,9 +1209,8 @@ def animate(
     if not testing:
         plotter.show(
             title=(
-                "Orient the view using the first/last ghost preview, "
-                "then press any key to produce the animation. "
-                "The ghost preview will not appear in the saved animation."
+                "Orient the view, then press any key. "
+                "The ghosts preview the animation and are not saved."
             ),
             cpos=animate_cpos,
             full_screen=False,
@@ -1205,27 +1232,11 @@ def animate(
         )
         time.sleep(1)
 
+    plotter.disable_depth_peeling()  # type: ignore[call-arg]
+
     # Remove the temporary preview actors before the animation begins.
     for actor in preview_actors:
         plotter.remove_actor(actor, render=False)
-
-    # The user may have reoriented or rescaled the view during the held first frame.
-    # Preserve that camera and only size the clipping range so every frame stays
-    # visible: temporarily add the last frame's geometry (the first frame's is already
-    # present), fit the clipping range to both, then remove the temporary actors. The
-    # body moves through the scene, so a clipping range fit to the first frame alone
-    # would clip later frames.
-    if is_free_flight:
-        temporary_actors = [
-            plotter.add_mesh(clip_mesh, lighting=False, render=False)
-            for clip_mesh in free_flight_clip_meshes
-        ]
-        plotter.reset_camera_clipping_range()
-        free_flight_clipping_range = plotter.camera.clipping_range
-        for temporary_actor in temporary_actors:
-            plotter.remove_actor(temporary_actor, render=False)
-        plotter.camera.clipping_range = free_flight_clipping_range
-
     # Rebuild the first frame as the actual animation frame after removing the preview.
     # The preview is intentionally uncolored and translucent, so the first saved frame
     # must be assembled again with its real scalar coloring and full opacity.
@@ -1234,7 +1245,6 @@ def animate(
         first_frame_panel_surfaces = _output_rendering.transform_mesh(
             first_frame_panel_surfaces, step_transforms[0]
         )
-
     first_frame_wake_surfaces = None
     first_frame_coloring: _output_rendering.ScalarColoring | None = None
     if scalar_type is not None and first_results_step == 0:
@@ -1254,7 +1264,6 @@ def animate(
             c_min,
             c_max,
         )
-
     _output_rendering.add_frame_geometry(
         plotter,
         first_frame_panel_surfaces,
@@ -1274,6 +1283,23 @@ def animate(
     if T_reflect is not None:
         assert image_surface_mesh is not None
         _output_rendering.settle_scalar_bar_layout(plotter)
+
+    # The user may have reoriented or rescaled the view during the held first frame.
+    # Preserve that camera and only size the clipping range so every frame stays
+    # visible: temporarily add the last frame's geometry (the first frame's is already
+    # present), fit the clipping range to both, then remove the temporary actors. The
+    # body moves through the scene, so a clipping range fit to the first frame alone
+    # would clip later frames.
+    if is_free_flight:
+        temporary_actors = [
+            plotter.add_mesh(clip_mesh, lighting=False, render=False)
+            for clip_mesh in free_flight_clip_meshes
+        ]
+        plotter.reset_camera_clipping_range()
+        free_flight_clipping_range = plotter.camera.clipping_range
+        for temporary_actor in temporary_actors:
+            plotter.remove_actor(temporary_actor, render=False)
+        plotter.camera.clipping_range = free_flight_clipping_range
 
     plotter.render()
 

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -1067,27 +1067,46 @@ def animate(
         first_panel_surfaces = _output_rendering.transform_mesh(
             first_panel_surfaces, step_transforms[0]
         )
-
+    first_frame_coloring: _output_rendering.ScalarColoring | None = None
+    if scalar_type is not None and first_results_step == 0:
+        assert color_map is not None
+        assert muted_color_map is not None
+        first_frame_coloring = _output_rendering.ScalarColoring(
+            _output_rendering.get_scalars(
+                step_airplanes[0],
+                scalar_type,
+                unsteady_solver.steady_problems[0].operating_point.qInf__E,
+            ),
+            scalar_type,
+            min_scalar,
+            max_scalar,
+            color_map,
+            muted_color_map,
+            c_min,
+            c_max,
+        )
     plotter.enable_depth_peeling(
-        number_of_peels=8, occlusion_ratio=0.0
+        number_of_peels=0, occlusion_ratio=0.0
     )  # type: ignore[call-arg]
 
     first_preview_actors = _output_rendering.add_frame_geometry(
         plotter,
         first_panel_surfaces,
         None,
-        None,
+        first_frame_coloring,
         T_reflect,
         window_scale,
     )
-    _set_preview_opacity(first_preview_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
+    if last_step != 0:
+        _set_preview_opacity(first_preview_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
     preview_actors.extend(first_preview_actors)
 
     if show_mujoco_geometry:
         first_mujoco_actors = _output_rendering.add_mujoco_geometry(
             plotter, worldbody_geoms, body_geoms, step_body_transforms[0], T_reflect
         )
-        _set_preview_opacity(first_mujoco_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
+        if last_step != 0:
+            _set_preview_opacity(first_mujoco_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
         preview_actors.extend(first_mujoco_actors)
 
     if last_step != 0:
@@ -1207,30 +1226,30 @@ def animate(
     # and proceed. If testing, show the Plotter with the first time step for 1 second,
     # and start the animation with the current window view.
     if not testing:
+        title = "Orient the view, then press any key."
+        if last_step != 0:
+            title += " The ghosts preview the animation and are not saved."
         plotter.show(
-            title=(
-                "Orient the view, then press any key. "
-                "The ghosts preview the animation and are not saved."
-            ),
+            title=title,
             cpos=animate_cpos,
             full_screen=False,
             auto_close=False,
         )
-        assert plotter.ren_win is not None
-        plotter.ren_win.SetWindowName(
-            "Rendering animation. Please leave the window open until rendering finishes."
-        )
-        plotter.render()
 
     else:
         plotter.show(
-            title="Rendering animation. Please leave the window open until rendering finishes.",
+            title="Testing. Please wait.",
             cpos=animate_cpos,
             full_screen=False,
             interactive=False,
             auto_close=False,
         )
         time.sleep(1)
+    assert plotter.ren_win is not None
+    plotter.ren_win.SetWindowName(
+        "Rendering animation. Please leave the window open until rendering finishes."
+    )
+    plotter.render()
 
     plotter.disable_depth_peeling()  # type: ignore[call-arg]
 
@@ -1238,32 +1257,12 @@ def animate(
     for actor in preview_actors:
         plotter.remove_actor(actor, render=False)
     # Rebuild the first frame as the actual animation frame after removing the preview.
-    # The preview is intentionally uncolored and translucent, so the first saved frame
-    # must be assembled again with its real scalar coloring and full opacity.
     first_frame_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[0])
     if is_free_flight:
         first_frame_panel_surfaces = _output_rendering.transform_mesh(
             first_frame_panel_surfaces, step_transforms[0]
         )
     first_frame_wake_surfaces = None
-    first_frame_coloring: _output_rendering.ScalarColoring | None = None
-    if scalar_type is not None and first_results_step == 0:
-        assert color_map is not None
-        assert muted_color_map is not None
-        first_frame_coloring = _output_rendering.ScalarColoring(
-            _output_rendering.get_scalars(
-                step_airplanes[0],
-                scalar_type,
-                unsteady_solver.steady_problems[0].operating_point.qInf__E,
-            ),
-            scalar_type,
-            min_scalar,
-            max_scalar,
-            color_map,
-            muted_color_map,
-            c_min,
-            c_max,
-        )
     _output_rendering.add_frame_geometry(
         plotter,
         first_frame_panel_surfaces,

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -57,6 +57,8 @@ _logger = _logging.get_logger("output")
 _STREAMLINE_COLOR = "orchid"
 _STREAMLINE_LINE_WIDTH = 2.0
 _IMAGE_SURFACE_OPACITY = 0.5
+_ANIMATE_PREVIEW_FIRST_OPACITY = 0.10
+_ANIMATE_PREVIEW_LAST_OPACITY = 0.35
 
 # Define the number of samples used for multisample anti-aliasing. PyVista defaults to
 # 8, whose resolve is not reproducible on every driver: rendering one scene twice can
@@ -64,6 +66,12 @@ _IMAGE_SURFACE_OPACITY = 0.5
 # vary between runs. Four samples is stable and renders indistinguishably, so the
 # visualizations pin it rather than take the default.
 _MULTI_SAMPLES = 4
+
+
+def _set_preview_opacity(actors: list[pv.Actor], opacity: float) -> None:
+    """Sets the opacity of temporary animation-preview actors."""
+    for actor in actors:
+        actor.prop.opacity = opacity
 
 # Define the colors of the series in the results plots.
 [
@@ -333,6 +341,8 @@ def draw(
         render_window = plotter.ren_win
         assert render_window is not None
         render_window.Render()
+        render_window.SetWindowName("Assembling the scene. Please wait.")
+        render_window.Render()
         granted_width, granted_height = render_window.GetSize()
         if granted_width < window_width or granted_height < window_height:
             pv.close_all()
@@ -440,6 +450,7 @@ def draw(
         T_reflect,
         window_scale,
     )
+
 
     # If showing MuJoCo geometry, gather the geoms that extra_xml injects. The geom
     # actors are added later, between the camera's framing fit and its clipping fit, so
@@ -861,6 +872,8 @@ def animate(
         render_window = plotter.ren_win
         assert render_window is not None
         render_window.Render()
+        render_window.SetWindowName("Assembling the scene. Please wait.")
+        render_window.Render()
         granted_width, granted_height = render_window.GetSize()
         if granted_width < window_width or granted_height < window_height:
             pv.close_all()
@@ -1037,46 +1050,74 @@ def animate(
             plotter, playback, window_scale, animate_text_color
         )
 
-    # Get the Panel surfaces of the first time step's Airplane(s), mapping them into
-    # Earth axes for free flight.
-    panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[0])
+    # Hold the temporary preview actors shown during the framing phase.
+    preview_actors: list[pv.Actor] = []
+
+    # Show the first and last time steps together during framing. This gives the user
+    # both the initial body pose and the final wake/trajectory extent without multiplying
+    # actors across every time step of a long simulation.
+    first_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[0])
     if is_free_flight:
-        panel_surfaces = _output_rendering.transform_mesh(
-            panel_surfaces, step_transforms[0]
+        first_panel_surfaces = _output_rendering.transform_mesh(
+            first_panel_surfaces, step_transforms[0]
         )
 
-    # Choose the first time step's scalar coloring, leaving it None to color the Panels
-    # uniformly.
-    coloring: _output_rendering.ScalarColoring | None = None
-    if scalar_type is not None and first_results_step == 0:
-        assert color_map is not None
-        assert muted_color_map is not None
-        coloring = _output_rendering.ScalarColoring(
-            _output_rendering.get_scalars(
-                step_airplanes[0],
-                scalar_type,
-                unsteady_solver.steady_problems[0].operating_point.qInf__E,
-            ),
-            scalar_type,
-            min_scalar,
-            max_scalar,
-            color_map,
-            muted_color_map,
-            c_min,
-            c_max,
-        )
-
-    # Add the first time step's geometry. No wake is passed, since the first time step
-    # has not shed one yet.
-    _output_rendering.add_frame_geometry(
-        plotter, panel_surfaces, None, coloring, T_reflect, window_scale
+    first_preview_actors = _output_rendering.add_frame_geometry(
+        plotter,
+        first_panel_surfaces,
+        None,
+        None,
+        T_reflect,
+        window_scale,
     )
+    _set_preview_opacity(first_preview_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
+    preview_actors.extend(first_preview_actors)
 
-    # If showing MuJoCo geometry, add it at the first time step's pose.
     if show_mujoco_geometry:
-        _output_rendering.add_mujoco_geometry(
+        first_mujoco_actors = _output_rendering.add_mujoco_geometry(
             plotter, worldbody_geoms, body_geoms, step_body_transforms[0], T_reflect
         )
+        _set_preview_opacity(first_mujoco_actors, _ANIMATE_PREVIEW_FIRST_OPACITY)
+        preview_actors.extend(first_mujoco_actors)
+
+    if last_step != 0:
+        last_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[last_step])
+        if is_free_flight:
+            last_panel_surfaces = _output_rendering.transform_mesh(
+                last_panel_surfaces, step_transforms[last_step]
+            )
+
+        last_wake_surfaces = None
+        if show_wake_vortices:
+            last_wake_surfaces = _output_rendering.get_wake_ring_vortex_surfaces(
+                unsteady_solver, last_step
+            )
+            if is_free_flight:
+                last_wake_surfaces = _output_rendering.transform_mesh(
+                    last_wake_surfaces, step_transforms[last_step]
+                )
+
+        last_preview_actors = _output_rendering.add_frame_geometry(
+            plotter,
+            last_panel_surfaces,
+            last_wake_surfaces,
+            None,
+            T_reflect,
+            window_scale,
+        )
+        _set_preview_opacity(last_preview_actors, _ANIMATE_PREVIEW_LAST_OPACITY)
+        preview_actors.extend(last_preview_actors)
+
+        if show_mujoco_geometry:
+            last_mujoco_actors = _output_rendering.add_mujoco_geometry(
+                plotter,
+                [],
+                body_geoms,
+                step_body_transforms[last_step],
+                T_reflect,
+            )
+            _set_preview_opacity(last_mujoco_actors, _ANIMATE_PREVIEW_LAST_OPACITY)
+            preview_actors.extend(last_mujoco_actors)
 
     # If an image surface is defined, plot the pre-computed plane, set the camera
     # direction, and fit the camera to the last time step's geometry bounds so the view
@@ -1137,22 +1178,34 @@ def animate(
     # and start the animation with the current window view.
     if not testing:
         plotter.show(
-            title="Orient the view, then press any key to produce the animation.",
+            title=(
+                "Orient the view using the first/last ghost preview, "
+                "then press any key to produce the animation. "
+                "The ghost preview will not appear in the saved animation."
+            ),
             cpos=animate_cpos,
             full_screen=False,
             auto_close=False,
         )
         assert plotter.ren_win is not None
-        plotter.ren_win.SetWindowName("Rendering speed not to scale.")
+        plotter.ren_win.SetWindowName(
+            "Rendering animation. Please leave the window open until rendering finishes."
+        )
+        plotter.render()
+
     else:
         plotter.show(
-            title="Rendering speed not to scale.",
+            title="Rendering animation. Please leave the window open until rendering finishes.",
             cpos=animate_cpos,
             full_screen=False,
             interactive=False,
             auto_close=False,
         )
         time.sleep(1)
+
+    # Remove the temporary preview actors before the animation begins.
+    for actor in preview_actors:
+        plotter.remove_actor(actor, render=False)
 
     # The user may have reoriented or rescaled the view during the held first frame.
     # Preserve that camera and only size the clipping range so every frame stays
@@ -1170,6 +1223,57 @@ def animate(
         for temporary_actor in temporary_actors:
             plotter.remove_actor(temporary_actor, render=False)
         plotter.camera.clipping_range = free_flight_clipping_range
+
+    # Rebuild the first frame as the actual animation frame after removing the preview.
+    # The preview is intentionally uncolored and translucent, so the first saved frame
+    # must be assembled again with its real scalar coloring and full opacity.
+    first_frame_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[0])
+    if is_free_flight:
+        first_frame_panel_surfaces = _output_rendering.transform_mesh(
+            first_frame_panel_surfaces, step_transforms[0]
+        )
+
+    first_frame_wake_surfaces = None
+    first_frame_coloring: _output_rendering.ScalarColoring | None = None
+    if scalar_type is not None and first_results_step == 0:
+        assert color_map is not None
+        assert muted_color_map is not None
+        first_frame_coloring = _output_rendering.ScalarColoring(
+            _output_rendering.get_scalars(
+                step_airplanes[0],
+                scalar_type,
+                unsteady_solver.steady_problems[0].operating_point.qInf__E,
+            ),
+            scalar_type,
+            min_scalar,
+            max_scalar,
+            color_map,
+            muted_color_map,
+            c_min,
+            c_max,
+        )
+
+    _output_rendering.add_frame_geometry(
+        plotter,
+        first_frame_panel_surfaces,
+        first_frame_wake_surfaces,
+        first_frame_coloring,
+        T_reflect,
+        window_scale,
+    )
+    if show_mujoco_geometry:
+        _output_rendering.add_mujoco_geometry(
+            plotter,
+            worldbody_geoms,
+            body_geoms,
+            step_body_transforms[0],
+            T_reflect,
+        )
+    if T_reflect is not None:
+        assert image_surface_mesh is not None
+        _output_rendering.settle_scalar_bar_layout(plotter)
+
+    plotter.render()
 
     # Start a list to hold a WebP Image of each frame, beginning with this first frame.
     images = [_output_rendering.screenshot_image(plotter)]

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -73,6 +73,7 @@ def _set_preview_opacity(actors: list[pv.Actor], opacity: float) -> None:
     for actor in actors:
         actor.prop.opacity = opacity
 
+
 # Define the colors of the series in the results plots.
 [
     _ALPHA_COLOR,
@@ -450,7 +451,6 @@ def draw(
         T_reflect,
         window_scale,
     )
-
 
     # If showing MuJoCo geometry, gather the geoms that extra_xml injects. The geom
     # actors are added later, between the camera's framing fit and its clipping fit, so
@@ -1054,8 +1054,8 @@ def animate(
     preview_actors: list[pv.Actor] = []
 
     # Show the first and last time steps together during framing. This gives the user
-    # both the initial body pose and the final wake/trajectory extent without multiplying
-    # actors across every time step of a long simulation.
+    # both the initial body pose and the final wake/trajectory extent without
+    # multiplying actors across every time step of a long simulation.
     first_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[0])
     if is_free_flight:
         first_panel_surfaces = _output_rendering.transform_mesh(
@@ -1081,7 +1081,9 @@ def animate(
         preview_actors.extend(first_mujoco_actors)
 
     if last_step != 0:
-        last_panel_surfaces = _output_rendering.get_panel_surfaces(step_airplanes[last_step])
+        last_panel_surfaces = _output_rendering.get_panel_surfaces(
+            step_airplanes[last_step]
+        )
         if is_free_flight:
             last_panel_surfaces = _output_rendering.transform_mesh(
                 last_panel_surfaces, step_transforms[last_step]


### PR DESCRIPTION
# Description

Add a first/last ghost preview during `animate()` framing so the user can orient the view against the full motion before rendering.

## Motivation

Improve `animate()` framing by showing the first and last time steps together, making the final wake extent and motion easier to account for when orienting the view.

## Relevant Issues

Closes #264.

## Changes

* Added first/last ghost preview actors during the `animate()` framing phase.
* Returned actors from rendering helpers so temporary preview geometry can be removed cleanly.
* Updated the assembly, framing, and rendering window titles.
* Preserved the existing clipping-range logic and rebuilt the first real frame after removing the preview actors.

## Dependency Updates

None.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current contribution guidelines.
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with black (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in reStructuredText format, and are formatted using docformatter (`--in-place --black`).
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check.
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.