### PR TITLE
Keep the mesh type on reflected Wings

### DIFF
--- a/pterasoftware/geometry/airplane.py
+++ b/pterasoftware/geometry/airplane.py
@@ -1193,51 +1193,84 @@ class Airplane:
             wing.generate_mesh(symmetry_type)
             return [wing]
         else:
-            reflected_wing_cross_sections = []
-            for wing_cross_section in wing.wing_cross_sections:
-                airfoil = wing_cross_section.airfoil
-
-                reflected_airfoil = copy.deepcopy(airfoil)
-
-                if wing_cross_section.control_surface_symmetry_type == "asymmetric":
-                    reflected_control_surface_deflection = (
-                        -1 * wing_cross_section.control_surface_deflection
-                    )
-                else:
-                    reflected_control_surface_deflection = (
-                        wing_cross_section.control_surface_deflection
-                    )
-
-                reflected_wing_cross_sections.append(
-                    wing_cross_section_mod.WingCrossSection(
-                        airfoil=reflected_airfoil,
-                        num_spanwise_panels=wing_cross_section.num_spanwise_panels,
-                        chord=wing_cross_section.chord,
-                        Lp_Wcsp_Lpp=np.copy(wing_cross_section.Lp_Wcsp_Lpp),
-                        angles_Wcsp_to_Wcs_ixyz=np.copy(
-                            wing_cross_section.angles_Wcsp_to_Wcs_ixyz
-                        ),
-                        control_surface_symmetry_type=None,
-                        control_surface_hinge_point=wing_cross_section.control_surface_hinge_point,
-                        control_surface_deflection=reflected_control_surface_deflection,
-                        spanwise_spacing=wing_cross_section.spanwise_spacing,
-                    )
-                )
-
             assert wing.symmetryNormal_G is not None
             assert wing.symmetryPoint_G_Cg is not None
