### PR TITLE
Preserve shared references when saving

### DIFF
--- a/docs/CLASSES_AND_IMMUTABILITY.md
+++ b/docs/CLASSES_AND_IMMUTABILITY.md
@@ -79,15 +79,15 @@ When implementing `__deepcopy__`, handle cached derived properties based on thei
 
 The `_serialization` module uses the same `object.__new__()` + `object.__setattr__()` pattern as the `__deepcopy__` methods but with a simpler strategy: the logical state of each object is preserved exactly as it was at save time, including all cached values on primary slots. For these primary attributes, no values are reset to `None` during deserialization.
 
-Some redundant or alias slots (for example, solver alias slots and `Movement._airplanes` / `Movement._operating_points`) are treated specially: they are serialized as `null` and then deterministically rebuilt from their canonical sources during deserialization. This preserves object graph identity and avoids duplicating equivalent objects while still yielding the same effective state as the original instance.
+Shared references are preserved by an identity memo: the first encounter of an object serializes it in full, and every later encounter (for example, a solver's `airplanes` alias into its `SteadyProblem`, or `Movement._airplanes` inside an `UnsteadyProblem`) serializes as a reference to it. Deserialization resolves those references to the same rebuilt instance, so object graph identity survives the round trip without duplicating equivalent objects. The one exception is `MuJoCoModel`'s native engine objects, which cannot be serialized at all, so they are serialized as `null` and rebuilt from the model's XML string on deserialization.
 
 This works because:
 
 1. Deserialized objects are fully formed snapshots. There is no subsequent `__init__`, solver run, or meshing step that would populate set once attributes, so there is no conflict with set once guards.
-2. Cached derived values remain valid because the immutable and set once attributes they depend on are also restored with their original values, and any alias slots are rebuilt to match.
+2. Cached derived values remain valid because the immutable and set once attributes they depend on are also restored with their original values, and alias slots resolve to the same restored objects as their canonical sources.
 3. NumPy array writeable flags are preserved through serialization, maintaining the same mutability guarantees as the original objects.
 
-When adding or renaming `__slots__` on any class, both `__deepcopy__` and `_serialization` are affected. The serialization module discovers attributes generically via `__slots__`, so new slots are automatically serialized (subject to the intentional omission of redundant/alias slots described above). However, adding or removing slots requires incrementing `_FORMAT_VERSION` in `_serialization.py` to ensure old files are not loaded with incompatible code.
+When adding or renaming `__slots__` on any class, both `__deepcopy__` and `_serialization` are affected. The serialization module discovers attributes generically via `__slots__`, so new slots are automatically serialized (subject to the `MuJoCoModel` exception described above). However, adding or removing slots requires incrementing `_FORMAT_VERSION` in `_serialization.py` to ensure old files are not loaded with incompatible code.
 
 ### List Collection Immutability
 

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -105,6 +105,14 @@ def _all_slots(cls: type) -> list[str]:
 # parameter on load().
 _DEFAULT_MAX_DECOMPRESSED_SIZE = 4_000_000_000  # 4 GB
 
+# This is the maximum read size in bytes for decompressing gzip files during load().
+# Each read is sized to this value or to the remaining allowance under the maximum
+# allowed size, whichever is smaller. Reading in bounded chunks matters because the
+# buffered reader preallocates the requested size, so a single read call sized to the
+# maximum allowed size would spike memory by the full cap (4 GB by default) on every
+# load.
+_GZIP_READ_CHUNK_SIZE = 16_777_216  # 16 MiB
+
 # Maps class names to their types for deserialization dispatch.
 _CLASS_REGISTRY: dict[str, type] = {
     "Airfoil": Airfoil,
@@ -287,13 +295,28 @@ def load(path: str | Path, max_size: int | None = None) -> object:
         max_size = _DEFAULT_MAX_DECOMPRESSED_SIZE
 
     if lowered_name.endswith(".json.gz"):
+        # Decompress in chunks and stop as soon as the accumulated size exceeds the cap.
+        # A single f.read(max_size + 1) call would make the buffered reader preallocate
+        # max_size + 1 bytes up front, so every load would spike memory by the full cap
+        # regardless of the actual decompressed size.
+        decompressed = bytearray()
         with gzip.open(path, "rb") as f:
-            raw = f.read(max_size + 1)
-            if len(raw) > max_size:
-                raise ValueError(
-                    f"Decompressed file exceeds the maximum allowed size of "
-                    f"{max_size} bytes."
-                )
+            while True:
+                # Each read is also capped at the remaining allowance so that neither
+                # the read buffer nor the total decompressed data ever exceeds the cap
+                # by more than one byte, even when max_size is smaller than the chunk
+                # size.
+                remaining = max_size + 1 - len(decompressed)
+                chunk = f.read(min(_GZIP_READ_CHUNK_SIZE, remaining))
+                if not chunk:
+                    break
+                decompressed += chunk
+                if len(decompressed) > max_size:
+                    raise ValueError(
+                        f"Decompressed file exceeds the maximum allowed size of "
+                        f"{max_size} bytes."
+                    )
+        raw: bytes | bytearray = decompressed
     else:
         with open(path, "rb") as f:
             raw = f.read()

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -80,7 +80,7 @@ _CALLABLE_FUNC_TO_NAME = {func: name for name, func in _CALLABLE_NAME_TO_FUNC.it
 
 # Increments only when the serialization structure changes (slots added/removed/
 # renamed, class registry changed, encoding strategy changed).
-_FORMAT_VERSION = 25
+_FORMAT_VERSION = 26
 
 
 def _all_slots(cls: type) -> list[str]:
@@ -177,22 +177,6 @@ _PUBLIC_SAVEABLE_CLASSES: frozenset[str] = frozenset(
         "FreeFlightUnsteadyRingVortexLatticeMethodSolver",
     }
 )
-
-# These are the slots on steady solvers that are aliases into the SteadyProblem graph.
-_STEADY_SOLVER_SKIP_SLOTS: frozenset[str] = frozenset(
-    {"airplanes", "operating_point", "reynolds_numbers", "vInf_GP1__E", "panels"}
-)
-
-# These are the slots on the unsteady solver that are aliases into the UnsteadyProblem
-# graph.
-_UNSTEADY_SOLVER_SKIP_SLOTS: frozenset[str] = frozenset(
-    {"current_airplanes", "current_operating_point", "panels"}
-)
-
-# These are the slots on Movement that are redundant when serialized inside an
-# UnsteadyProblem. The canonical data lives in the SteadyProblems. These are
-# reconstructed on deserialization to preserve object identity.
-_MOVEMENT_SKIP_SLOTS: frozenset[str] = frozenset({"_airplanes", "_operating_points"})
 
 # These are the slots on MuJoCoModel that are serialized as null. _model and _data wrap
 # native MuJoCo state and are rebuilt from the serialized XML string and the serialized
@@ -523,17 +507,14 @@ def _log_load_warnings(data: dict[str, Any]) -> None:
 
 
 def _object_to_dict(
-    obj: object,
-    *,
-    _skip_slots: frozenset[str] = frozenset(),
-    memo: dict[int, tuple[int, object]] | None = None,
+    obj: object, *, memo: dict[int, tuple[int, object]] | None = None
 ) -> dict[str, Any]:
     """Generically serializes a Ptera Software object to a dict.
 
     Iterates over the class's __slots__ to discover all attributes, including cache
     slots. JSON keys are the slot names themselves (e.g., "_rho", "_name", "forces_W").
-    Slots listed in _skip_slots are serialized as null (used by the shared reference
-    optimization for UnsteadyProblem and solver classes).
+    The MuJoCoModel's native engine objects are serialized as null and rebuilt on
+    deserialization.
 
     Shared references are preserved via an identity memo. The first encounter of each
     object serializes it fully and stamps the dict with an "_id" key holding a small
@@ -543,7 +524,6 @@ def _object_to_dict(
     WingCrossSection) is stored only once and its sharing survives the round trip.
 
     :param obj: The Ptera Software object to serialize.
-    :param _skip_slots: A frozenset of slot names to serialize as null.
     :param memo: The identity memo mapping an object's id() to its "_id" integer and the
         object itself (held to keep its id() from being recycled during the walk). If
         None, a fresh memo is created, making this a top level call.
@@ -565,20 +545,11 @@ def _object_to_dict(
 
     _logger.debug(_logging.indent() + "Serializing %s", class_name)
 
-    # Solver skip slots always apply because the aliases are always redundant with
-    # solver._steady_problem or solver.unsteady_problem.
-    if isinstance(
-        obj,
-        (SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver),
-    ):
-        _skip_slots = _skip_slots | _STEADY_SOLVER_SKIP_SLOTS
-    elif isinstance(obj, UnsteadyRingVortexLatticeMethodSolver):
-        _skip_slots = _skip_slots | _UNSTEADY_SOLVER_SKIP_SLOTS
-
-    # The MuJoCoModel's native model and data objects cannot be serialized. They are
+    # The MuJoCoModel's native model and data objects cannot be serialized, so they are
     # rebuilt from the XML string and the assets dict on deserialization.
+    skip_slots: frozenset[str] = frozenset()
     if isinstance(obj, MuJoCoModel):
-        _skip_slots = _skip_slots | _MUJOCO_MODEL_SKIP_SLOTS
+        skip_slots = _MUJOCO_MODEL_SKIP_SLOTS
 
     # Register the object in the memo before serializing its slots so that any reference
     # back to it from within its own subtree serializes as a ref.
@@ -586,16 +557,9 @@ def _object_to_dict(
     memo[id(obj)] = (ref_id, obj)
 
     result: dict[str, Any] = {"_type": class_name, "_id": ref_id}
-    is_unsteady_problem = isinstance(obj, UnsteadyProblem)
     for slot_name in _all_slots(cls):
-        if slot_name in _skip_slots:
+        if slot_name in skip_slots:
             result[slot_name] = None
-        elif is_unsteady_problem and slot_name == "_movement":
-            # Pass _MOVEMENT_SKIP_SLOTS to the Movement child so that _airplanes and
-            # _operating_points are serialized as null.
-            result[slot_name] = _object_to_dict(
-                getattr(obj, slot_name), _skip_slots=_MOVEMENT_SKIP_SLOTS, memo=memo
-            )
         else:
             result[slot_name] = _serialize_value(getattr(obj, slot_name), memo=memo)
     return result
@@ -608,9 +572,8 @@ def _object_from_dict(
 
     Uses the "_type" tag to look up the class in the registry. Creates an empty instance
     via object.__new__(cls), bypassing __init__ entirely. Then restores every serialized
-    attribute (including caches) via object.__setattr__(). After restoring all slots,
-    calls _reconstruct_shared_references() to rebuild any slots that were skipped during
-    serialization.
+    attribute (including caches) via object.__setattr__(). For a MuJoCoModel, rebuilds
+    the native engine objects that were serialized as null.
 
     The instance is registered in the table under the dict's "_id" integer before its
     slots are restored, so {"_type": "ref", "id": ...} dicts elsewhere in the data
@@ -637,109 +600,14 @@ def _object_from_dict(
         object.__setattr__(
             obj, slot_name, _deserialize_value(data[slot_name], table=table)
         )
-    _reconstruct_shared_references(obj)
-    return obj
 
-
-def _reconstruct_shared_references(obj: object) -> None:
-    """Rebuilds shared references that were skipped during serialization.
-
-    Called after _object_from_dict restores all serialized slots. Handles
-    UnsteadyProblem (Movement <-> SteadyProblem aliases), steady solvers (solver ->
-    SteadyProblem aliases), and the unsteady solver (solver -> UnsteadyProblem aliases).
-
-    :param obj: The deserialized Ptera Software object.
-    :return: None
-    """
     if isinstance(obj, MuJoCoModel):
         # The native model and data objects were skipped during serialization. Rebuild
         # them from the deserialized XML string. This module is inherently coupled to
         # class internals, so calling a private method directly is acceptable here.
         # noinspection PyProtectedMember
         obj._rebuild_engine()
-
-    if isinstance(
-        obj,
-        (SteadyHorseshoeVortexLatticeMethodSolver, SteadyRingVortexLatticeMethodSolver),
-    ):
-        # This module is inherently coupled to class internals (it reads __slots__ and
-        # writes private backing stores for all classes), so accessing a private
-        # attribute directly is acceptable here.
-        # noinspection PyProtectedMember
-        problem = obj._steady_problem
-        object.__setattr__(obj, "airplanes", problem.airplanes)
-        object.__setattr__(obj, "operating_point", problem.operating_point)
-        object.__setattr__(obj, "reynolds_numbers", problem.reynolds_numbers)
-        object.__setattr__(obj, "vInf_GP1__E", problem.operating_point.vInf_GP1__E)
-
-        if obj.ran:
-            # Reconstruct the flattened panels array (same order as _collapse_geometry).
-            panels_list: list[Panel] = []
-            for airplane in problem.airplanes:
-                for wing in airplane.wings:
-                    assert wing.panels is not None
-                    panels_list.extend(np.ravel(wing.panels))
-            object.__setattr__(obj, "panels", np.array(panels_list, dtype=object))
-        else:
-            # Pre run: panels is an uninitialized object array sized to num_panels.
-            object.__setattr__(obj, "panels", np.empty(obj.num_panels, dtype=object))
-
-    if isinstance(obj, UnsteadyProblem):
-        movement = obj.movement
-        steady_problems = obj.steady_problems
-        num_steps = len(steady_problems)
-        num_airplane_movements = len(movement.airplane_movements)
-
-        # Reconstruct Movement._airplanes as a tuple[tuple[Airplane, ...], ...]. The
-        # outer index is the AirplaneMovement, and the inner index is the time step.
-        airplanes = tuple(
-            tuple(
-                steady_problems[step].airplanes[airplane_movement_index]
-                for step in range(num_steps)
-            )
-            for airplane_movement_index in range(num_airplane_movements)
-        )
-        object.__setattr__(movement, "_airplanes", airplanes)
-
-        # Reconstruct Movement._operating_points: tuple[OperatingPoint, ...]. It is
-        # indexed by time step.
-        operating_points = tuple(
-            steady_problems[step].operating_point for step in range(num_steps)
-        )
-        object.__setattr__(movement, "_operating_points", operating_points)
-
-    if isinstance(obj, UnsteadyRingVortexLatticeMethodSolver):
-        unsteady_problem = obj.unsteady_problem
-
-        # This module is inherently coupled to class internals (it reads __slots__ and
-        # writes private backing stores for all classes), so accessing a private
-        # attribute directly is acceptable here.
-        # noinspection PyProtectedMember
-        current_step = obj._current_step
-        current_steady_problem = unsteady_problem.steady_problems[current_step]
-        object.__setattr__(
-            obj, "current_operating_point", current_steady_problem.operating_point
-        )
-
-        if obj.ran:
-            object.__setattr__(
-                obj, "current_airplanes", current_steady_problem.airplanes
-            )
-
-            # Reconstruct flattened panels from current step's airplanes.
-            current_panels_list: list[Panel] = []
-            for airplane in current_steady_problem.airplanes:
-                for wing in airplane.wings:
-                    assert wing.panels is not None
-                    current_panels_list.extend(np.ravel(wing.panels))
-            object.__setattr__(
-                obj, "panels", np.array(current_panels_list, dtype=object)
-            )
-        else:
-            # Pre run: current_airplanes is an empty tuple and panels is an empty object
-            # array.
-            object.__setattr__(obj, "current_airplanes", ())
-            object.__setattr__(obj, "panels", np.empty(0, dtype=object))
+    return obj
 
 
 def _ndarray_to_dict(

--- a/pterasoftware/_serialization.py
+++ b/pterasoftware/_serialization.py
@@ -80,7 +80,7 @@ _CALLABLE_FUNC_TO_NAME = {func: name for name, func in _CALLABLE_NAME_TO_FUNC.it
 
 # Increments only when the serialization structure changes (slots added/removed/
 # renamed, class registry changed, encoding strategy changed).
-_FORMAT_VERSION = 24
+_FORMAT_VERSION = 25
 
 
 def _all_slots(cls: type) -> list[str]:
@@ -208,6 +208,10 @@ def save(path: str | Path, obj: object) -> None:
     unmeshed geometry objects. Gzip compression typically reduces file sizes by 10x or
     more, and plain ".json" files use indented formatting that further increases their
     size.
+
+    Shared references are preserved. An object referenced from many places (e.g., an
+    Airfoil shared by every per step WingCrossSection) is written once, every other
+    reference is written as a pointer to it, and load() restores the sharing.
 
     The file records an internal serialization format version. load() accepts a file
     only when that format version matches the running code's exactly, and there is no
@@ -358,11 +362,15 @@ def hash_object(obj: object) -> str:
 
     The digest is the SHA-256 hash of the object's JSON serialization, computed over
     every serialized slot (including cache slots) and folded together with the current
-    serialization format version. Two objects with identical serialized content produce
-    the same digest regardless of instance identity, and any difference in serialized
-    content produces a different digest. The digest survives a save and load round trip,
-    but it is only stable within a single serialization format version, because a format
-    version change is folded into the hash and shifts every digest.
+    serialization format version. Two object graphs with identical content and identical
+    internal sharing structure produce the same digest regardless of instance identity,
+    and any difference in serialized content produces a different digest. Because shared
+    references serialize as refs, two graphs whose contents are equal but whose aliasing
+    differs (e.g., one Airfoil shared by every WingCrossSection versus an equal but
+    distinct Airfoil per WingCrossSection) produce different digests. The digest
+    survives a save and load round trip, but it is only stable within a single
+    serialization format version, because a format version change is folded into the
+    hash and shifts every digest.
 
     :param obj: The Ptera Software object to hash. Must be an instance of a class
         registered for serialization; an unregistered type raises a TypeError.
@@ -515,7 +523,10 @@ def _log_load_warnings(data: dict[str, Any]) -> None:
 
 
 def _object_to_dict(
-    obj: object, *, _skip_slots: frozenset[str] = frozenset()
+    obj: object,
+    *,
+    _skip_slots: frozenset[str] = frozenset(),
+    memo: dict[int, tuple[int, object]] | None = None,
 ) -> dict[str, Any]:
     """Generically serializes a Ptera Software object to a dict.
 
@@ -524,14 +535,33 @@ def _object_to_dict(
     Slots listed in _skip_slots are serialized as null (used by the shared reference
     optimization for UnsteadyProblem and solver classes).
 
+    Shared references are preserved via an identity memo. The first encounter of each
+    object serializes it fully and stamps the dict with an "_id" key holding a small
+    integer. Every later encounter of the same object (by identity) serializes as a
+    {"_type": "ref", "id": ...} dict pointing at that integer, so an object that is
+    referenced from many places (e.g., an Airfoil shared by every per step
+    WingCrossSection) is stored only once and its sharing survives the round trip.
+
     :param obj: The Ptera Software object to serialize.
     :param _skip_slots: A frozenset of slot names to serialize as null.
-    :return: A dict with "_type" set to the class name and one key per slot.
+    :param memo: The identity memo mapping an object's id() to its "_id" integer and the
+        object itself (held to keep its id() from being recycled during the walk). If
+        None, a fresh memo is created, making this a top level call.
+    :return: A dict with "_type" set to the class name, "_id" set to the memo integer,
+        and one key per slot, or a {"_type": "ref", "id": ...} dict if the object was
+        already serialized under this memo.
     """
     cls = type(obj)
     class_name = cls.__name__
     if class_name not in _CLASS_REGISTRY:
         raise TypeError(f"_object_to_dict does not handle {class_name}.")
+
+    if memo is None:
+        memo = {}
+
+    memoized = memo.get(id(obj))
+    if memoized is not None:
+        return {"_type": "ref", "id": memoized[0]}
 
     _logger.debug(_logging.indent() + "Serializing %s", class_name)
 
@@ -550,7 +580,12 @@ def _object_to_dict(
     if isinstance(obj, MuJoCoModel):
         _skip_slots = _skip_slots | _MUJOCO_MODEL_SKIP_SLOTS
 
-    result: dict[str, Any] = {"_type": class_name}
+    # Register the object in the memo before serializing its slots so that any reference
+    # back to it from within its own subtree serializes as a ref.
+    ref_id = len(memo)
+    memo[id(obj)] = (ref_id, obj)
+
+    result: dict[str, Any] = {"_type": class_name, "_id": ref_id}
     is_unsteady_problem = isinstance(obj, UnsteadyProblem)
     for slot_name in _all_slots(cls):
         if slot_name in _skip_slots:
@@ -559,14 +594,16 @@ def _object_to_dict(
             # Pass _MOVEMENT_SKIP_SLOTS to the Movement child so that _airplanes and
             # _operating_points are serialized as null.
             result[slot_name] = _object_to_dict(
-                getattr(obj, slot_name), _skip_slots=_MOVEMENT_SKIP_SLOTS
+                getattr(obj, slot_name), _skip_slots=_MOVEMENT_SKIP_SLOTS, memo=memo
             )
         else:
-            result[slot_name] = _serialize_value(getattr(obj, slot_name))
+            result[slot_name] = _serialize_value(getattr(obj, slot_name), memo=memo)
     return result
 
 
-def _object_from_dict(data: dict[str, Any]) -> object:
+def _object_from_dict(
+    data: dict[str, Any], *, table: dict[int, object] | None = None
+) -> object:
     """Generically deserializes a Ptera Software object from a dict.
 
     Uses the "_type" tag to look up the class in the registry. Creates an empty instance
@@ -575,7 +612,13 @@ def _object_from_dict(data: dict[str, Any]) -> object:
     calls _reconstruct_shared_references() to rebuild any slots that were skipped during
     serialization.
 
+    The instance is registered in the table under the dict's "_id" integer before its
+    slots are restored, so {"_type": "ref", "id": ...} dicts elsewhere in the data
+    resolve to the same instance and shared references survive the round trip.
+
     :param data: The dict produced by _object_to_dict.
+    :param table: The reference table mapping "_id" integers to their reconstructed
+        instances. If None, a fresh table is created, making this a top level call.
     :return: The reconstructed Ptera Software object.
     """
     type_tag = data["_type"]
@@ -583,11 +626,17 @@ def _object_from_dict(data: dict[str, Any]) -> object:
     if cls is None:
         raise TypeError(f"Unknown class in _object_from_dict: '{type_tag}'.")
 
+    if table is None:
+        table = {}
+
     _logger.debug(_logging.indent() + "Deserializing %s", type_tag)
 
     obj: object = object.__new__(cls)
+    table[data["_id"]] = obj
     for slot_name in _all_slots(cls):
-        object.__setattr__(obj, slot_name, _deserialize_value(data[slot_name]))
+        object.__setattr__(
+            obj, slot_name, _deserialize_value(data[slot_name], table=table)
+        )
     _reconstruct_shared_references(obj)
     return obj
 
@@ -693,7 +742,9 @@ def _reconstruct_shared_references(obj: object) -> None:
             object.__setattr__(obj, "panels", np.empty(0, dtype=object))
 
 
-def _ndarray_to_dict(arr: np.ndarray) -> dict[str, Any]:
+def _ndarray_to_dict(
+    arr: np.ndarray, *, memo: dict[int, tuple[int, object]] | None = None
+) -> dict[str, Any]:
     """Converts a NumPy ndarray to a JSON serializable dict.
 
     For numeric and bool dtypes, the array data is encoded as a base64 string with dtype
@@ -703,14 +754,18 @@ def _ndarray_to_dict(arr: np.ndarray) -> dict[str, Any]:
     the original mutability.
 
     :param arr: The ndarray to serialize.
+    :param memo: The identity memo threaded through to _serialize_value for dtype=object
+        elements. If None, a fresh memo is created.
     :return: A dict representing the serialized ndarray.
     """
     if arr.dtype == object:
+        if memo is None:
+            memo = {}
         return {
             "_type": "ndarray",
             "dtype": "object",
             "shape": list(arr.shape),
-            "items": [_serialize_value(item) for item in arr.ravel()],
+            "items": [_serialize_value(item, memo=memo) for item in arr.ravel()],
             "writeable": bool(arr.flags.writeable),
         }
 
@@ -723,7 +778,9 @@ def _ndarray_to_dict(arr: np.ndarray) -> dict[str, Any]:
     }
 
 
-def _ndarray_from_dict(array_dict: dict[str, Any]) -> np.ndarray:
+def _ndarray_from_dict(
+    array_dict: dict[str, Any], *, table: dict[int, object] | None = None
+) -> np.ndarray:
     """Reconstructs a NumPy ndarray from a dict produced by _ndarray_to_dict.
 
     Dispatches on dtype: base64 decode for numeric and bool dtypes, element by element
@@ -732,13 +789,17 @@ def _ndarray_from_dict(array_dict: dict[str, Any]) -> np.ndarray:
     the field is absent, the array defaults to writeable.
 
     :param array_dict: The dict produced by _ndarray_to_dict.
+    :param table: The reference table threaded through to _deserialize_value for
+        dtype=object elements. If None, a fresh table is created.
     :return: The reconstructed ndarray.
     """
     shape = array_dict["shape"]
     writeable = array_dict.get("writeable", True)
 
     if array_dict["dtype"] == "object":
-        items = [_deserialize_value(item) for item in array_dict["items"]]
+        if table is None:
+            table = {}
+        items = [_deserialize_value(item, table=table) for item in array_dict["items"]]
         arr = np.empty(len(items), dtype=object)
         for i, item in enumerate(items):
             arr[i] = item
@@ -757,7 +818,9 @@ def _ndarray_from_dict(array_dict: dict[str, Any]) -> np.ndarray:
     return arr
 
 
-def _serialize_value(value: object) -> object:
+def _serialize_value(
+    value: object, *, memo: dict[int, tuple[int, object]] | None = None
+) -> object:
     """Serializes a single value based on its runtime type.
 
     Dispatch order: None, bool (before int since bool is a subclass of int), int, float,
@@ -770,8 +833,14 @@ def _serialize_value(value: object) -> object:
     JSON object keys are strings, and a lossy key coercion would break the round trip.
 
     :param value: The value to serialize.
+    :param memo: The identity memo threaded through to _object_to_dict for registered
+        class instances, so shared references serialize once. If None, a fresh memo is
+        created, making this a top level call.
     :return: The JSON serializable representation of the value.
     """
+    if memo is None:
+        memo = {}
+
     if value is None:
         return None
 
@@ -798,18 +867,18 @@ def _serialize_value(value: object) -> object:
         }
 
     if isinstance(value, np.ndarray):
-        return _ndarray_to_dict(value)
+        return _ndarray_to_dict(value, memo=memo)
 
     if isinstance(value, tuple):
         return {
             "_type": "tuple",
-            "items": [_serialize_value(item) for item in value],
+            "items": [_serialize_value(item, memo=memo) for item in value],
         }
 
     if isinstance(value, list):
         return {
             "_type": "list",
-            "items": [_serialize_value(item) for item in value],
+            "items": [_serialize_value(item, memo=memo) for item in value],
         }
 
     if isinstance(value, dict):
@@ -821,11 +890,13 @@ def _serialize_value(value: object) -> object:
                 )
         return {
             "_type": "dict",
-            "items": {key: _serialize_value(item) for key, item in value.items()},
+            "items": {
+                key: _serialize_value(item, memo=memo) for key, item in value.items()
+            },
         }
 
     if type(value).__name__ in _CLASS_REGISTRY:
-        return _object_to_dict(value)
+        return _object_to_dict(value, memo=memo)
 
     if callable(value):
         name = _CALLABLE_FUNC_TO_NAME.get(value)
@@ -839,7 +910,9 @@ def _serialize_value(value: object) -> object:
     raise TypeError(f"_serialize_value does not handle {type(value).__name__}.")
 
 
-def _deserialize_value(data: object) -> object:
+def _deserialize_value(
+    data: object, *, table: dict[int, object] | None = None
+) -> object:
     """Deserializes a single value from its JSON representation.
 
     The format is self describing via _type tags. None, bool, and str are bare JSON
@@ -848,8 +921,14 @@ def _deserialize_value(data: object) -> object:
     are wrapped during serialization.
 
     :param data: The serialized data.
+    :param table: The reference table mapping "_id" integers to their reconstructed
+        instances, used to resolve {"_type": "ref", "id": ...} dicts. If None, a fresh
+        table is created, making this a top level call.
     :return: The deserialized value.
     """
+    if table is None:
+        table = {}
+
     if data is None:
         return None
 
@@ -872,14 +951,25 @@ def _deserialize_value(data: object) -> object:
         if type_tag == "bytes":
             return base64.b64decode(data["data"])
         if type_tag == "ndarray":
-            return _ndarray_from_dict(data)
+            return _ndarray_from_dict(data, table=table)
+        if type_tag == "ref":
+            ref_id = data["id"]
+            if ref_id not in table:
+                raise ValueError(
+                    f"Reference to unknown shared object id {ref_id} encountered "
+                    "during deserialization."
+                )
+            return table[ref_id]
         if type_tag == "tuple":
-            return tuple(_deserialize_value(item) for item in data["items"])
+            return tuple(
+                _deserialize_value(item, table=table) for item in data["items"]
+            )
         if type_tag == "list":
-            return [_deserialize_value(item) for item in data["items"]]
+            return [_deserialize_value(item, table=table) for item in data["items"]]
         if type_tag == "dict":
             return {
-                key: _deserialize_value(item) for key, item in data["items"].items()
+                key: _deserialize_value(item, table=table)
+                for key, item in data["items"].items()
             }
         if type_tag == "callable":
             name = data["name"]
@@ -888,7 +978,7 @@ def _deserialize_value(data: object) -> object:
                 raise ValueError(f"Unknown callable name: '{name}'.")
             return func
         if type_tag in _CLASS_REGISTRY:
-            return _object_from_dict(data)
+            return _object_from_dict(data, table=table)
         raise TypeError(f"Unknown _type tag: '{type_tag}'.")
 
     if isinstance(data, (int, float)):

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -529,6 +529,18 @@ class TestSerializeValue(unittest.TestCase):
         with self.assertRaises(TypeError):
             _serialize_value(set())
 
+    def test_shared_object_serializes_as_ref(self) -> None:
+        """Tests that the second encounter of one object serializes as a ref dict.
+
+        :return: None
+        """
+        operating_point = OperatingPoint()
+        result = _serialize_value((operating_point, operating_point))
+        assert isinstance(result, dict)
+        first, second = result["items"]
+        self.assertEqual(first["_type"], "OperatingPoint")
+        self.assertEqual(second, {"_type": "ref", "id": first["_id"]})
+
 
 class TestDeserializeValue(unittest.TestCase):
     """This class contains methods for testing _deserialize_value."""
@@ -704,6 +716,15 @@ class TestDeserializeValue(unittest.TestCase):
         """
         with self.assertRaises(TypeError):
             _deserialize_value({"_type": "unknown"})
+
+    def test_unknown_ref_id_raises(self) -> None:
+        """Tests that a ref to an id absent from the reference table raises a
+        ValueError.
+
+        :return: None
+        """
+        with self.assertRaises(ValueError):
+            _deserialize_value({"_type": "ref", "id": 0})
 
 
 class TestValueRoundTrip(unittest.TestCase):
@@ -923,6 +944,46 @@ class TestHashObject(unittest.TestCase):
             hash_object(OperatingPoint()),
             hash_object(Airfoil(name="NACA0012")),
         )
+
+    def test_differs_for_different_aliasing(self) -> None:
+        """Tests that graphs with equal content but different sharing hash differently.
+
+        :return: None
+        """
+        shared_airfoil = Airfoil(name="naca2412")
+        shared_wing = Wing(
+            wing_cross_sections=[
+                WingCrossSection(
+                    airfoil=shared_airfoil,
+                    num_spanwise_panels=3,
+                    chord=1.0,
+                    spanwise_spacing="uniform",
+                ),
+                WingCrossSection(
+                    airfoil=shared_airfoil,
+                    num_spanwise_panels=None,
+                    chord=0.5,
+                    Lp_Wcsp_Lpp=(0.0, 0.5, 0.0),
+                ),
+            ],
+        )
+        distinct_wing = Wing(
+            wing_cross_sections=[
+                WingCrossSection(
+                    airfoil=Airfoil(name="naca2412"),
+                    num_spanwise_panels=3,
+                    chord=1.0,
+                    spanwise_spacing="uniform",
+                ),
+                WingCrossSection(
+                    airfoil=Airfoil(name="naca2412"),
+                    num_spanwise_panels=None,
+                    chord=0.5,
+                    Lp_Wcsp_Lpp=(0.0, 0.5, 0.0),
+                ),
+            ],
+        )
+        self.assertNotEqual(hash_object(shared_wing), hash_object(distinct_wing))
 
     def test_stable_across_save_load_round_trip(self) -> None:
         """Tests that a save and load round trip preserves an object's digest.
@@ -1438,6 +1499,62 @@ class TestWingRoundTrip(unittest.TestCase):
         assert isinstance(result, Wing)
         self.assertEqual(result.name, wing.name)
         self.assertEqual(result.num_chordwise_panels, wing.num_chordwise_panels)
+
+    def test_shared_airfoil_identity_round_trip(self) -> None:
+        """Tests that one Airfoil shared by both WingCrossSections is still one shared
+        Airfoil after a round trip.
+
+        :return: None
+        """
+        airfoil = Airfoil(name="naca2412")
+        root_wing_cross_section = WingCrossSection(
+            airfoil=airfoil,
+            num_spanwise_panels=3,
+            chord=1.0,
+            spanwise_spacing="uniform",
+        )
+        tip_wing_cross_section = WingCrossSection(
+            airfoil=airfoil,
+            num_spanwise_panels=None,
+            chord=0.5,
+            Lp_Wcsp_Lpp=(0.0, 0.5, 0.0),
+        )
+        wing = Wing(
+            wing_cross_sections=[root_wing_cross_section, tip_wing_cross_section],
+        )
+        result = _deserialize_value(_serialize_value(wing))
+        assert isinstance(result, Wing)
+        self.assertIs(
+            result.wing_cross_sections[0].airfoil,
+            result.wing_cross_sections[1].airfoil,
+        )
+
+    def test_distinct_airfoils_identity_round_trip(self) -> None:
+        """Tests that equal but distinct Airfoils are still distinct after a round trip.
+
+        :return: None
+        """
+        root_wing_cross_section = WingCrossSection(
+            airfoil=Airfoil(name="naca2412"),
+            num_spanwise_panels=3,
+            chord=1.0,
+            spanwise_spacing="uniform",
+        )
+        tip_wing_cross_section = WingCrossSection(
+            airfoil=Airfoil(name="naca2412"),
+            num_spanwise_panels=None,
+            chord=0.5,
+            Lp_Wcsp_Lpp=(0.0, 0.5, 0.0),
+        )
+        wing = Wing(
+            wing_cross_sections=[root_wing_cross_section, tip_wing_cross_section],
+        )
+        result = _deserialize_value(_serialize_value(wing))
+        assert isinstance(result, Wing)
+        self.assertIsNot(
+            result.wing_cross_sections[0].airfoil,
+            result.wing_cross_sections[1].airfoil,
+        )
 
 
 class TestAirplaneRoundTrip(unittest.TestCase):

--- a/tests/unit/test_serialization.py
+++ b/tests/unit/test_serialization.py
@@ -1720,7 +1720,10 @@ class TestSteadyHorseshoeSolverRoundTrip(unittest.TestCase):
         solver.run()
         result = _deserialize_value(_serialize_value(solver))
         assert isinstance(result, SteadyHorseshoeVortexLatticeMethodSolver)
-        self.assertIs(result.airplanes, result._steady_problem.airplanes)
+        for solver_airplane, problem_airplane in zip(
+            result.airplanes, result._steady_problem.airplanes, strict=True
+        ):
+            self.assertIs(solver_airplane, problem_airplane)
         self.assertIs(result.operating_point, result._steady_problem.operating_point)
 
     def test_pre_run_round_trip(self) -> None:
@@ -1782,7 +1785,10 @@ class TestSteadyRingSolverRoundTrip(unittest.TestCase):
         solver.run()
         result = _deserialize_value(_serialize_value(solver))
         assert isinstance(result, SteadyRingVortexLatticeMethodSolver)
-        self.assertIs(result.airplanes, result._steady_problem.airplanes)
+        for solver_airplane, problem_airplane in zip(
+            result.airplanes, result._steady_problem.airplanes, strict=True
+        ):
+            self.assertIs(solver_airplane, problem_airplane)
         self.assertIs(result.operating_point, result._steady_problem.operating_point)
 
     def test_pre_run_round_trip(self) -> None:


### PR DESCRIPTION
# Description

This PR replaces the serializer's per-class skip-slot carve-outs with a serializer-wide identity memo, so any object referenced from more than one place in a saved graph is written exactly once and restored as one shared instance. It also fixes the gzip path of `load`, which spiked memory by the full decompressed-size cap on every load regardless of the file's actual size. The public `save` and `load` API is unchanged. The format version is bumped, so files written under the previous format are rejected on load, as has always been the case across format changes.

Streaming save and load (#286) is out of scope. The integer references introduced here are the building block that design calls for, but the walk still materializes the whole tree.

## Motivation

Serialization walked the object graph as a tree with no identity tracking, so an object referenced from many places was written once per reference and reconstructed as a distinct object per reference on load. The worst case was an `Airfoil` shared by every per step `WingCrossSection` of an unsteady simulation: it was duplicated `num_steps` times per `WingCrossSection`, inflating files and save-time memory, and loading made the duplication permanent. The previous mitigation was a set of hand-maintained skip-slot sets (the solver alias slots and `Movement._airplanes` and `Movement._operating_points`) that were serialized as null and rebuilt by `_reconstruct_shared_references`. That only covered the aliases someone had noticed, could not cover the free-flight problem (#245) because its `steady_problems` grows during the run, and reimplemented the solvers' own construction logic in a second place that had to be kept in sync. Separately, `load` read a `.json.gz` file with a single `f.read(max_size + 1)`, which makes the buffered reader preallocate the full cap (4 GB by default), so loading even a tiny compressed file transiently allocated 4 GB.

## Relevant Issues

Closes #245. The identity memo is the serializer-wide shared-reference scheme that issue's additional context asks about. Related to #286, whose record-stream layout builds on integer references of this kind.

## Changes

* `_object_to_dict` in `_serialization.py` threads an identity memo through the walk. The first encounter of an object stamps its dict with an `_id` integer, registered before its slots are serialized so a back reference from within its own subtree resolves, and every later encounter of the same object serializes as `{"_type": "ref", "id": ...}`.
* `_object_from_dict` registers each rebuilt instance in a reference table under its `_id` before restoring its slots, and `_deserialize_value` resolves `ref` dicts through that table, raising a `ValueError` on a ref to an unknown id.
* `_serialize_value`, `_deserialize_value`, `_ndarray_to_dict`, and `_ndarray_from_dict` gain keyword-only `memo` and `table` parameters so the memo reaches objects nested inside tuples, lists, dicts, and object-dtype arrays. A `None` memo or table marks a top level call and creates a fresh one.
* Removed `_STEADY_SOLVER_SKIP_SLOTS`, `_UNSTEADY_SOLVER_SKIP_SLOTS`, `_MOVEMENT_SKIP_SLOTS`, the `UnsteadyProblem` special case for `_movement` in `_object_to_dict`, and the entire `_reconstruct_shared_references` function. The solver alias slots and `Movement._airplanes` and `Movement._operating_points` now round trip on their own as refs, and the steady solvers' `panels`, `reynolds_numbers`, and `vInf_GP1__E` slots are serialized directly instead of being recomputed on load. `_MUJOCO_MODEL_SKIP_SLOTS` is the only remaining null-serialized slot set, and the `MuJoCoModel._rebuild_engine` call now lives in `_object_from_dict`.
* `load` decompresses `.json.gz` files in bounded chunks of `_GZIP_READ_CHUNK_SIZE` (16 MiB), so peak memory tracks the actual decompressed size instead of the cap. Each read is also capped at the remaining allowance under `max_size`, so a small `max_size` never allocates a full chunk. The allowance is `max_size + 1` rather than `max_size` because the extra byte is the overflow probe: a read sized to exactly the remaining allowance returns empty both at end of file and when the buffer is already full, so the only way to distinguish a file of exactly `max_size` bytes (which loads) from a larger one (which raises) is to attempt to read one byte past the cap. Nothing above `max_size` is ever deserialized, and the buffer holds that one probe byte only transiently before raising.
* `hash_object` now folds sharing structure into the digest as a consequence of refs: two graphs with equal content but different aliasing (one `Airfoil` shared by every `WingCrossSection` versus an equal but distinct `Airfoil` per `WingCrossSection`) produce different digests. The docstring states this.
* `_FORMAT_VERSION` bumped from 24 to 26 (25 for the memo, 26 for dropping the skip slots).
* `docs/CLASSES_AND_IMMUTABILITY.md` describes the identity memo in place of the skip-and-rebuild mechanism, and names the `MuJoCoModel` engine objects as the one remaining null-serialized exception.
* New tests in `tests/unit/test_serialization.py`: `test_shared_object_serializes_as_ref` in `TestSerializeValue`, `test_unknown_ref_id_raises` in `TestDeserializeValue`, `test_differs_for_different_aliasing` in `TestHashObject`, and `test_shared_airfoil_identity_round_trip` and `test_distinct_airfoils_identity_round_trip` in `TestWingRoundTrip`. The steady solver identity tests now compare `airplanes` element by element, since tuple containers are not memoized and the solver's tuple is rebuilt as an equal tuple rather than the same tuple object.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.

Assisted-by: Claude Fable 5
