### PR TITLE
[BUG] Fix NaN loads from a one-step window

### DIFF
--- a/pterasoftware/unsteady_ring_vortex_lattice_method.py
+++ b/pterasoftware/unsteady_ring_vortex_lattice_method.py
@@ -36,8 +36,6 @@ from . import (
 _logger = _logging.get_logger("unsteady_ring_vortex_lattice_method")
 
 
-# TODO: Add unit tests for trapezoid-rule-based averages for the mean and RMS loads and
-#  load coefficients.
 # TEST: Assess how comprehensive this function's integration tests are and update or
 #  extend them if needed.
 class UnsteadyRingVortexLatticeMethodSolver:
@@ -3145,11 +3143,35 @@ class UnsteadyRingVortexLatticeMethodSolver:
         # number of intervals for the trapezoidal rule is one less than the number of
         # samples.
         num_intervals = num_steps_to_average - 1
+
+        # A delta_time at or above the LCM period leaves a single sample in the
+        # averaging window, which the trapezoidal rule has no interval to integrate
+        # over. The mean of one sample is that sample and its RMS is that sample's
+        # magnitude, so use those limiting values. Dividing by the zero intervals
+        # instead yields NaN loads with no error, which is a silent modeling failure.
+        single_sample = not static and num_intervals == 0
+        if single_sample:
+            _logger.warning(
+                _logging.indent()
+                + "The averaging window holds a single time step, so the mean and RMS "
+                "loads are that step's values"
+            )
+            _logger.warning(
+                _logging.indent()
+                + "Set delta_time below the movement's LCM period to average over a "
+                "resolved cycle"
+            )
+
         for airplane_id in range(self.num_airplanes):
             for name, final_name, mean_name, rms_name in load_names:
                 history = load_histories[name][airplane_id]
                 if static:
                     getattr(self.unsteady_problem, final_name).append(history[:, -1])
+                elif single_sample:
+                    getattr(self.unsteady_problem, mean_name).append(history[:, -1])
+                    getattr(self.unsteady_problem, rms_name).append(
+                        np.abs(history[:, -1])
+                    )
                 else:
                     getattr(self.unsteady_problem, mean_name).append(
                         np.trapezoid(history, axis=-1) / num_intervals

--- a/tests/unit/test_unsteady_ring_vortex_lattice_method.py
+++ b/tests/unit/test_unsteady_ring_vortex_lattice_method.py
@@ -2,7 +2,7 @@
 
 import unittest
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -187,3 +187,174 @@ class TestUnsteadyRingVortexLatticeMethodSolverHookDefaults(unittest.TestCase):
         self.assertIs(
             self.solver._apply_body_rate(points, base_velocity), base_velocity
         )
+
+
+class TestUnsteadyRingVortexLatticeMethodSolverFinalizeLoads(unittest.TestCase):
+    """Tests for the trapezoid rule mean and RMS load averaging in _finalize_loads."""
+
+    # The Airplane attributes that _finalize_loads reads at each time step in the
+    # averaging window. Every one of them has to be present on the stand-in Airplanes,
+    # since _finalize_loads collects all of them on every call.
+    _LOAD_ATTRIBUTES = (
+        "forces_W",
+        "forceCoefficients_W",
+        "moments_W_CgP1",
+        "momentCoefficients_W_CgP1",
+        "forces_G",
+        "forceCoefficients_G",
+        "moments_G_Cg",
+        "momentCoefficients_G_Cg",
+        "moments_W_Cg",
+        "momentCoefficients_W_Cg",
+    )
+
+    def setUp(self) -> None:
+        """Set up a fresh solver whose movement is variable, which is the case that
+        averages over the final cycle."""
+        self.solver = solver_fixtures.make_unsteady_ring_solver_fixture()
+        self.assertFalse(self.solver.unsteady_problem.movement.static)
+
+    def _finalize_with_history(self, history: np.ndarray) -> None:
+        """Run _finalize_loads over a prescribed single Airplane load history.
+
+        Every load quantity is given the same history, so any of the UnsteadyProblem's
+        mean and RMS lists reflects it.
+
+        :param history: An ndarray of floats with shape (3, num_steps) holding the
+            Airplane's load vector at each time step in the averaging window.
+        :return: None
+        """
+        num_steps = history.shape[1]
+        self.solver.num_steps = num_steps
+        self.solver._first_averaging_step = 0
+
+        steady_problems = [
+            MagicMock(
+                airplanes=[
+                    MagicMock(
+                        **{name: history[:, step] for name in self._LOAD_ATTRIBUTES}
+                    )
+                ]
+            )
+            for step in range(num_steps)
+        ]
+
+        with patch.object(
+            type(self.solver),
+            "_get_steady_problem_at",
+            autospec=True,
+            side_effect=lambda solver, step: steady_problems[step],
+        ):
+            self.solver._finalize_loads()
+
+    def test_mean_loads_use_the_trapezoid_rule(self) -> None:
+        """Test that the mean loads are the trapezoid rule integral of the load history
+        divided by the number of intervals."""
+        history = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [2.0, 2.0, 2.0, 2.0, 2.0],
+            ],
+            dtype=float,
+        )
+
+        self._finalize_with_history(history)
+
+        # Over five evenly spaced samples the trapezoid rule halves the two endpoints,
+        # so the ramp integrates to (0.5 * 1 + 2 + 3 + 4 + 0.5 * 5) / 4 = 3.0 and each
+        # constant integrates to itself.
+        np.testing.assert_allclose(
+            self.solver.unsteady_problem.finalMeanForces_W[0],
+            np.array([3.0, 0.0, 2.0], dtype=float),
+        )
+
+    def test_rms_loads_use_the_trapezoid_rule(self) -> None:
+        """Test that the RMS loads are the square root of the trapezoid rule integral of
+        the squared load history divided by the number of intervals."""
+        history = np.array(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [2.0, 2.0, 2.0, 2.0, 2.0],
+            ],
+            dtype=float,
+        )
+
+        self._finalize_with_history(history)
+
+        # The squared ramp integrates to (0.5 * 1 + 4 + 9 + 16 + 0.5 * 25) / 4 = 10.5,
+        # so its RMS is sqrt(10.5). A constant's RMS is its own magnitude.
+        np.testing.assert_allclose(
+            self.solver.unsteady_problem.finalRmsForces_W[0],
+            np.array([np.sqrt(10.5), 0.0, 2.0], dtype=float),
+        )
+
+    def test_mean_load_over_a_full_cycle_recovers_the_cycle_average(self) -> None:
+        """Test that averaging a sinusoid sampled over exactly one cycle recovers the
+        sinusoid's offset, since its oscillating part integrates to zero."""
+        offset = 3.0
+        amplitude = 7.0
+        phases_rad = np.linspace(0.0, 2.0 * np.pi, 9, dtype=float)
+        oscillation = offset + amplitude * np.sin(phases_rad)
+        history = np.vstack([oscillation, oscillation, oscillation])
+
+        self._finalize_with_history(history)
+
+        np.testing.assert_allclose(
+            self.solver.unsteady_problem.finalMeanForces_W[0],
+            np.full(3, offset, dtype=float),
+            atol=1e-12,
+        )
+
+    def test_single_sample_window_reports_that_sample(self) -> None:
+        """Test that an averaging window holding one time step reports that step's loads
+        as the mean and its magnitude as the RMS, rather than dividing by zero intervals
+        and reporting NaN."""
+        history = np.array([[-2.0], [0.0], [4.0]], dtype=float)
+
+        with self.assertLogs(
+            "pterasoftware.unsteady_ring_vortex_lattice_method", level="WARNING"
+        ):
+            self._finalize_with_history(history)
+
+        np.testing.assert_allclose(
+            self.solver.unsteady_problem.finalMeanForces_W[0],
+            np.array([-2.0, 0.0, 4.0], dtype=float),
+        )
+        np.testing.assert_allclose(
+            self.solver.unsteady_problem.finalRmsForces_W[0],
+            np.array([2.0, 0.0, 4.0], dtype=float),
+        )
+
+    def test_single_sample_window_warns(self) -> None:
+        """Test that a single time step averaging window warns that the loads are that
+        step's values and says how to resolve the cycle."""
+        history = np.array([[-2.0], [0.0], [4.0]], dtype=float)
+
+        with self.assertLogs(
+            "pterasoftware.unsteady_ring_vortex_lattice_method", level="WARNING"
+        ) as caught:
+            self._finalize_with_history(history)
+
+        self.assertTrue(
+            any("single time step" in message for message in caught.output),
+            "The single sample warning should name the collapsed averaging window.",
+        )
+        self.assertTrue(
+            any("delta_time" in message for message in caught.output),
+            "The single sample warning should say how to resolve the cycle.",
+        )
+
+    def test_multiple_sample_window_does_not_warn(self) -> None:
+        """Test that an averaging window holding more than one time step does not warn
+        about a collapsed window."""
+        history = np.array(
+            [[1.0, 2.0], [0.0, 0.0], [2.0, 2.0]],
+            dtype=float,
+        )
+
+        with self.assertNoLogs(
+            "pterasoftware.unsteady_ring_vortex_lattice_method", level="WARNING"
+        ):
+            self._finalize_with_history(history)