-            reflected_wing = wing_mod.Wing(
-                wing_cross_sections=reflected_wing_cross_sections,
-                name=f"Reflected {wing.name}",
-                Ler_Gs_Cgs=np.copy(wing.Ler_Gs_Cgs),
-                angles_Gs_to_Wn_ixyz=np.copy(wing.angles_Gs_to_Wn_ixyz),
-                symmetric=False,
-                mirror_only=True,
-                symmetryNormal_G=np.copy(wing.symmetryNormal_G),
-                symmetryPoint_G_Cg=np.copy(wing.symmetryPoint_G_Cg),
-                num_chordwise_panels=wing.num_chordwise_panels,
-                chordwise_spacing=wing.chordwise_spacing,
-            )
+
+            # Build the reflected Wing the same way the original was built so it carries
+            # the same spanwise mesh provenance, which the convergence tools dispatch
+            # on.
+            if wing.spanwise_mesh == "edge_defined":
+                # The stored edge curves are in wing axes, which for a type 3 Wing
+                # already include the reflection, so they are reused verbatim.
+                leadingEdgePoints_Wn_Ler = wing.leadingEdgePoints_Wn_Ler
+                trailingEdgePoints_Wn_Ler = wing.trailingEdgePoints_Wn_Ler
+                tip_trim_fraction = wing.tip_trim_fraction
+                assert leadingEdgePoints_Wn_Ler is not None
+                assert trailingEdgePoints_Wn_Ler is not None
+                assert tip_trim_fraction is not None
+
+                reflected_wing = wing_mod.Wing.from_edge_points(
+                    leadingEdgePoints_Wn_Ler=np.copy(leadingEdgePoints_Wn_Ler),
+                    trailingEdgePoints_Wn_Ler=np.copy(trailingEdgePoints_Wn_Ler),
+                    num_wing_cross_sections=len(wing.wing_cross_sections),
+                    airfoil=copy.deepcopy(wing.wing_cross_sections[0].airfoil),
+                    name=f"Reflected {wing.name}",
+                    Ler_Gs_Cgs=np.copy(wing.Ler_Gs_Cgs),
+                    angles_Gs_to_Wn_ixyz=np.copy(wing.angles_Gs_to_Wn_ixyz),
+                    symmetric=False,
+                    mirror_only=True,
+                    symmetryNormal_G=np.copy(wing.symmetryNormal_G),
+                    symmetryPoint_G_Cg=np.copy(wing.symmetryPoint_G_Cg),
+                    num_chordwise_panels=wing.num_chordwise_panels,
+                    chordwise_spacing=wing.chordwise_spacing,
+                    tip_trim_fraction=tip_trim_fraction,
+                )
+            else:
+                reflected_wing_cross_sections = []
+                for wing_cross_section in wing.wing_cross_sections:
+                    airfoil = wing_cross_section.airfoil
+
+                    reflected_airfoil = copy.deepcopy(airfoil)
+
+                    if wing_cross_section.control_surface_symmetry_type == "asymmetric":
+                        reflected_control_surface_deflection = (
+                            -1 * wing_cross_section.control_surface_deflection
+                        )
+                    else:
+                        reflected_control_surface_deflection = (
+                            wing_cross_section.control_surface_deflection
+                        )
+
+                    reflected_wing_cross_sections.append(
+                        wing_cross_section_mod.WingCrossSection(
+                            airfoil=reflected_airfoil,
+                            num_spanwise_panels=wing_cross_section.num_spanwise_panels,
+                            chord=wing_cross_section.chord,
+                            Lp_Wcsp_Lpp=np.copy(wing_cross_section.Lp_Wcsp_Lpp),
+                            angles_Wcsp_to_Wcs_ixyz=np.copy(
+                                wing_cross_section.angles_Wcsp_to_Wcs_ixyz
+                            ),
+                            control_surface_symmetry_type=None,
+                            control_surface_hinge_point=wing_cross_section.control_surface_hinge_point,
+                            control_surface_deflection=reflected_control_surface_deflection,
+                            spanwise_spacing=wing_cross_section.spanwise_spacing,
+                        )
+                    )
+
+                # Re-exploding an already exploded Wing reproduces it exactly.
+                reflected_wing = wing_mod.Wing(
+                    wing_cross_sections=reflected_wing_cross_sections,
+                    name=f"Reflected {wing.name}",
+                    Ler_Gs_Cgs=np.copy(wing.Ler_Gs_Cgs),
+                    angles_Gs_to_Wn_ixyz=np.copy(wing.angles_Gs_to_Wn_ixyz),
+                    symmetric=False,
+                    mirror_only=True,
+                    symmetryNormal_G=np.copy(wing.symmetryNormal_G),
+                    symmetryPoint_G_Cg=np.copy(wing.symmetryPoint_G_Cg),
+                    explode_into_strips=wing.spanwise_mesh == "exploded",
+                    num_chordwise_panels=wing.num_chordwise_panels,
+                    chordwise_spacing=wing.chordwise_spacing,
+                )
 
             wing.symmetric = False
             wing.mirror_only = False

--- a/tests/unit/test_airplane.py
+++ b/tests/unit/test_airplane.py
@@ -362,6 +362,103 @@ class TestAirplane(unittest.TestCase):
         self.assertTrue(second_wing.mirror_only)
         self.assertTrue(second_wing.name.startswith("Reflected"))
 
