### PR TITLE
[FEATURE] Warn on weightless free flight

### DIFF
--- a/pterasoftware/problems.py
+++ b/pterasoftware/problems.py
@@ -580,6 +580,9 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
             floating point tolerance, where weight is the Airplane's weight and g_E is
             the OperatingPoint's gravitational acceleration, which keeps the Airplane's
             weight, the supplied mass, and the gravitational field mutually consistent.
+            A zero g_E satisfies that requirement with the Airplane's zero weight
+            default, so it is accepted but logs a warning that the run models a
+            weightless body in a gravity-free world.
         :param I_BP1_CgP1: An array-like object of numbers (int or float) with shape
             (3,3) representing the inertia matrix of the Airplane (in the first
             Airplane's body axes, relative to the first Airplane's CG). It must be
@@ -675,9 +678,8 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
         # silent modeling error. g_E is constant across the run, so checking the initial
         # OperatingPoint suffices. A zero g_E (the default, no gravitational field)
         # consistently requires a zero weight.
-        expected_weight = self._mass * float(
-            np.linalg.norm(initial_operating_point.g_E)
-        )
+        g_magnitude = float(np.linalg.norm(initial_operating_point.g_E))
+        expected_weight = self._mass * g_magnitude
         if not np.isclose(initial_airplane.weight, expected_weight):
             raise ValueError(
                 "The Airplane's weight must equal mass * |g_E| within floating point "
@@ -685,6 +687,25 @@ class FreeFlightUnsteadyProblem(_CoupledUnsteadyProblem):
                 f"mass * |g_E| is {expected_weight} N. Set the Airplane's weight, the "
                 "mass, and the OperatingPoint's g_E so they agree (for a zero-gravity "
                 "simulation, leave both g_E and the weight at zero)."
+            )
+
+        # A zero g_E is the consistency check's one silent path, because the zero
+        # expected weight it produces is satisfied by the Airplane's own zero weight
+        # default. An all-defaults free flight run therefore models a weightless body in
+        # a gravity-free world, which is rarely what a free-flight run intends. Keep the
+        # configuration expressible, since a genuinely weightless body is a valid thing
+        # to model, but say so rather than proceeding silently.
+        if g_magnitude == 0.0:
+            _logger.warning(
+                _logging.indent()
+                + "The OperatingPoint's g_E is (0.0, 0.0, 0.0), so this free flight "
+                "run models a weightless body in a gravity-free world"
+            )
+            _logger.warning(
+                _logging.indent()
+                + "Set g_E to model a gravitational field (for example, to "
+                "(0.0, 0.0, 9.80665) for standard gravity) and set the Airplane's "
+                "weight to mass * |g_E|"
             )
 
         # The free-flight dynamics never apply externalFX_W: Non-aerodynamic loads enter

--- a/tests/unit/fixtures/problem_fixtures.py
+++ b/tests/unit/fixtures/problem_fixtures.py
@@ -218,6 +218,7 @@ def make_basic_free_flight_unsteady_problem_fixture(
     ) = None,
     mujoco_assets: dict[str, bytes] | None = None,
     extra_xml: dict[str, str] | None = None,
+    weightless: bool = False,
 ) -> ps.problems.FreeFlightUnsteadyProblem:
     """This method makes a fixture that is a FreeFlightUnsteadyProblem for general
     testing.
@@ -234,11 +235,25 @@ def make_basic_free_flight_unsteady_problem_fixture(
     :param extra_xml: dict or None A dict mapping injection point names to XML fragment
         strings to inject into the generated MuJoCo XML. If None, no extra XML is
         injected. The default is None.
+    :param weightless: bool Whether to configure the fixture with no gravitational
+        field. If True, the Airplane keeps its 0.0 weight default and the OperatingPoint
+        keeps its (0.0, 0.0, 0.0) g_E default, which is the all-defaults configuration
+        that FreeFlightUnsteadyProblem warns about. The default is False.
     :return basic_free_flight_unsteady_problem_fixture: FreeFlightUnsteadyProblem This
         is the FreeFlightUnsteadyProblem configured for general testing.
     """
-    # Build the FreeFlightMovement using a static motion configuration.
-    base_airplane = geometry_fixtures.make_first_airplane_fixture()
+    # Build the FreeFlightMovement using a static motion configuration. A weightless
+    # fixture builds its Airplane from the Wing fixture directly, since the shared
+    # Airplane fixture carries a non zero weight that a zero gravitational field cannot
+    # be consistent with.
+    if weightless:
+        base_airplane = ps.geometry.airplane.Airplane(
+            wings=[geometry_fixtures.make_type_4_wing_fixture()],
+            name="First Test Airplane",
+            Cg_GP1_CgP1=[0.0, 0.0, 0.0],
+        )
+    else:
+        base_airplane = geometry_fixtures.make_first_airplane_fixture()
     base_wing = base_airplane.wings[0]
 
     # Create WingCrossSectionMovements (one per WingCrossSection in the Wing).
