### PR TITLE
Run octowrap as a frozen pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,9 @@ jobs:
           pip install -r requirements.txt -r requirements_dev.txt
       # Run each linter and formatter through pre-commit so CI uses the exact
       # frozen hook versions from .pre-commit-config.yaml and only ever sees
-      # tracked files. The octowrap and mypy hooks run with language: system,
-      # so their versions come from the requirements_dev.txt install above
-      # rather than a frozen rev. The pinned-versions hook stays out of CI by
+      # tracked files. The mypy hook runs with language: system, so its
+      # version comes from the requirements_dev.txt install above rather
+      # than a frozen rev. The pinned-versions hook stays out of CI by
       # design: a fresh runner that just installed the requirements files
       # would pass it trivially.
       - name: isort
@@ -96,7 +96,7 @@ jobs:
         run: pre-commit run --all-files codespell
       - name: docformatter
         run: pre-commit run --all-files docformatter
-      - name: octowrap
-        run: pre-commit run --all-files octowrap
+      - name: octowrap-check
+        run: pre-commit run --all-files octowrap-check
       - name: mypy
         run: pre-commit run --all-files mypy

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,8 @@ draw.webp
 *_orientation.png
 *_angular_velocity.png
 *_aerodynamic_angles.png
+*_loads.csv
+*_state.csv
 
 # The canonical reference outputs under docs/examples_expected_output/ are committed
 # copies of these artifacts, so re-include that tree after the usage-artifact ignores

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,14 @@ repos:
     hooks:
       - id: zizmor
         name: checker  zizmor
+  - repo: https://github.com/camUrban/octowrap
+    rev: 5df77a33ceadd9a849d7a8c0d22fa7468bba3906  # frozen: v0.7.0
+    hooks:
+      # On failure, octowrap prints the fix commands, built from the interpreter in
+      # pre-commit's cached hook environment so the interactive fix runs against this
+      # exact pinned copy.
+      - id: octowrap-check
+        name: checker  octowrap-check
   - repo: local
     hooks:
       # The hooks in this repo run with language: system, so pre-commit executes
@@ -99,15 +107,6 @@ repos:
         language: system
         always_run: true
         pass_filenames: false
-      - id: octowrap
-        name: checker  octowrap
-        entry: "bash -c 'output=$(octowrap --check \"$@\" 2>&1); rc=$?; if [ $rc -ne 0 ]; then echo \"$output\" | grep -v -e \"would be reformatted\" -e \"^$\"; echo; echo \"Run: octowrap -i . (if no TTY access, first run octowrap --diff . to review the proposed changes, then octowrap . to apply them)\"; exit 1; fi' --"
-        language: system
-        types: [python]
-        # Pre-commit batches the passed filenames to parallelize hook invocations, and
-        # each failing batch would print the hint line independently. Serializing
-        # guarantees a single invocation, so the hint prints exactly once.
-        require_serial: true
       - id: ascii-only
         name: checker  ascii-only
         entry: python scripts/check_ascii_only.py

--- a/docs/website/conf.py
+++ b/docs/website/conf.py
@@ -167,8 +167,6 @@ exclude_patterns = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 napoleon_google_docstring = True

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,6 @@ coverage
 docformatter
 isort
 mypy == 2.3.0
-octowrap == 0.6.2
 pre-commit
 pyvista == 0.48.4
 scipy-stubs == 1.18.0.1

--- a/scripts/check_pinned_versions.py
+++ b/scripts/check_pinned_versions.py
@@ -1,11 +1,10 @@
 """Verify that the environment holds the versions pinned in requirements_dev.txt.
 
-The octowrap and mypy hooks run with language: system, so pre-commit executes whatever
-tool versions the active virtual environment holds instead of managing pinned copies
-itself. This pre-commit hook closes that gap: it reads every exact pin (==) from
-requirements_dev.txt, compares each against the version installed in the running
-environment, and fails with a reinstall hint when any package is missing or has drifted
-from its pin.
+The mypy hook runs with language: system, so pre-commit executes whatever tool versions
+the active virtual environment holds instead of managing pinned copies itself. This hook
+closes that gap: it reads every exact pin (==) from requirements_dev.txt, compares each
+against the version installed in the running environment, and fails with a reinstall
+hint when any package is missing or has drifted from its pin.
 """
 
 import re


### PR DESCRIPTION
# Description

Replace the local `language: system` octowrap hook with the `octowrap-check` hook published by the `octowrap` repository, frozen at v0.7.0 in `.pre-commit-config.yaml`. Pre-commit now manages the pinned copy in its own cached environment, so the `requirements_dev.txt` pin and the bash wrapper that filtered output and printed the fix hint are gone. Also add the `*_loads.csv` and `*_state.csv` files that `plot_results` writes to `.gitignore`, and drop the SciPy and Matplotlib entries from `intersphinx_mapping` in `docs/website/conf.py`.

## Motivation

The local hook ran whatever octowrap the active virtual environment held, which needed a `requirements_dev.txt` pin and the `pinned-versions` hook to keep local runs and CI aligned. A frozen upstream hook removes that machinery, and the published hook prints its own fix commands. The generated CSVs were missed when the plotting CSV output was added, so they showed up as untracked files after running examples. The Read the Docs build has been failing because the SciPy inventory fetch times out and `fail_on_warning` turns that warning into a hard failure. Measuring the built site showed that the SciPy and Matplotlib inventories resolve zero cross-references, since the package only mentions those libraries in prose, while the Python and NumPy inventories resolve hundreds of links each and stay.

## Relevant Issues

None.

## Changes

* `.pre-commit-config.yaml`: add the `octowrap-check` hook from `camUrban/octowrap` frozen at v0.7.0 and remove the local `octowrap` hook.
* `.github/workflows/ci.yml`: run the `octowrap-check` hook in the `lint` job and update the comment so `mypy` is the only `language: system` hook.
* `requirements_dev.txt`: remove the `octowrap == 0.6.2` pin.
* `scripts/check_pinned_versions.py`: update the module docstring to name only the `mypy` hook.
* `.gitignore`: ignore `*_loads.csv` and `*_state.csv` alongside the other usage artifacts, leaving the tracked copies under `docs/examples_expected_output/` in place.
* `docs/website/conf.py`: remove the `scipy` and `matplotlib` entries from `intersphinx_mapping`, keeping `python` and `numpy`.

## Dependency Updates

Removed the `octowrap == 0.6.2` dev dependency from `requirements_dev.txt`. Pre-commit now provides octowrap v0.7.0 through the frozen hook.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.

Assisted-by: Claude Fable 5.1