+    def test_process_wing_symmetry_type_5_edge_defined(self) -> None:
+        """Test that a type 5 edge-defined Wing's reflection is also edge-defined."""
+        ys = np.linspace(0.0, 1.0, 4)
+        zeros = np.zeros_like(ys)
+        leading = np.column_stack((ys, ys, zeros))
+        trailing = np.column_stack((np.ones_like(ys), ys, zeros))
+        wing = ps.geometry.wing.Wing.from_edge_points(
+            leadingEdgePoints_Wn_Ler=leading,
+            trailingEdgePoints_Wn_Ler=trailing,
+            num_wing_cross_sections=3,
+            airfoil=ps.geometry.airfoil.Airfoil(name="naca0012"),
+            symmetric=True,
+            symmetryNormal_G=[0.0, 0.707, 0.707],
+            symmetryPoint_G_Cg=[0.5, 0.0, 0.0],
+            num_chordwise_panels=2,
+            chordwise_spacing="uniform",
+            tip_trim_fraction=0.2,
+        )
+
+        result = ps.geometry.airplane.Airplane.process_wing_symmetry(wing)
+
+        original_wing = result[0]
+        reflected_wing = result[1]
+        self.assertEqual(reflected_wing.symmetry_type, 3)
+        self.assertEqual(reflected_wing.spanwise_mesh, "edge_defined")
+        self.assertEqual(reflected_wing.tip_trim_fraction, 0.2)
+        npt.assert_array_equal(reflected_wing.leadingEdgePoints_Wn_Ler, leading)
+        npt.assert_array_equal(reflected_wing.trailingEdgePoints_Wn_Ler, trailing)
+        self.assertEqual(
+            len(reflected_wing.wing_cross_sections),
+            len(original_wing.wing_cross_sections),
+        )
+        for original_wing_cross_section, reflected_wing_cross_section in zip(
+            original_wing.wing_cross_sections, reflected_wing.wing_cross_sections
+        ):
+            self.assertEqual(
+                reflected_wing_cross_section.chord, original_wing_cross_section.chord
+            )
+            npt.assert_array_equal(
+                reflected_wing_cross_section.Lp_Wcsp_Lpp,
+                original_wing_cross_section.Lp_Wcsp_Lpp,
+            )
+            self.assertIsNone(
+                reflected_wing_cross_section.control_surface_symmetry_type
+            )
+
+    def test_process_wing_symmetry_type_5_exploded(self) -> None:
+        """Test that a type 5 exploded Wing's reflection is also exploded."""
+        root_wing_cross_section = ps.geometry.wing_cross_section.WingCrossSection(
+            airfoil=geometry_fixtures.make_test_airfoil_fixture(),
+            num_spanwise_panels=4,
+            chord=2.0,
+            Lp_Wcsp_Lpp=[0.0, 0.0, 0.0],
+            angles_Wcsp_to_Wcs_ixyz=[0.0, 0.0, 0.0],
+            control_surface_symmetry_type="symmetric",
+            spanwise_spacing="uniform",
+        )
+        tip_wing_cross_section = (
+            geometry_fixtures.make_tip_wing_cross_section_with_control_surface_fixture()
+        )
+        wing = ps.geometry.wing.Wing(
+            wing_cross_sections=[root_wing_cross_section, tip_wing_cross_section],
+            symmetric=True,
+            symmetryNormal_G=[0.0, 0.707, 0.707],
+            symmetryPoint_G_Cg=[0.5, 0.0, 0.0],
+            explode_into_strips=True,
+        )
+
+        result = ps.geometry.airplane.Airplane.process_wing_symmetry(wing)
+
+        original_wing = result[0]
+        reflected_wing = result[1]
+        self.assertEqual(reflected_wing.symmetry_type, 3)
+        self.assertEqual(reflected_wing.spanwise_mesh, "exploded")
+        self.assertEqual(
+            len(reflected_wing.wing_cross_sections),
+            len(original_wing.wing_cross_sections),
+        )
+        for original_wing_cross_section, reflected_wing_cross_section in zip(
+            original_wing.wing_cross_sections, reflected_wing.wing_cross_sections
+        ):
+            self.assertEqual(
+                reflected_wing_cross_section.num_spanwise_panels,
+                original_wing_cross_section.num_spanwise_panels,
+            )
+            self.assertEqual(
+                reflected_wing_cross_section.chord, original_wing_cross_section.chord
+            )
+            npt.assert_array_equal(
+                reflected_wing_cross_section.Lp_Wcsp_Lpp,
+                original_wing_cross_section.Lp_Wcsp_Lpp,
+            )
+            npt.assert_array_equal(
+                reflected_wing_cross_section.angles_Wcsp_to_Wcs_ixyz,
+                original_wing_cross_section.angles_Wcsp_to_Wcs_ixyz,
+            )
+
     def test_process_wing_symmetry_control_surface_validation_types_1_2_3(self) -> None:
         """Test control surface validation for symmetry types 1, 2, 3."""
         # Type 1: should fail with control surfaces. Create fresh fixtures since