### PR DESCRIPTION
## Description

`_finalize_loads` divided by zero intervals when the averaging window held a single time step, reporting every mean and RMS load as `NaN`. It now reports that sample's value and magnitude, and warns that the window collapsed.

## Motivation

For variable geometry, `_finalize_loads` averages the final cycle with the trapezoid rule and divides by `num_steps_to_average - 1`. When the averaging window holds one sample that divisor is zero, so every mean and RMS load and load coefficient comes out `NaN`. Nothing in the package reports it: the only signal is a NumPy `invalid value encountered in divide` `RuntimeWarning`, which is not raised, not logged through the package's logger, and easy to miss.

The window collapses to one sample whenever `delta_time` is at or above the movement's LCM period, which an explicit `delta_time` is not clamped against; the clamp to `_MIN_TIME_STEPS_PER_LCM_PERIOD` only applies to the estimated value. That configuration is under-resolved, but the package accepts it and returns `NaN` rather than saying so.

Reproduced with a 0.5 s flapping period, `delta_time = 0.6`, and `num_cycles = 1`, which gives `num_steps = 1`:

```
num_steps_to_average = 1
finalMeanForces_W  = [array([nan, nan, nan])]
finalRmsForces_W   = [array([nan, nan, nan])]
RuntimeWarnings during run: 20 x 'invalid value encountered in divide'
```