@@ -265,12 +280,13 @@ def make_basic_free_flight_unsteady_problem_fixture(
     # Create the FreeFlightOperatingPointMovement. Free flight requires the Airplane's
     # weight, the mass, and the gravitational field to agree (weight == mass * |g_E|).
     # The shared OperatingPoint fixtures default to no gravity, so rebuild the
-    # OperatingPoint with standard gravity here (preserving every other field) and
+    # OperatingPoint with the requested gravity here (preserving every other field) and
     # derive the matching mass from the Airplane's weight.
     if base_operating_point is None:
         base_operating_point = (
             operating_point_fixtures.make_basic_operating_point_fixture()
         )
+    g_E = (0.0, 0.0, 0.0) if weightless else (0.0, 0.0, 9.80665)
     base_operating_point = ps.operating_point.OperatingPoint(
         rho=base_operating_point.rho,
         vCg__E=base_operating_point.vCg__E,
@@ -282,10 +298,12 @@ def make_basic_free_flight_unsteady_problem_fixture(
         surfacePoint_E_Eo=base_operating_point.surfacePoint_E_Eo,
         externalFX_W=base_operating_point.externalFX_W,
         nu=base_operating_point.nu,
-        g_E=(0.0, 0.0, 9.80665),
+        g_E=g_E,
         omegas_BP1__E=base_operating_point.omegas_BP1__E,
     )
-    mass = base_airplane.weight / 9.80665
+    # A zero gravitational field makes mass * |g_E| zero for any mass, so the Airplane's
+    # zero weight is consistent with any positive value.
+    mass = 1.0 if weightless else base_airplane.weight / 9.80665
     op_movement = ps.movements.free_flight_operating_point_movement.FreeFlightOperatingPointMovement(
         base_operating_point=base_operating_point,
     )

--- a/tests/unit/test_free_flight_unsteady_problem.py
+++ b/tests/unit/test_free_flight_unsteady_problem.py
@@ -382,6 +382,27 @@ class TestFreeFlightUnsteadyProblem(unittest.TestCase):
                 I_BP1_CgP1=np.eye(3, dtype=float),
             )
 
+    def test_zero_gravity_warns_that_the_body_is_weightless(self) -> None:
+        """Test that a zero g_E warns that the run models a weightless body."""
+        with self.assertLogs("pterasoftware.problems", level="WARNING") as caught:
+            problem_fixtures.make_basic_free_flight_unsteady_problem_fixture(
+                weightless=True
+            )
+
+        self.assertTrue(
+            any("weightless body" in message for message in caught.output),
+            "The zero g_E warning should say that the body is weightless.",
+        )
+        self.assertTrue(
+            any("9.80665" in message for message in caught.output),
+            "The zero g_E warning should show how to set standard gravity.",
+        )
+
+    def test_non_zero_gravity_does_not_warn(self) -> None:
+        """Test that a non zero g_E does not warn about a weightless body."""
+        with self.assertNoLogs("pterasoftware.problems", level="WARNING"):
+            problem_fixtures.make_basic_free_flight_unsteady_problem_fixture()
+
 
 class TestFreeFlightUnsteadyProblemInitializeNextProblem(unittest.TestCase):
     """Tests for FreeFlightUnsteadyProblem.initialize_next_problem."""


### PR DESCRIPTION
## Description

`FreeFlightUnsteadyProblem` now logs a warning when the `OperatingPoint`'s `g_E` has zero magnitude, stating that the run models a weightless body in a gravity-free world and showing how to set standard gravity.

## Motivation

`Airplane.weight` defaults to `0.0` and `OperatingPoint.g_E` defaults to `(0.0, 0.0, 0.0)`, so an all-defaults free-flight problem passes the `weight == mass * |g_E|` consistency check and silently simulates a weightless body. Every partial misconfiguration, a nonzero weight without gravity or gravity without a matching weight, already raises a descriptive error, so the fully-defaulted case was the one silent path through that check.

The zero defaults are kept, per the issue: gravity always physically exists, zero is a valid value, and a genuinely weightless body stays expressible.

Before, constructing a free-flight problem with the default weight and the default `g_E` produced no output at all. After:

```
WARNING pterasoftware.problems: The OperatingPoint's g_E is (0.0, 0.0, 0.0), so this free flight run models a weightless body in a gravity-free world
WARNING pterasoftware.problems: Set g_E to model a gravitational field (for example, to (0.0, 0.0, 9.80665) for standard gravity) and set the Airplane's weight to mass * |g_E|
```

## Relevant Issues

Closes #193.

## Changes

* Hoist the `g_E` magnitude into a local in `FreeFlightUnsteadyProblem.__init__`, so the new check reuses the value the consistency check already computes.
* Log a warning from `FreeFlightUnsteadyProblem.__init__` when that magnitude is zero.
* Document the warning in the `mass` parameter's docstring, where the consistency requirement is described.
* Add a `weightless` option to `make_basic_free_flight_unsteady_problem_fixture`, so the zero-gravity configuration is built through the same path as every other free-flight fixture.
* Add tests that a zero `g_E` warns and that a non-zero `g_E` does not.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Verification

`tests.unit.test_free_flight_unsteady_problem` goes from 55 to 57 tests, all passing. Both new tests were confirmed to fail without the change (`AssertionError: no logs of level WARNING or higher triggered on pterasoftware.problems`). The full suite goes from `Ran 2586 tests ... OK` to `Ran 2588 tests ... OK`.

`pre-commit run --files <changed files>` passes every hook, including `black`, `isort`, `docformatter`, `codespell`, `octowrap`, `ascii-only`, and `mypy`. `mypy pterasoftware` reports no issues in 47 source files.

Tested on Windows 11 with Python 3.12.9. I did not run the suite on Linux or on Python 3.11, 3.13, or 3.14, so the CI matrix is unverified from my side. Both shipped free-flight examples set `g_E=(0.0, 0.0, 9.80665)`, so the new warning does not fire in them and no expected example output changes.