### PR DESCRIPTION
# Description

`Airplane.process_wing_symmetry` splits a type 5 Wing (symmetric, with a non-coincident symmetry plane) into the original half and a reflected type 3 Wing. It built the reflected Wing with the plain `Wing` constructor, which marks every Wing as `"trapezoidal"`. An edge-defined or exploded original therefore produced a reflection with the wrong `spanwise_mesh`, and an edge-defined reflection carried no `leadingEdgePoints_Wn_Ler`, `trailingEdgePoints_Wn_Ler`, or `tip_trim_fraction`. This PR builds the reflection the same way the original was built so it carries the same provenance. Trapezoidal type 5 Wings are unaffected.

## Motivation

The convergence tools dispatch on `spanwise_mesh`: an edge-defined Wing is refined by resampling its stored edge curves, a trapezoidal Wing by sweeping spanwise Panel counts, and an exploded Wing is rejected. With the old behavior, an edge-defined type 5 Wing's two halves were refined by different methods and ended up with different meshes, with nothing raised to flag it. The exploded case was rejected only because the original half failed the same guard.

## Relevant Issues

None.

## Changes

* In `Airplane.process_wing_symmetry`, an edge-defined original Wing now produces its reflection through `Wing.from_edge_points`, passing the stored edge curves, the same number of WingCrossSections, the first WingCrossSection's Airfoil, and the same `tip_trim_fraction`. The curves are reused verbatim because they are expressed in wing axes, and a type 3 Wing's axes already include the reflection.
* For any other original, the reflection is still built with the Wing constructor, now with `explode_into_strips` set when the original is exploded. Re-exploding single-strip WingCrossSections reproduces them exactly.
* Added `test_process_wing_symmetry_type_5_edge_defined` and `test_process_wing_symmetry_type_5_exploded` to `tests/unit/test_airplane.py`, which check the reflected Wing's `symmetry_type`, `spanwise_mesh`, stored curves and tip trim (edge-defined only), and per-WingCrossSection geometry against the original.

## Dependency Updates

None.

## Change Magnitude

**Minor**: Small change such as a bug fix, small enhancement, or documentation update.

## Checklist (check each item when completed or not applicable)

* [x] I am familiar with the current [contribution guidelines](https://github.com/camUrban/PteraSoftware/blob/main/CONTRIBUTING.md).
* [x] PR description links all relevant issues and follows this template.
* [x] My branch is based on `main` and is up to date with the upstream `main` branch.
* [x] All calculations use S.I. units.
* [x] Code is formatted with [black](https://github.com/psf/black) (line length = 88).
* [x] Code is well documented with block comments where appropriate.
* [x] Any external code, algorithms, or equations used have been cited in comments or docstrings.
* [x] All new modules, classes, functions, and methods have docstrings in [reStructuredText format](https://realpython.com/documenting-python-code/), and are formatted using [docformatter](https://github.com/PyCQA/docformatter) (`--in-place --black`). See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] All new classes, functions, and methods in the `pterasoftware` package use type hints. See the [style guide for type hints and docstrings](https://github.com/camUrban/PteraSoftware/blob/main/docs/TYPE_HINT_AND_DOCSTRING_STYLE.md) for more details.
* [x] If any major functionality was added or significantly changed, I have added or updated tests in the `tests` package.
* [x] Code locally passes all tests in the `tests` package.
* [x] This PR passes the ReadTheDocs build check (this runs automatically with the other workflows).
* [x] This PR passes the `ascii-only`, `pre-commit-hooks`, and `zizmor` GitHub actions.
* [x] This PR passes the `lint` job of the `CI` GitHub action.
* [x] This PR passes the `test` jobs of the `CI` GitHub action.

Assisted-by: Claude Fable 5.1