After:

```
WARNING pterasoftware.unsteady_ring_vortex_lattice_method: The averaging window holds a single time step, so the mean and RMS loads are that step's values
WARNING pterasoftware.unsteady_ring_vortex_lattice_method: Set delta_time below the movement's LCM period to average over a resolved cycle
finalMeanForces_W  = [array([-2.15483046e+00,  6.88338275e-15, -1.98668932e+01])]
finalRmsForces_W   = [array([ 2.15483046e+00,  6.88338275e-15,  1.98668932e+01])]
RuntimeWarnings during run: []
```

A single sample has a well defined mean and RMS: the sample itself, and its magnitude. Those are the limiting values of the trapezoid rule expressions, so using them keeps the reported loads consistent with the multi-sample case.

If you would rather reject an under-resolved `delta_time` outright, the natural place is `Movement`, where the estimated `delta_time` is already clamped against the LCM period. I did not do that here because it would turn currently-accepted configurations into errors, which felt like your call rather than mine. Happy to change the approach.

## Relevant Issues

Closes #112. The `NaN` behavior has no issue of its own; I found it while writing the unit tests that issue asks for.

## Changes

* Use the single sample's value as the mean and its magnitude as the RMS when the averaging window holds one time step, instead of dividing by zero intervals.
* Log a warning, once per solve, naming the collapsed window and how to resolve the cycle.
* Add unit tests for the trapezoid rule mean and RMS, including that a sinusoid sampled over exactly one cycle averages to its offset.
* Add unit tests for the single sample window and its warning.
* Drop the `TODO` asking for these tests.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Verification

`tests.unit.test_unsteady_ring_vortex_lattice_method` goes from 20 to 26 tests, all passing. The two single-sample tests were confirmed to fail without the fix (`FAILED (failures=2)`). The four trapezoid rule tests characterize existing behavior and pass either way, which is what #112 asked for. The full suite goes from `Ran 2586 tests ... OK` to `Ran 2592 tests ... OK`, so the integration tests that compare solver output against references are unchanged.

`pre-commit run --files <changed files>` passes every hook, including `black`, `isort`, `docformatter`, `codespell`, `octowrap`, `ascii-only`, and `mypy`. `mypy pterasoftware` reports no issues in 47 source files.

Tested on Windows 11 with Python 3.12.9. I did not run the suite on Linux or on Python 3.11, 3.13, or 3.14, so the CI matrix is unverified from my side. The new unit tests drive `_finalize_loads` directly with stand-in `Airplane`s rather than through a full solve, so they cover the averaging arithmetic and not the load values feeding it.
