### PR TITLE
Register the fork guard hook only on Linux

### DIFF
--- a/pterasoftware/_functions.py
+++ b/pterasoftware/_functions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -743,11 +744,12 @@ _SOLVE_THREAD_THRESHOLD = 3_000
 #
 # Forking after a solve that has initialized Numba's GNU OpenMP layer would abort at the
 # child kernel launch (omppool.cpp parallel_for, GCC off-Windows only). The child
-# survives fork, so the parent cannot veto via before-fork hooks; instead an
+# survives fork, so the parent cannot veto via before-fork hooks. Instead, an
 # after_in_child hook flags children that inherited a live "omp" layer, and the solve
-# guard raises on entry in that child. Plain fork work and subprocess stay unaffected,
-# and the "omp" gate keeps the check off platforms where Numba would not abort (e.g.,
-# macOS clang wheels).
+# guard raises on entry in that child. Plain fork work and subprocess stay unaffected.
+# The hook is registered only on Linux, the one platform whose Numba wheels build the
+# layer with GCC. The macOS wheels build it with clang against LLVM's libomp, which
+# resets itself in the child, and Windows has no fork.
 _solve_loop_lock = threading.Lock()
 _solve_loop_owner: str | None = None
 _solve_loop_limiter: threadpoolctl.threadpool_limits | None = None
@@ -764,7 +766,7 @@ def _flag_forked_child() -> None:
         _forked_from_omp_process = True
 
 
-if hasattr(os, "register_at_fork"):
+if sys.platform.startswith("linux"):
     os.register_at_fork(after_in_child=_flag_forked_child)
 
 

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -2,6 +2,7 @@
 
 import threading
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -627,8 +628,6 @@ class TestSolveLoopThreadLimits(unittest.TestCase):
 
     def test_flag_forked_child_sets_flag_only_for_omp(self) -> None:
         """The after_in_child hook should flag only when the layer is omp."""
-        from unittest.mock import patch
-
         original = _functions._forked_from_omp_process
         try:
             _functions._forked_from_omp_process = False


### PR DESCRIPTION
# Description

This PR registers the `after_in_child` fork guard hook from #287 only on Linux, so a forked child on macOS with a live `omp` threading layer no longer raises for a fork that would have worked. My apologies to @CyberSarvesh for suggesting the `omp` gate and then missing in my review that it does not exclude macOS the way the block comment claimed.

## Motivation

Numba only aborts a forked child when its OpenMP pool was built with GCC, which is true of the Linux wheels alone, while the macOS wheels build it with clang against LLVM's `libomp`, whose own `pthread_atfork` handler resets the runtime in the child, so the guard raised on macOS where Numba would not have killed the child.

## Relevant Issues

Follows up on #287, which fixed #229.

## Changes

* `_functions.py`: register the `after_in_child` hook under `sys.platform.startswith("linux")` instead of `hasattr(os, "register_at_fork")`, and correct the block comment to say why the hook is Linux-only.
* `test_functions.py`: move the `unittest.mock.patch` import from inside `test_flag_forked_child_sets_flag_only_for_omp` to the module level.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.

Assisted-by: Claude Fable 5.1
