### PR TITLE
Save animations faster in bounded memory

### DIFF
--- a/pterasoftware/_mujoco_model.py
+++ b/pterasoftware/_mujoco_model.py
@@ -556,9 +556,9 @@ class MuJoCoModel:
             )
 
             # Drop any point normals the mesh's PyVista source attached. The rendering
-            # layer recomputes shading normals from the posed triangles when it adds
-            # each geom actor, so stored normals are never read, and ones left behind
-            # here would sit stale against the posed points.
+            # layer computes shading normals from the posed triangles when it takes this
+            # geometry, so stored normals are never read, and ones left behind here
+            # would sit stale against the posed points.
             if "Normals" in geom_mesh.point_data:
                 del geom_mesh.point_data["Normals"]
 

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -100,6 +100,14 @@ REFERENCE_WINDOW_SIZE = (1024, 768)
 # Some programs will not render a WebP any faster than this.
 _MAX_FRAME_RATE = 50.0
 
+# Define the libwebp compression method that every saved WebP is encoded with, from 0
+# (the fastest) to 6 (the slowest). The method sets how hard the encoder works to shrink
+# the file at a given quality, so it trades encode time for file size and leaves the
+# image quality alone. The fastest method encodes about twice as fast as the default of
+# 4 for a file about a fifth larger, which is the better side of that trade for
+# animations, whose save time is otherwise dominated by the encode.
+WEBP_METHOD = 0
+
 # Define the number of captured frames an AnimationWriter holds while they wait to be
 # encoded. When frames are captured faster than they are encoded, the capture loop
 # blocks once this many are waiting, which bounds the raw frames in memory no matter how
@@ -991,8 +999,8 @@ class AnimationWriter:
     interpreter open at exit.
 
     The file this writes is identical to the one the webp package's save_images produces
-    from the same frames, frame rate, and quality. It gives each frame the same
-    cumulative timestamp and uses the same encoder options.
+    from the same frames, frame rate, quality, and compression method. It gives each
+    frame the same cumulative timestamp and uses the same encoder options.
     """
 
     def __init__(self, path: Path, frame_rate: float, quality: float) -> None:
@@ -1062,7 +1070,9 @@ class AnimationWriter:
         """
         ended = False
         try:
-            config = webp.WebPConfig.new(lossless=False, quality=self._quality)
+            config = webp.WebPConfig.new(
+                lossless=False, quality=self._quality, method=WEBP_METHOD
+            )
             encoder = None
             frame_size: tuple[int, int] | None = None
             num_frames = 0

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -4,6 +4,9 @@ visualizations with PyVista."""
 from __future__ import annotations
 
 import math
+import queue
+import threading
+from pathlib import Path
 from typing import NamedTuple, cast
 
 import matplotlib.colors
@@ -96,6 +99,14 @@ REFERENCE_WINDOW_SIZE = (1024, 768)
 # Define the highest frame rate, in frames per second, that an animation is saved at.
 # Some programs will not render a WebP any faster than this.
 _MAX_FRAME_RATE = 50.0
+
+# Define the number of captured frames an AnimationWriter holds while they wait to be
+# encoded. When frames are captured faster than they are encoded, the capture loop
+# blocks once this many are waiting, which bounds the raw frames in memory no matter how
+# many time steps an animation has. Each slot costs one raw frame of memory, and the
+# slower of the two stages sets the pace whatever the depth, so a deeper queue buys
+# nothing. Two slots let one frame wait while another is encoded.
+_ANIMATION_WRITER_QUEUE_DEPTH = 2
 
 # Define the fewest frames per cycle of the fastest prescribed motion that a saved
 # animation can show before it stops resolving that motion. The Nyquist floor is 2.0
@@ -955,6 +966,150 @@ def screenshot_image(plotter: pv.Plotter) -> webp.Image.Image:
             )
         )
     )
+
+
+class AnimationWriter:
+    """Encodes an animation's frames into a WebP file as they are captured.
+
+    **Contains the following methods:**
+
+    add_frame: Hands a captured frame to the writer.
+
+    close: Finishes the animation and writes it to its file.
+
+    **Notes:**
+
+    The frames are handed to a background thread that feeds them to libwebp's animation
+    encoder one at a time, so the raw frames never accumulate. The queue between the
+    capture loop and the thread is bounded, so a capture loop that outruns the encode
+    blocks rather than piling frames up. The encode releases the global interpreter
+    lock, so it overlaps with the rendering on the main thread rather than following it.
+
+    The encoder lives on the background thread alone, from its creation through the
+    assembly of the file, so no two threads ever touch it. The thread is a daemon, so a
+    capture loop that raises and abandons the writer leaves nothing that could hold the
+    interpreter open at exit.
+
+    The file this writes is identical to the one the webp package's save_images produces
+    from the same frames, frame rate, and quality. It gives each frame the same
+    cumulative timestamp and uses the same encoder options.
+    """
+
+    def __init__(self, path: Path, frame_rate: float, quality: float) -> None:
+        """The initialization method.
+
+        :param path: The path of the WebP file to write. Its directory must already
+            exist.
+        :param frame_rate: The frame rate to play the animation back at, in frames per
+            second. It must be positive.
+        :param quality: The quality of the saved WebP, where 0.0 is the smallest file
+            with the most compression artifacts and 100.0 is the largest file with the
+            fewest.
+        :return: None
+        """
+        self._path = path
+        self._frame_rate = frame_rate
+        self._quality = quality
+
+        # The queue carries the captured frames to the encoding thread, and None marks
+        # the end of the animation.
+        self._queue: queue.Queue[webp.Image.Image | None] = queue.Queue(
+            maxsize=_ANIMATION_WRITER_QUEUE_DEPTH
+        )
+
+        # An exception the encoding thread raises is held here until close re-raises it
+        # on the calling thread.
+        self._error: Exception | None = None
+
+        self._thread = threading.Thread(
+            target=self._encode, name="animation-writer", daemon=True
+        )
+        self._thread.start()
+
+    def add_frame(self, image: webp.Image.Image) -> None:
+        """Hands a captured frame to the writer.
+
+        This blocks while the queue of frames waiting to be encoded is full. Every frame
+        must have the same size as the first.
+
+        :param image: The frame as an Image with a transparent background.
+        :return: None
+        """
+        self._queue.put(image)
+
+    def close(self) -> None:
+        """Finishes the animation and writes it to its file.
+
+        This blocks until every frame has been encoded and the file has been written.
+        Any exception the encoding raised is re-raised here.
+
+        :return: None
+        """
+        self._queue.put(None)
+        self._thread.join()
+        if self._error is not None:
+            raise self._error
+
+    def _encode(self) -> None:
+        """Encodes the frames from the queue into the WebP file, on the background
+        thread.
+
+        An exception is held for close to re-raise. If it was raised before the queue's
+        end marker was read, the queue is then drained through that marker so that
+        add_frame never blocks on a queue that nothing is emptying.
+
+        :return: None
+        """
+        ended = False
+        try:
+            config = webp.WebPConfig.new(lossless=False, quality=self._quality)
+            encoder = None
+            frame_size: tuple[int, int] | None = None
+            num_frames = 0
+            while True:
+                image = self._queue.get()
+                if image is None:
+                    ended = True
+                    break
+
+                # The encoder is sized to the first frame, since the frames are the size
+                # of the render window, which can be larger than the size that was asked
+                # for on a display that scales its pixels.
+                picture = webp.WebPPicture.from_pil(image)
+                picture_size = (int(picture.ptr.width), int(picture.ptr.height))
+                if encoder is None:
+                    encoder = webp.WebPAnimEncoder.new(
+                        picture_size[0],
+                        picture_size[1],
+                        webp.WebPAnimEncoderOptions.new(),
+                    )
+                    frame_size = picture_size
+                elif picture_size != frame_size:
+                    assert frame_size is not None
+                    raise ValueError(
+                        f"Every frame must have the same size as the first, which "
+                        f"was {frame_size[0]} by {frame_size[1]} pixels, but frame "
+                        f"{num_frames} was {picture_size[0]} by {picture_size[1]}."
+                    )
+
+                # Each frame starts at a cumulative timestamp, in whole milliseconds,
+                # rather than lasting a fixed duration, which plays a fractional frame
+                # rate back to within a small fraction of a percent.
+                encoder.encode_frame(
+                    picture, round((num_frames * 1000) / self._frame_rate), config
+                )
+                num_frames += 1
+
+            if encoder is None:
+                raise ValueError("An animation must have at least one frame.")
+
+            animation = encoder.assemble(round((num_frames * 1000) / self._frame_rate))
+            with open(self._path, "wb") as animation_file:
+                animation_file.write(animation.buffer())
+        except Exception as error:
+            self._error = error
+            while not ended:
+                ended = self._queue.get() is None
 
 
 def settle_scalar_bar_layout(plotter: pv.Plotter) -> None:

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -663,9 +663,35 @@ def get_mujoco_render_geometry(
     free_flight_unsteady_problem = cast(
         problems.FreeFlightUnsteadyProblem, free_flight_solver.unsteady_problem
     )
-    render_geoms = _private_access.get_mujoco_model(
+    extracted_render_geoms = _private_access.get_mujoco_model(
         free_flight_unsteady_problem
     ).get_render_geometry()
+
+    # Compute each geom's shading normals here, once, splitting the sharp edges so the
+    # shading stays crisp across creases. The split duplicates the points along edges
+    # sharper than PyVista's feature angle, letting each face shade with its own normal,
+    # where plain smooth shading would average one normal across the crease and smear
+    # it. The geoms are rigid, so transform_mesh carries the normals along with the
+    # points, and add_mujoco_geometry hands PyVista a mesh that already has them rather
+    # than having it split the edges again for every frame of an animation, which costs
+    # more than the rest of the frame put together for a detailed mesh. The split leaves
+    # behind a point id array that nothing reads, so it is dropped.
+    render_geoms = []
+    for render_geom in extracted_render_geoms:
+        mesh = render_geom.mesh.compute_normals(
+            cell_normals=False,
+            split_vertices=True,
+            feature_angle=pv.global_theme.sharp_edges_feature_angle,
+        )
+        if "pyvistaOriginalPointIds" in mesh.point_data:
+            del mesh.point_data["pyvistaOriginalPointIds"]
+        render_geoms.append(
+            _mujoco_model.RenderGeom(
+                mesh=mesh,
+                rgba=render_geom.rgba,
+                body_attached=render_geom.body_attached,
+            )
+        )
 
     worldbody_geoms = [
         render_geom for render_geom in render_geoms if not render_geom.body_attached
@@ -686,7 +712,8 @@ def transform_mesh(
     :param mesh: The PolyData mesh to transform.
     :param T_pas: A (4,4) ndarray of floats representing the passive transformation to
         apply to the mesh's points.
-    :return: A new PolyData mesh with all points mapped through the transformation.
+    :return: A new PolyData mesh with all points mapped through the transformation,
+        along with its active point normals, if it has any, mapped as directions.
     """
     transformed = mesh.copy()
     transformed.points = _transformations.apply_T_to_vectors(
@@ -694,6 +721,17 @@ def transform_mesh(
         mesh.points,
         is_position=True,
     )
+
+    # Carry any shading normals along as directions, so they stay perpendicular to the
+    # faces they shade. Under a reflection, this maps an outward normal to the reflected
+    # face's outward normal, which is what the shading needs.
+    normals_name = mesh.point_data.active_normals_name
+    if normals_name is not None:
+        transformed.point_data[normals_name] = _transformations.apply_T_to_vectors(
+            T_pas,
+            mesh.point_data[normals_name],
+            is_position=False,
+        )
     return transformed
 
 
@@ -1429,32 +1467,28 @@ def add_mujoco_geometry(
         color = (float(rgba[0]), float(rgba[1]), float(rgba[2]))
         opacity = float(rgba[3])
 
-        # Split the sharp edges so the shading stays crisp across creases. The split
-        # duplicates the points along edges sharper than PyVista's feature angle,
-        # letting each face shade with its own normal, where plain smooth shading would
-        # average one normal across the crease and smear it.
+        # The mesh carries its shading normals, computed with the sharp edges split when
+        # get_mujoco_render_geometry extracted it, so PyVista passes them through here
+        # rather than recomputing them for every frame.
         actor = plotter.add_mesh(
             posed_mesh,
             color=color,
             opacity=opacity,
             smooth_shading=True,
-            split_sharp_edges=True,
             ambient=_MUJOCO_GEOMETRY_AMBIENT,
             diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
             render=False,
         )
         actors.append(actor)
         if T_reflect is not None:
-            # Splitting the sharp edges recomputes the normals from the triangle
-            # winding, and a reflection inverts the winding's outward sense. Flip the
-            # reflected copy's faces so the recomputed normals point outward again
-            # instead of inverting the shading.
+            # A reflection inverts the faces' winding. Flip the reflected copy's faces
+            # so they wind outward again, which the shading needs even though the
+            # reflected normals it carries already point outward.
             actor = plotter.add_mesh(
                 _reflect_mesh(posed_mesh, T_reflect).flip_faces(),
                 color=mute_color(color, IMAGE_REFLECTION_MUTE_FACTOR),
                 opacity=opacity,
                 smooth_shading=True,
-                split_sharp_edges=True,
                 ambient=_MUJOCO_GEOMETRY_AMBIENT,
                 diffuse=_MUJOCO_GEOMETRY_DIFFUSE,
                 render=False,

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -1139,14 +1139,15 @@ def settle_scalar_bar_layout(plotter: pv.Plotter) -> None:
     """Runs the render pass that settles a Plotter's scalar bar layout, without
     displaying its result.
 
-    Adding an image surface mesh with an opacity leaves VTK's UnconstrainedFontSize
-    layout with the scalar bar's labels off their bar edges (PyVista issue #7516). The
-    layout only settles once the bar has been rendered again, so this marks the bars
-    modified and renders. The result of that render is the mispositioned layout, so the
-    buffers are held back from swapping, which keeps it off the screen and leaves the
-    settled layout to the caller's next render. The render window is driven directly
-    rather than through the Plotter, since the Plotter's render does nothing before its
-    first show.
+    Any actor with an opacity below one in the scene, such as the image surface plane, a
+    preview ghost, or a translucent MuJoCo geom, leaves VTK's UnconstrainedFontSize
+    layout with the scalar bar's labels off their bar edges on the first render after
+    the scene is assembled (PyVista issue #7516). The layout only settles once the bar
+    has been rendered again, so this marks the bars modified and renders. The result of
+    that render is the mispositioned layout, so the buffers are held back from swapping,
+    which keeps it off the screen and leaves the settled layout to the caller's next
+    render. The render window is driven directly rather than through the Plotter, since
+    the Plotter's render does nothing before its first show.
 
     :param plotter: The Plotter whose scalar bar layout to settle.
     :return: None

--- a/pterasoftware/_output_rendering.py
+++ b/pterasoftware/_output_rendering.py
@@ -322,53 +322,53 @@ def get_panel_surfaces(
         returned.
     :return: A PolyData representation of the Airplanes' Wings' Panels' surfaces.
     """
-    # Initialize empty ndarrays to hold the Panels' vertices and faces.
-    panel_vertices = np.empty((0, 3), dtype=float)
-    panel_faces = np.empty(0, dtype=int)
-
-    # Initialize a variable to keep track of how many Panels have been added thus far.
-    panel_num = 0
-
-    # Increment through the Airplanes' Wing(s).
+    # Gather every Wing's Panels in order, so the vertex and face ndarrays can be sized
+    # once rather than grown by stacking a Panel at a time, which is called once per
+    # time step of an animation.
+    wing_panels = []
     for airplane in airplanes:
         for wing in airplane.wings:
             _panels = wing.panels
             assert _panels is not None
+            wing_panels.append(np.ravel(_panels))
+    num_panels = sum(panels.size for panels in wing_panels)
 
-            # Unravel this Wing's ndarray of Panels iterate through it.
-            panels = np.ravel(_panels)
-            for panel in panels:
-                # Arrange this Panel's vertices and faces into ndarrays in the proper
-                # form to represent PolyData surfaces.
-                panel_vertices_to_add = np.vstack(
-                    (
-                        panel.Flpp_GP1_CgP1,
-                        panel.Frpp_GP1_CgP1,
-                        panel.Brpp_GP1_CgP1,
-                        panel.Blpp_GP1_CgP1,
-                    )
-                )
-                panel_face_to_add = np.array(
-                    [
-                        4,
-                        (panel_num * 4),
-                        (panel_num * 4) + 1,
-                        (panel_num * 4) + 2,
-                        (panel_num * 4) + 3,
-                    ],
-                    dtype=int,
-                )
-
-                # Add this Panel's vertices and faces to the ndarray of all vertices and
-                # faces.
-                panel_vertices = np.vstack((panel_vertices, panel_vertices_to_add))
-                panel_faces = np.hstack((panel_faces, panel_face_to_add))
-
-                # Update the number of Panels.
-                panel_num += 1
+    # Fill each Panel's four vertices, wound front left, front right, back right, and
+    # back left so the cell traces the Panel's outline.
+    panel_vertices = np.empty((num_panels * 4, 3), dtype=float)
+    panel_num = 0
+    for panels in wing_panels:
+        for panel in panels:
+            base_vertex = panel_num * 4
+            panel_vertices[base_vertex] = panel.Flpp_GP1_CgP1
+            panel_vertices[base_vertex + 1] = panel.Frpp_GP1_CgP1
+            panel_vertices[base_vertex + 2] = panel.Brpp_GP1_CgP1
+            panel_vertices[base_vertex + 3] = panel.Blpp_GP1_CgP1
+            panel_num += 1
 
     # Return the Panels' surfaces.
-    return pv.PolyData(panel_vertices, panel_faces)
+    return pv.PolyData(panel_vertices, _get_quadrilateral_faces(num_panels))
+
+
+def _get_quadrilateral_faces(num_quadrilaterals: int) -> np.ndarray:
+    """Returns the faces ndarray of a PolyData made of consecutive quadrilaterals.
+
+    The faces are in PolyData's padded form, where each face is its vertex count
+    followed by its vertex indices. Face i covers vertices 4i through 4i + 3, so this is
+    the faces ndarray for any mesh whose vertices are stored four to a cell in cell
+    order.
+
+    :param num_quadrilaterals: The number of quadrilateral faces.
+    :return: A (num_quadrilaterals * 5,) ndarray of ints representing the faces.
+    """
+    base_vertices = np.arange(num_quadrilaterals, dtype=int) * 4
+    faces = np.empty((num_quadrilaterals, 5), dtype=int)
+    faces[:, 0] = 4
+    faces[:, 1] = base_vertices
+    faces[:, 2] = base_vertices + 1
+    faces[:, 3] = base_vertices + 2
+    faces[:, 4] = base_vertices + 3
+    return np.ravel(faces)
 
 
 def get_streamline_surfaces(
@@ -825,46 +825,21 @@ def get_wake_ring_vortex_surfaces(
     stackBlwrvp_GP1_CgP1 = solver.listStackBlwrvp_GP1_CgP1[step]
     stackBrwrvp_GP1_CgP1 = solver.listStackBrwrvp_GP1_CgP1[step]
 
-    # Initialize empty ndarrays to hold each wake ring vortex's vertices and face.
-    wake_ring_vortex_vertices = np.zeros((0, 3), dtype=float)
-    wake_ring_vortex_faces = np.zeros(0, dtype=int)
-
-    for wake_ring_vortex_num in range(num_wake_ring_vortices):
-        Frwrvp_GP1_CgP1 = stackFrwrvp_GP1_CgP1[wake_ring_vortex_num]
-        Flwrvp_GP1_CgP1 = stackFlwrvp_GP1_CgP1[wake_ring_vortex_num]
-        Blwrvp_GP1_CgP1 = stackBlwrvp_GP1_CgP1[wake_ring_vortex_num]
-        Brwrvp_GP1_CgP1 = stackBrwrvp_GP1_CgP1[wake_ring_vortex_num]
-
-        wake_ring_vortex_vertices_to_add = np.vstack(
-            (
-                Flwrvp_GP1_CgP1,
-                Frwrvp_GP1_CgP1,
-                Brwrvp_GP1_CgP1,
-                Blwrvp_GP1_CgP1,
-            )
-        )
-        wake_ring_vortex_face_to_add = np.array(
-            [
-                4,
-                (wake_ring_vortex_num * 4),
-                (wake_ring_vortex_num * 4) + 1,
-                (wake_ring_vortex_num * 4) + 2,
-                (wake_ring_vortex_num * 4) + 3,
-            ],
-            dtype=int,
-        )
-
-        # Stack this wake ring vortex's vertices and faces to the ndarrays of all wake
-        # ring vortices' vertices and faces.
-        wake_ring_vortex_vertices = np.vstack(
-            (wake_ring_vortex_vertices, wake_ring_vortex_vertices_to_add)
-        )
-        wake_ring_vortex_faces = np.hstack(
-            (wake_ring_vortex_faces, wake_ring_vortex_face_to_add)
-        )
+    # Interleave the four corner stacks so each wake ring vortex's vertices are wound
+    # front left, front right, back right, and back left. Every corner stack is a
+    # (num_wake_ring_vortices, 3) ndarray, so four strided assignments build the whole
+    # mesh at once rather than a wake ring vortex at a time, which matters because this
+    # is called once per time step of an animation.
+    wake_ring_vortex_vertices = np.empty((num_wake_ring_vortices * 4, 3), dtype=float)
+    wake_ring_vortex_vertices[0::4] = stackFlwrvp_GP1_CgP1[:num_wake_ring_vortices]
+    wake_ring_vortex_vertices[1::4] = stackFrwrvp_GP1_CgP1[:num_wake_ring_vortices]
+    wake_ring_vortex_vertices[2::4] = stackBrwrvp_GP1_CgP1[:num_wake_ring_vortices]
+    wake_ring_vortex_vertices[3::4] = stackBlwrvp_GP1_CgP1[:num_wake_ring_vortices]
 
     # Return the wake ring vortex surfaces.
-    return pv.PolyData(wake_ring_vortex_vertices, wake_ring_vortex_faces)
+    return pv.PolyData(
+        wake_ring_vortex_vertices, _get_quadrilateral_faces(num_wake_ring_vortices)
+    )
 
 
 def get_scalars(

--- a/pterasoftware/geometry/airplane.py
+++ b/pterasoftware/geometry/airplane.py
@@ -770,11 +770,15 @@ class Airplane:
             image = webp.Image.fromarray(
                 cast(np.ndarray[Any, Any], screenshot),
             )
+            # The compression method matches _output_rendering.WEBP_METHOD, which this
+            # module cannot import without a circular import. It trades file size for
+            # encode time and leaves the image quality alone.
             webp.save_image(
                 img=image,
                 file_path=f"{self._name.lower().replace(' ', '_')}_geometry.webp",
                 lossless=False,
                 quality=quality,
+                method=0,
             )
 
         # Close all the plotters.

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -635,10 +635,14 @@ def draw(
     else:
         draw_cpos = None
 
-    # Settle the scalar bar layout before the drawing is displayed. This is the first of
-    # the two passes it takes, and show below is the second, so the labels are in place
-    # by the time the user sees anything.
-    if T_reflect is not None:
+    # The scene is translucent when it holds the image surface plane or a geom whose
+    # rgba has an alpha below one. Settle the scalar bar layout before such a drawing is
+    # displayed. This is the first of the two passes it takes, and show below is the
+    # second, so the labels are in place by the time the user sees anything.
+    scene_is_translucent = T_reflect is not None or any(
+        float(render_geom.rgba[3]) < 1.0 for render_geom in worldbody_geoms + body_geoms
+    )
+    if scene_is_translucent:
         _output_rendering.settle_scalar_bar_layout(plotter)
 
     if not testing:
@@ -1224,11 +1228,17 @@ def animate(
     else:
         animate_cpos = None
 
-    # Give the first frame the scalar bar layout pass that the frames in the loop get,
-    # so the view held for the user matches the animation that follows it. This is the
-    # first of the two passes the layout takes to settle, and show below is the second,
-    # so the labels are in place by the time the user sees anything.
-    if T_reflect is not None:
+    # The frames are translucent when the scene holds the image surface plane or a geom
+    # whose rgba has an alpha below one, and the held first frame is translucent
+    # whenever it has ghosts as well. Give a translucent held frame the scalar bar
+    # layout pass that translucent frames in the loop get, so the view held for the user
+    # matches the animation that follows it. This is the first of the two passes the
+    # layout takes to settle, and show below is the second, so the labels are in place
+    # by the time the user sees anything.
+    scene_is_translucent = T_reflect is not None or any(
+        float(render_geom.rgba[3]) < 1.0 for render_geom in worldbody_geoms + body_geoms
+    )
+    if scene_is_translucent or last_step != 0:
         _output_rendering.settle_scalar_bar_layout(plotter)
 
     # If not testing, show the Plotter with the first time step so the user can orient
@@ -1289,8 +1299,7 @@ def animate(
             step_body_transforms[0],
             T_reflect,
         )
-    if T_reflect is not None:
-        assert image_surface_mesh is not None
+    if scene_is_translucent:
         _output_rendering.settle_scalar_bar_layout(plotter)
 
     # The user may have reoriented or rescaled the view during the held first frame.
@@ -1422,9 +1431,9 @@ def animate(
                 render=False,
             )
 
-        # If an image surface is present, settle the scalar bar layout before the frame
-        # is displayed, leaving the second of its two passes to the render below.
-        if T_reflect is not None:
+        # If the frame is translucent, settle the scalar bar layout before it is
+        # displayed, leaving the second of its two passes to the render below.
+        if scene_is_translucent:
             _output_rendering.settle_scalar_bar_layout(plotter)
 
         # Render the assembled frame. Every add above is made with render=False, so

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -1306,8 +1306,14 @@ def animate(
 
     plotter.render()
 
-    # Start a list to hold a WebP Image of each frame, beginning with this first frame.
-    images = [_output_rendering.screenshot_image(plotter)]
+    # If saving, start the writer that encodes each frame into the WebP as it is
+    # captured, so the frames never accumulate in memory, and hand it this first frame.
+    animation_writer = None
+    if save:
+        animation_writer = _output_rendering.AnimationWriter(
+            path, playback.frame_rate, quality
+        )
+        animation_writer.add_frame(_output_rendering.screenshot_image(plotter))
 
     # Initialize a variable to keep track of the current time step.
     current_step = 1
@@ -1410,23 +1416,19 @@ def animate(
         # is whole is invisible, unlike the renders the adds used to trigger.
         plotter.render()
 
-        # If saving, append a WebP Image of this frame to the list of Images. Only the
-        # time steps that are multiples of the stride are saved, so a speed the maximum
-        # frame rate cannot carry drops the ones in between. The render above is not
-        # skipped, so the animation on screen still steps through every time step.
-        if save and current_step % playback.keep_every == 0:
-            images.append(_output_rendering.screenshot_image(plotter))
+        # If saving, hand a WebP Image of this frame to the writer. Only the time steps
+        # that are multiples of the stride are saved, so a speed the maximum frame rate
+        # cannot carry drops the ones in between. The render above is not skipped, so
+        # the animation on screen still steps through every time step.
+        if animation_writer is not None and current_step % playback.keep_every == 0:
+            animation_writer.add_frame(_output_rendering.screenshot_image(plotter))
 
         # Increment the time step tracker.
         current_step += 1
 
-    # If saving, save the list of Images as an animated WebP.
-    if save:
-        # Convert the list of WebP Images to an WebP animation. webp annotates file_path
-        # as a str, so the Path is converted at the boundary.
-        webp.save_images(
-            images, str(path), fps=playback.frame_rate, lossless=False, quality=quality
-        )
+    # If saving, finish the animation and write it to its file.
+    if animation_writer is not None:
+        animation_writer.close()
 
     # Close all the Plotters.
     pv.close_all()

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -1316,6 +1316,16 @@ def animate(
     # captured, so the frames never accumulate in memory, and hand it this first frame.
     animation_writer = None
     if save:
+        # Ask the driver not to wait for the display's vertical blank before each buffer
+        # swap. With the wait in place, every captured frame costs at least one refresh
+        # period however little work it holds, so capture speed follows the display's
+        # refresh rate. The frames are read back from the buffer, so the tearing the
+        # wait prevents never reaches the file. This is a request the platform may
+        # ignore, in which case capture simply keeps the refresh rate's pace. It is not
+        # made when not saving, since the window is then what the user watches, and the
+        # wait is the only pacing the playback has.
+        plotter.ren_win.SetSwapControl(0)
+
         animation_writer = _output_rendering.AnimationWriter(
             path, playback.frame_rate, quality
         )

--- a/pterasoftware/output.py
+++ b/pterasoftware/output.py
@@ -668,7 +668,13 @@ def draw(
         image = _output_rendering.screenshot_image(plotter)
 
         # webp annotates file_path as a str, so the Path is converted at the boundary.
-        webp.save_image(img=image, file_path=str(path), lossless=False, quality=quality)
+        webp.save_image(
+            img=image,
+            file_path=str(path),
+            lossless=False,
+            quality=quality,
+            method=_output_rendering.WEBP_METHOD,
+        )
 
     # Close all Plotters.
     pv.close_all()

--- a/tests/unit/fixtures/output_rendering_fixtures.py
+++ b/tests/unit/fixtures/output_rendering_fixtures.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pyvista as pv
+import webp
 
 import pterasoftware as ps
 
@@ -275,3 +276,26 @@ def make_outlier_scalars_fixture() -> np.ndarray:
     scalars = np.ones(101, dtype=float)
     scalars[-1] = 101.0
     return scalars
+
+
+def make_animation_frames_fixture(
+    num_frames: int, width: int = 16, height: int = 12
+) -> list[webp.Image.Image]:
+    """Makes a fixture that is a list of frames for an animation.
+
+    Each frame is filled with random colors from a fixed seed, so the frames differ from
+    one another and the encoder cannot merge any of them, while the list is the same on
+    every call.
+
+    :param num_frames: The number of frames to make.
+    :param width: The width of each frame in pixels. The default is 16.
+    :param height: The height of each frame in pixels. The default is 12.
+    :return: A list of num_frames Images with transparent backgrounds.
+    """
+    rng = np.random.default_rng(0)
+    return [
+        webp.Image.fromarray(
+            rng.integers(0, 255, size=(height, width, 4), dtype=np.uint8)
+        )
+        for _ in range(num_frames)
+    ]

--- a/tests/unit/test_output_rendering.py
+++ b/tests/unit/test_output_rendering.py
@@ -256,7 +256,12 @@ class TestAnimationWriter(unittest.TestCase):
 
         expected_path = self.animation_path.with_name("expected.webp")
         webp.save_images(
-            frames, str(expected_path), fps=30.0, lossless=False, quality=50.0
+            frames,
+            str(expected_path),
+            fps=30.0,
+            lossless=False,
+            quality=50.0,
+            method=_output_rendering.WEBP_METHOD,
         )
 
         self.assertEqual(self.animation_path.read_bytes(), expected_path.read_bytes())

--- a/tests/unit/test_output_rendering.py
+++ b/tests/unit/test_output_rendering.py
@@ -447,6 +447,24 @@ class TestGetMuJoCoRenderGeometry(unittest.TestCase):
         self.assertEqual(len(body_geoms), 1)
         self.assertTrue(body_geoms[0].body_attached)
 
+    def test_meshes_carry_their_shading_normals(self) -> None:
+        """Test that every geom's mesh comes back with active point normals.
+
+        The normals are computed once here so that adding a geom to a frame does not
+        recompute them, which is the cost that dominates a frame for a detailed mesh.
+        """
+        solver = solver_fixtures.make_free_flight_unsteady_ring_solver_fixture(
+            extra_xml={
+                "worldbody": '<geom name="ground" type="plane" size="5 4 0.1"/>',
+                "body": '<geom name="box_geom" type="box" size="0.1 0.2 0.3"/>',
+            }
+        )
+        worldbody_geoms, body_geoms = _output_rendering.get_mujoco_render_geometry(
+            solver
+        )
+        for render_geom in worldbody_geoms + body_geoms:
+            self.assertIsNotNone(render_geom.mesh.point_data.active_normals)
+
     def test_returns_empty_lists_without_extra_geometry(self) -> None:
         """Test that a solver whose model carries no extra geoms returns two empty
         lists."""
@@ -654,6 +672,34 @@ class TestTransformMesh(unittest.TestCase):
         mesh = output_rendering_fixtures.make_cube_mesh_fixture()
         transformed = _output_rendering.transform_mesh(mesh, np.eye(4, dtype=float))
         npt.assert_array_equal(transformed.faces, mesh.faces)
+
+    def test_maps_the_normals_as_directions(self) -> None:
+        """Test that a mesh's active point normals are rotated but not translated.
+
+        A body mesh carries its shading normals across the frames of an animation, so
+        they have to turn with the faces they shade while ignoring where those faces
+        move to.
+        """
+        mesh = output_rendering_fixtures.make_cube_mesh_fixture().compute_normals(
+            cell_normals=False
+        )
+        T_pas = _transformations.compose_T_pas(
+            _transformations.generate_rot_T(
+                angles=np.array([0.0, 0.0, np.pi / 2], dtype=float),
+                passive=True,
+                intrinsic=True,
+                order="xyz",
+            ),
+            _transformations.generate_trans_T(
+                translations=np.array([1.0, 2.0, 3.0], dtype=float), passive=True
+            ),
+        )
+        transformed = _output_rendering.transform_mesh(mesh, T_pas)
+        npt.assert_allclose(
+            transformed.point_data["Normals"],
+            np.array(mesh.point_data["Normals"]) @ T_pas[:3, :3].T,
+            atol=1e-12,
+        )
 
 
 class TestGetFreeFlightFitParallelScale(unittest.TestCase):

--- a/tests/unit/test_output_rendering.py
+++ b/tests/unit/test_output_rendering.py
@@ -6,12 +6,15 @@ only a solved simulation carries. The classes here cover the computation and the
 geometry building that feed them, which are settled before any rendering begins.
 """
 
+import tempfile
 import unittest
+from pathlib import Path
 
 import matplotlib.colors
 import numpy as np
 import numpy.testing as npt
 import pyvista as pv
+import webp
 
 import pterasoftware as ps
 
@@ -201,6 +204,98 @@ class TestResolvePlaybackAliasingWarning(unittest.TestCase):
         """Test that a simulation whose geometry never moves is not warned about."""
         with self.assertNoLogs("pterasoftware.output", level="WARNING"):
             _output_rendering.resolve_playback(self.static_solver, 1.0, True)
+
+
+class TestAnimationWriter(unittest.TestCase):
+    """This class contains methods for testing _output_rendering.AnimationWriter."""
+
+    def setUp(self) -> None:
+        """Create a temporary directory to hold this test's animation."""
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.animation_path = Path(self.temporary_directory.name) / "animation.webp"
+
+    def tearDown(self) -> None:
+        """Remove the temporary directory and the animation it holds."""
+        self.temporary_directory.cleanup()
+
+    def test_writes_every_frame_at_the_frame_rate(self) -> None:
+        """Test that the file holds every frame, each ending at its cumulative
+        timestamp.
+
+        At 25 frames per second, each frame lasts 40 milliseconds, so the five frames
+        end at 40, 80, 120, 160, and 200 milliseconds.
+        """
+        frames = output_rendering_fixtures.make_animation_frames_fixture(5)
+
+        writer = _output_rendering.AnimationWriter(self.animation_path, 25.0, 75.0)
+        for frame in frames:
+            writer.add_frame(frame)
+        writer.close()
+
+        with open(self.animation_path, "rb") as animation_file:
+            animation_data = webp.WebPData.from_buffer(animation_file.read())
+        decoder = webp.WebPAnimDecoder.new(animation_data)
+        self.assertEqual(decoder.anim_info.frame_count, 5)
+        self.assertEqual(
+            [timestamp for _, timestamp in decoder.frames()], [40, 80, 120, 160, 200]
+        )
+
+    def test_matches_the_webp_packages_own_encoder(self) -> None:
+        """Test that the file is byte for byte what the webp package's save_images
+        writes from the same frames.
+
+        save_images is what the animations were saved with before the writer existed, so
+        this is what keeps the saved animations unchanged.
+        """
+        frames = output_rendering_fixtures.make_animation_frames_fixture(5)
+
+        writer = _output_rendering.AnimationWriter(self.animation_path, 30.0, 50.0)
+        for frame in frames:
+            writer.add_frame(frame)
+        writer.close()
+
+        expected_path = self.animation_path.with_name("expected.webp")
+        webp.save_images(
+            frames, str(expected_path), fps=30.0, lossless=False, quality=50.0
+        )
+
+        self.assertEqual(self.animation_path.read_bytes(), expected_path.read_bytes())
+
+    def test_rejects_a_frame_of_a_different_size(self) -> None:
+        """Test that a frame whose size differs from the first's is rejected when the
+        writer is closed, and that the frames after it do not block the caller.
+
+        More frames follow the bad one than the writer's queue can hold, so the test
+        would hang rather than fail if the writer stopped emptying the queue.
+        """
+        frames = output_rendering_fixtures.make_animation_frames_fixture(2)
+        wrong_size_frame = output_rendering_fixtures.make_animation_frames_fixture(
+            1, width=32, height=24
+        )[0]
+        trailing_frames = output_rendering_fixtures.make_animation_frames_fixture(
+            _output_rendering._ANIMATION_WRITER_QUEUE_DEPTH + 2
+        )
+
+        writer = _output_rendering.AnimationWriter(self.animation_path, 25.0, 75.0)
+        for frame in frames:
+            writer.add_frame(frame)
+        writer.add_frame(wrong_size_frame)
+        for frame in trailing_frames:
+            writer.add_frame(frame)
+
+        with self.assertRaises(ValueError) as context:
+            writer.close()
+        self.assertIn("16 by 12", str(context.exception))
+        self.assertIn("32 by 24", str(context.exception))
+        self.assertFalse(self.animation_path.exists())
+
+    def test_rejects_an_animation_without_frames(self) -> None:
+        """Test that closing a writer that was given no frames is rejected."""
+        writer = _output_rendering.AnimationWriter(self.animation_path, 25.0, 75.0)
+
+        with self.assertRaises(ValueError):
+            writer.close()
+        self.assertFalse(self.animation_path.exists())
 
 
 class TestGetFreeFlightTransformation(unittest.TestCase):


### PR DESCRIPTION
# Description

This pull request reworks how `animate` saves its frames so that a long simulation can be saved without running out of memory, and so that each frame costs less to build, render, and encode. Frames are now handed to a background thread that feeds them to libwebp's animation encoder as they are captured, through a bounded queue, so the raw frames in memory stay at a fixed count no matter how many time steps the animation has. Around that change, the per-frame work that dominated capture time is cut down: the `Panel` and wake ring vortex meshes are built in one allocation each, the MuJoCo geoms' shading normals are computed once when their geometry is extracted rather than on every frame, the driver's vertical blank wait is released while frames are being captured, and every saved WebP is encoded with libwebp's fastest compression method. The saved animation file is byte for byte what the `webp` package's `save_images` produced from the same frames, frame rate, quality, and method, and the rendered frames are unchanged.

A related fix corrects when the scalar bar's layout is settled. The settle pass that hides VTK's first-render label misplacement ran only when an image surface was present, so the held framing view of an animation without one, whose translucent ghosts trigger the same misplacement, showed the labels off their bar edges until the key press rendered the view again. The pass now runs whenever the scene is translucent, which covers the image surface plane, a MuJoCo geom whose `rgba` has an alpha below one, and the held frame's ghosts.

## Motivation

Saving an animation held every frame as a raw RGBA image until the last time step, so its memory grew linearly with the frame count, and a long simulation ran out of memory before the file was written. That is a hard ceiling on the length of animation `animate` can save, and it is hit by exactly the simulations whose animations are most worth saving. Once the frames fit in memory, the save was still slow: the mesh builders grew their ndarrays one cell at a time, so the wake builder alone took longer than a display refresh period at a few thousand wake ring vortices, every geom's normals were recomputed on every frame, every buffer swap waited for the display's vertical blank, and the encode ran after the capture loop finished instead of overlapping with it. This pull request removes the memory ceiling and attacks each of those costs in turn.

The scalar bar misplacement was a visual artifact of VTK's first render of a translucent scene, not a difference in the data being plotted. The labels always settled once the view was rendered again, so only the first thing the user saw was wrong. Drawings and animations without any translucent actor never showed the artifact and are left unchanged.

## Relevant Issues

None.

## Changes

* Added `AnimationWriter` to `_output_rendering.py`, which starts a daemon thread that pulls captured frames from a `queue.Queue` bounded by the new `_ANIMATION_WRITER_QUEUE_DEPTH` constant (two frames), feeds each one to a `webp.WebPAnimEncoder` with the same cumulative millisecond timestamps and encoder options that `save_images` uses, and assembles and writes the file when `close` is called. An exception on the encoding thread is held and re-raised by `close`, and the thread drains the queue through its end marker after an error so `add_frame` never blocks on a queue nothing is emptying. Frames of a different size than the first raise a `ValueError` naming both sizes, and closing a writer that was given no frames also raises.
* Changed `animate` in `output.py` to create an `AnimationWriter` when saving, hand it the first frame and each kept frame in the loop, and close it after the loop, replacing the list of `Image`s that was passed to `webp.save_images` at the end.
* Added the `WEBP_METHOD` constant (0, the fastest libwebp compression method) to `_output_rendering.py`, and passed it to every WebP save: the `AnimationWriter`'s `WebPConfig`, `draw`'s `webp.save_image` call in `output.py`, and `Airplane.draw`'s `webp.save_image` call in `geometry/airplane.py`, which spells the value out with a comment because importing `_output_rendering` there would be circular. The method trades encode time for file size and leaves image quality alone, encoding about twice as fast as the default of 4 for a file about a fifth larger.
* Rewrote `get_panel_surfaces` and `get_wake_ring_vortex_surfaces` in `_output_rendering.py` to size their vertex ndarrays once and fill them, with the wake vertices built by four strided assignments from the corner stacks the solver already stores. Both now get their faces from the new `_get_quadrilateral_faces` helper, which builds the padded faces ndarray for a mesh stored four vertices to a cell.
* Changed `get_mujoco_render_geometry` in `_output_rendering.py` to call `compute_normals` with the sharp edges split once per geom when the geometry is extracted, dropping the `pyvistaOriginalPointIds` array the split leaves behind, and rebuilding each `RenderGeom` around the mesh that now carries its normals.
* Extended `transform_mesh` in `_output_rendering.py` to map a mesh's active point normals through the transformation as directions, so they stay perpendicular to the posed faces, including under a reflection.
* Removed the `split_sharp_edges` argument from both `add_mesh` calls in `add_mujoco_geometry`, so PyVista passes the stored normals through instead of recomputing them on every frame. The reflected copy's faces are still flipped because a reflection inverts their winding.
* Updated the comment in `MuJoCoModel.get_render_geometry` in `_mujoco_model.py` that explains why point normals are dropped, since the rendering layer now computes them when it takes the geometry rather than when it adds each actor.
* Changed `animate` in `output.py` to call `SetSwapControl(0)` on the render window when saving, which asks the driver not to wait for the display's vertical blank before each buffer swap. The frames are read back from the buffer, so tearing never reaches the file, a platform that ignores the request keeps the refresh rate's pace, and the wait is left in place when not saving because it is then the only pacing the playback has.
* Changed `draw` and `animate` in `output.py` to settle the scalar bar layout whenever the scene is translucent, computed from whether `T_reflect` is set or any `RenderGeom`'s `rgba` has an alpha below one, and additionally for `animate`'s held first frame whenever it has ghosts. The `settle_scalar_bar_layout` docstring in `_output_rendering.py` now describes the general translucent-actor trigger.
* Added `make_animation_frames_fixture` to `output_rendering_fixtures.py`, which builds a seeded list of random RGBA frames, and a `TestAnimationWriter` class to `test_output_rendering.py` that checks every frame lands at its cumulative timestamp, that the file is byte for byte what `save_images` writes, that a frame of a different size is rejected without blocking the caller, and that an animation without frames is rejected.
* Added `test_meshes_carry_their_shading_normals` to `TestGetMuJoCoRenderGeometry` and `test_maps_the_normals_as_directions` to `TestTransformMesh` in `test_output_rendering.py`.

## Dependency Updates

None.

## Change Magnitude

**Moderate**: Medium-sized change that adds or modifies a feature without large-scale impact.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.

Assisted-by: Claude Fable 5.1
